### PR TITLE
Bugfix - infoclick popup box margin overlapping with search bar

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/FeatureQuery/FeatureQueryResultRenderer.ts
+++ b/GIFrameworkMaps.Web/Scripts/FeatureQuery/FeatureQueryResultRenderer.ts
@@ -257,7 +257,7 @@ export class FeatureQueryResultRenderer {
         }
         this._gifwMapInstance.popupOverlay.overlay.setPosition(coords);
         this._gifwMapInstance.popupOverlay.overlay.panIntoView({
-            margin: 60,
+            margin: 90,
             animation: { duration: 250 }
         });
         if (popupOptions && popupOptions.offset !== undefined) {


### PR DESCRIPTION
The top margin of popup boxes has been slightly increased to resolve the issue of overlapping with the search bar.
Closes #6 