### PR TITLE
Allow proxying of feature and map requests

### DIFF
--- a/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
@@ -45,6 +45,8 @@ namespace GIFrameworkMaps.Data
             modelBuilder.Entity<WelcomeMessage>().Property(w => w.DismissOnButtonOnly).HasDefaultValue(false);
             modelBuilder.Entity<TourDetails>().Property(w => w.Frequency).HasDefaultValue(-1);
             modelBuilder.Entity<WebLayerServiceDefinition>().Property(w => w.Type).HasConversion<string>();
+            modelBuilder.Entity<Layer>().Property(l => l.ProxyMetaRequests).HasDefaultValue(false);
+            modelBuilder.Entity<Layer>().Property(l => l.ProxyMapRequests).HasDefaultValue(false);
             /*Exclude DB search results from EF Migrations - https://stackoverflow.com/a/65151839/863487 */
             modelBuilder.Entity<Models.Search.DatabaseSearchResult>().HasNoKey().ToTable(nameof(DatabaseSearchResults), t => t.ExcludeFromMigrations());
         }

--- a/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
@@ -29,6 +29,7 @@ namespace GIFrameworkMaps.Data
         public DbSet<Models.Authorization.ApplicationRole> ApplicationRoles { get; set; }
         public DbSet<Models.Authorization.ApplicationUserRole> ApplicationUserRoles { get; set; }
         public DbSet<Models.WebLayerServiceDefinition> WebLayerServiceDefinitions { get; set; }
+        public DbSet<Models.ProxyAllowedHost> ProxyAllowedHosts{get;set;}
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/GIFrameworkMap.Data/Data/CommonRepository.cs
+++ b/GIFrameworkMap.Data/Data/CommonRepository.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace GIFrameworkMaps.Data
 {
@@ -224,6 +225,24 @@ namespace GIFrameworkMaps.Data
             }
 
             var allowedHosts = _context.ProxyAllowedHosts.AsNoTracking().ToList();
+
+            _memoryCache.Set(cacheKey, allowedHosts, new MemoryCacheEntryOptions
+            {
+                Priority = CacheItemPriority.Low,
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(12)
+            });
+            return allowedHosts;
+        }
+
+        public async Task<List<ProxyAllowedHost>> GetProxyAllowedHostsAsync()
+        {
+            string cacheKey = $"ProxyAllowedHosts";
+            if (_memoryCache.TryGetValue(cacheKey, out List<ProxyAllowedHost> cacheValue))
+            {
+                return cacheValue;
+            }
+
+            var allowedHosts = await _context.ProxyAllowedHosts.AsNoTracking().ToListAsync();
 
             _memoryCache.Set(cacheKey, allowedHosts, new MemoryCacheEntryOptions
             {

--- a/GIFrameworkMap.Data/Data/CommonRepository.cs
+++ b/GIFrameworkMap.Data/Data/CommonRepository.cs
@@ -214,5 +214,23 @@ namespace GIFrameworkMaps.Data
             });
             return services;
         }
+
+        public List<ProxyAllowedHost> GetProxyAllowedHosts()
+        {
+            string cacheKey = $"ProxyAllowedHosts";
+            if (_memoryCache.TryGetValue(cacheKey, out List<ProxyAllowedHost> cacheValue))
+            {
+                return cacheValue;
+            }
+
+            var allowedHosts = _context.ProxyAllowedHosts.AsNoTracking().ToList();
+
+            _memoryCache.Set(cacheKey, allowedHosts, new MemoryCacheEntryOptions
+            {
+                Priority = CacheItemPriority.Low,
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(12)
+            });
+            return allowedHosts;
+        }
     }
 }

--- a/GIFrameworkMap.Data/Data/IApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/IApplicationDbContext.cs
@@ -21,5 +21,6 @@ namespace GIFrameworkMaps.Data
         DbSet<Models.Authorization.ApplicationRole> ApplicationRoles { get; set; }
         DbSet<Models.Authorization.ApplicationUserRole> ApplicationUserRoles { get; set; }
         DbSet<Models.WebLayerServiceDefinition> WebLayerServiceDefinitions { get; set; }
+        DbSet<Models.ProxyAllowedHost> ProxyAllowedHosts { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Data/ICommonRepository.cs
+++ b/GIFrameworkMap.Data/Data/ICommonRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace GIFrameworkMaps.Data
 {
@@ -14,5 +15,7 @@ namespace GIFrameworkMaps.Data
         List<Models.Authorization.ApplicationUserRole> GetUserRoles(string userId);
         List<Models.WebLayerServiceDefinition> GetWebLayerServiceDefinitions();
         List<Models.ProxyAllowedHost> GetProxyAllowedHosts();
+
+        Task<List<Models.ProxyAllowedHost>> GetProxyAllowedHostsAsync();
     }
 }

--- a/GIFrameworkMap.Data/Data/ICommonRepository.cs
+++ b/GIFrameworkMap.Data/Data/ICommonRepository.cs
@@ -13,5 +13,6 @@ namespace GIFrameworkMaps.Data
         List<Models.Version> GetVersions();
         List<Models.Authorization.ApplicationUserRole> GetUserRoles(string userId);
         List<Models.WebLayerServiceDefinition> GetWebLayerServiceDefinitions();
+        List<Models.ProxyAllowedHost> GetProxyAllowedHosts();
     }
 }

--- a/GIFrameworkMap.Data/Data/Models/AutoMapping.cs
+++ b/GIFrameworkMap.Data/Data/Models/AutoMapping.cs
@@ -44,7 +44,9 @@ public class AutoMapping : Profile
             .ForMember(cl => cl.InfoTemplate, lvm => lvm.MapFrom(s => s.Layer.InfoTemplate))
             .ForMember(cl => cl.Filterable, lvm => lvm.MapFrom(s => s.Layer.Filterable))
             .ForMember(cl => cl.DefaultFilterEditable, lvm => lvm.MapFrom(s => s.Layer.DefaultFilterEditable))
-            .ForMember(cl => cl.InfoListTitleTemplate, lvm => lvm.MapFrom(s => s.Layer.InfoListTitleTemplate));
+            .ForMember(cl => cl.InfoListTitleTemplate, lvm => lvm.MapFrom(s => s.Layer.InfoListTitleTemplate))
+            .ForMember(cl => cl.ProxyMapRequests, lvm => lvm.MapFrom(s => s.Layer.ProxyMapRequests))
+            .ForMember(cl => cl.ProxyMetaRequests, lvm => lvm.MapFrom(s => s.Layer.ProxyMetaRequests));
 
 
     }

--- a/GIFrameworkMap.Data/Data/Models/Layer.cs
+++ b/GIFrameworkMap.Data/Data/Models/Layer.cs
@@ -23,6 +23,8 @@ namespace GIFrameworkMaps.Data.Models
         public string? InfoListTitleTemplate { get; set; }
         public bool Filterable { get; set; } = true;
         public bool DefaultFilterEditable { get; set; } = false;
+        public bool ProxyMetaRequests { get; set; }
+        public bool ProxyMapRequests { get; set; }
         public LayerSource LayerSource { get; set; }
         //public virtual List<Category> Categories { get; set; }
 

--- a/GIFrameworkMap.Data/Data/Models/ProxyAllowedHost.cs
+++ b/GIFrameworkMap.Data/Data/Models/ProxyAllowedHost.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GIFrameworkMaps.Data.Models
+{
+    public class ProxyAllowedHost
+    {
+        public int Id { get; set; }
+        [Required]
+        public string Host { get; set; }
+    }
+}

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/LayerViewModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/LayerViewModel.cs
@@ -20,6 +20,8 @@ namespace GIFrameworkMaps.Data.Models.ViewModels
         public string? InfoListTitleTemplate { get; set; }
         public bool Filterable { get; set; }
         public bool DefaultFilterEditable { get; set; }
+        public bool ProxyMetaRequests { get; set; }
+        public bool ProxyMapRequests { get; set; }
         public LayerSource LayerSource { get; set;}
     }
 }

--- a/GIFrameworkMap.Data/Data/Models/WebLayerServiceDefinition.cs
+++ b/GIFrameworkMap.Data/Data/Models/WebLayerServiceDefinition.cs
@@ -21,6 +21,8 @@ namespace GIFrameworkMaps.Data.Models
         public string Category { get; set; }
         [Required]
         public int SortOrder { get; set; }
+        public bool ProxyMetaRequests { get; set; }
+        public bool ProxyMapRequests { get; set; }
     }
 
     public enum ServiceType

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230125102945_AddProxyAllowList.Designer.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230125102945_AddProxyAllowList.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GIFrameworkMaps.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230125102945_AddProxyAllowList")]
+    partial class AddProxyAllowList
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230125102945_AddProxyAllowList.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230125102945_AddProxyAllowList.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddProxyAllowList : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProxyAllowedHosts",
+                schema: "giframeworkmaps",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Host = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProxyAllowedHosts", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProxyAllowedHosts",
+                schema: "giframeworkmaps");
+        }
+    }
+}

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230125163547_AddProxyColumns.Designer.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230125163547_AddProxyColumns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GIFrameworkMaps.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230125163547_AddProxyColumns")]
+    partial class AddProxyColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230125163547_AddProxyColumns.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230125163547_AddProxyColumns.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddProxyColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ProxyMapRequests",
+                schema: "giframeworkmaps",
+                table: "WebLayerServiceDefinitions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ProxyMetaRequests",
+                schema: "giframeworkmaps",
+                table: "WebLayerServiceDefinitions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ProxyMapRequests",
+                schema: "giframeworkmaps",
+                table: "Layer",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ProxyMetaRequests",
+                schema: "giframeworkmaps",
+                table: "Layer",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProxyMapRequests",
+                schema: "giframeworkmaps",
+                table: "WebLayerServiceDefinitions");
+
+            migrationBuilder.DropColumn(
+                name: "ProxyMetaRequests",
+                schema: "giframeworkmaps",
+                table: "WebLayerServiceDefinitions");
+
+            migrationBuilder.DropColumn(
+                name: "ProxyMapRequests",
+                schema: "giframeworkmaps",
+                table: "Layer");
+
+            migrationBuilder.DropColumn(
+                name: "ProxyMetaRequests",
+                schema: "giframeworkmaps",
+                table: "Layer");
+        }
+    }
+}

--- a/GIFrameworkMaps.Web/Program.cs
+++ b/GIFrameworkMaps.Web/Program.cs
@@ -108,5 +108,4 @@ var forwarder = app.Services.GetService<IHttpForwarder>();
 
 var startup = new Startup(builder.Configuration);
 startup.Configure(app, app.Environment, forwarder);
-//app.MapReverseProxy();
 app.Run();

--- a/GIFrameworkMaps.Web/Scripts/BroadcastReceiver.ts
+++ b/GIFrameworkMaps.Web/Scripts/BroadcastReceiver.ts
@@ -8,7 +8,6 @@ export class BroadcastReceiver {
         connection.on("ReceiveBroadcast", function (messageType, messageSeverity, message, version) {
             if (version === "all" || version === versionSlug) {
                 var msg = message.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-                var encodedMsg = `${messageSeverity}: ${msg} (${messageType})`;
                 switch (messageType) {
                     case "Toast":
                         BroadcastReceiver.showToast(messageSeverity,msg);

--- a/GIFrameworkMaps.Web/Scripts/BroadcastReceiver.ts
+++ b/GIFrameworkMaps.Web/Scripts/BroadcastReceiver.ts
@@ -9,7 +9,6 @@ export class BroadcastReceiver {
             if (version === "all" || version === versionSlug) {
                 var msg = message.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
                 var encodedMsg = `${messageSeverity}: ${msg} (${messageType})`;
-                console.log(encodedMsg);
                 switch (messageType) {
                     case "Toast":
                         BroadcastReceiver.showToast(messageSeverity,msg);

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/Layer.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/Layer.ts
@@ -41,4 +41,6 @@ export interface Layer {
     filterable: boolean;
     defaultFilterEditable: boolean;
     removable: boolean;
+    proxyMetaRequests: boolean;
+    proxyMapRequests: boolean;
 }

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/WebLayerServiceDefinition.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/WebLayerServiceDefinition.ts
@@ -7,6 +7,8 @@
     version: string;
     category: string;
     sortOrder: number;
+    proxyMetaRequests: boolean;
+    proxyMapRequests: boolean;
 }
 
 export enum ServiceType {

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -471,6 +471,8 @@ export class GIFWMap {
     public addWebLayerToMap(
         source: TileWMS|ImageWMS,
         name: string,
+        proxyMetaRequests: boolean = false,
+        proxyMapRequests: boolean = false,
         visible: boolean = true,
         type = LayerGroupType.Overlay,
         zIndex: number = 0,
@@ -504,7 +506,9 @@ export class GIFWMap {
         ol_layer.setProperties({ "layerId": layerId })
         ol_layer.setProperties({ "name": name });
         ol_layer.setProperties({ "gifw-queryable": queryable })
-        ol_layer.setProperties({ "gifw-proxy-meta-request": true });
+        if (proxyMetaRequests) {
+            ol_layer.setProperties({ "gifw-proxy-meta-request": true });
+        }
         ol_layer.setProperties({ "gifw-is-user-layer": true })
          /*TODO - This is a little odd. We have to create a 'stub' gifwLayer and an ol_layer
           * for different purposes. Be good if this was more streamlined*/
@@ -526,8 +530,8 @@ export class GIFWMap {
             filterable: true,
             defaultFilterEditable: false,
             removable: true,
-            proxyMetaRequests: true,
-            proxyMapRequests: true
+            proxyMetaRequests: proxyMetaRequests,
+            proxyMapRequests: proxyMapRequests
         }
 
         let layerGroup = this.getLayerGroupOfType(type);

--- a/GIFrameworkMaps.Web/Scripts/Metadata/Metadata.ts
+++ b/GIFrameworkMaps.Web/Scripts/Metadata/Metadata.ts
@@ -192,7 +192,6 @@ export class Metadata {
             
             let styles = (evaluateXPathToNodes(`//Layer[Name='${layerName}']/Style`, doc, null, null, { language: evaluateXPath.XQUERY_3_1_LANGUAGE }) as Node[]);
 
-            console.log(styles);
             //parse styles into list of styles
             let availableStyles: Style[] = [];
             styles.forEach(s => {

--- a/GIFrameworkMaps.Web/Scripts/Metadata/Metadata.ts
+++ b/GIFrameworkMaps.Web/Scripts/Metadata/Metadata.ts
@@ -8,7 +8,7 @@ import * as olExtent from "ol/extent";
 export class Metadata {
 
     /*TODO - Make all the metadata fetchers use this generic function*/
-    static async getCapabilities(baseUrl: string, service: string = "WMS", version: string = "1.1.0") {
+    static async getCapabilities(baseUrl: string, service: string = "WMS", version: string = "1.1.0", proxyEndpoint: string = "") {
         let getCapabilitiesURLParams = new URLSearchParams({
             service: service,
             version: version,
@@ -19,13 +19,15 @@ export class Metadata {
         let combinedURLParams = Util.Browser.combineURLSearchParams(baseURLParams, getCapabilitiesURLParams, true);
 
         let fetchUrl = `${baseURLasURL.origin}${baseURLasURL.pathname}?${combinedURLParams}`;
-
+        if (proxyEndpoint !== "") {
+            fetchUrl = `${proxyEndpoint}?url=${encodeURIComponent(fetchUrl)}`;
+        }
         let response = await fetch(fetchUrl);
         return response;
 
     }
 
-    static async getDescribeFeatureType(baseUrl: string, featureTypeName: string, httpMethod: string, outputFormat: string = 'application/json', additionalUrlParams: {} = {}): Promise<DescribeFeatureType> {
+    static async getDescribeFeatureType(baseUrl: string, featureTypeName: string, httpMethod: string, outputFormat: string = 'application/json', proxyEndpoint:string = "", additionalUrlParams: {} = {}): Promise<DescribeFeatureType> {
         
         let describeFeatureURLParams = new URLSearchParams({
             service: 'WFS',
@@ -40,7 +42,9 @@ export class Metadata {
         let baseURLParams = baseURLasURL.searchParams;
         let combinedURLParams = Util.Browser.combineURLSearchParams(baseURLParams, describeFeatureURLParams, true);
         let fetchUrl = `${baseURLasURL.origin}${baseURLasURL.pathname}?${combinedURLParams}`;
-
+        if (proxyEndpoint !== "") {
+            fetchUrl = `${proxyEndpoint}?url=${encodeURIComponent(fetchUrl)}`;
+        }
 
         try {
             let response = await fetch(fetchUrl,
@@ -64,7 +68,7 @@ export class Metadata {
      * a stripped down set of basic capabilities.
      * @param baseUrl - The base URL of the OGC server you want to query
      */
-    static async getBasicCapabilities(baseUrl: string, additionalUrlParams: {} = {}): Promise<BasicServerCapabilities> {
+    static async getBasicCapabilities(baseUrl: string, additionalUrlParams: {} = {}, proxyEndpoint: string = ""): Promise<BasicServerCapabilities> {
         let getCapabilitiesURLParams = new URLSearchParams({
             service: 'WFS',
             version: '1.1.0',
@@ -76,7 +80,9 @@ export class Metadata {
         let combinedURLParams = Util.Browser.combineURLSearchParams(baseURLParams, getCapabilitiesURLParams, true);
 
         let fetchUrl = `${baseURLasURL.origin}${baseURLasURL.pathname}?${combinedURLParams}`;
-
+        if (proxyEndpoint !== "") {
+            fetchUrl = `${proxyEndpoint}?url=${encodeURIComponent(fetchUrl)}`;
+        }
         try {
             let response = await fetch(fetchUrl);
             if (!response.ok) {
@@ -157,7 +163,7 @@ export class Metadata {
      * @param baseUrl - The base URL of the OGC server you want to query
      * @param layerName - The name of the layer to find in the list
      */
-    static async getStylesForLayer(baseUrl: string, layerName: string, additionalUrlParams: {} = {}): Promise<Style[]> {
+    static async getStylesForLayer(baseUrl: string, layerName: string, proxyEndpoint: string = "", additionalUrlParams: {} = {}): Promise<Style[]> {
         let getCapabilitiesURLParams = new URLSearchParams({
             service: 'WMS',
             version: '1.1.0',
@@ -169,6 +175,9 @@ export class Metadata {
         let combinedURLParams = Util.Browser.combineURLSearchParams(baseURLParams, getCapabilitiesURLParams, true);
 
         let fetchUrl = `${baseURLasURL.origin}${baseURLasURL.pathname}?${combinedURLParams}`;
+        if (proxyEndpoint !== "") {
+            fetchUrl = `${proxyEndpoint}?url=${encodeURIComponent(fetchUrl)}`;
+        }
 
         try {
             let response = await fetch(fetchUrl);
@@ -214,9 +223,9 @@ export class Metadata {
         }
     }
 
-    static async getLayersFromCapabilities(baseUrl: string, version:string = "1.1.0") {
+    static async getLayersFromCapabilities(baseUrl: string, version:string = "1.1.0", proxyEndpoint:string = "") {
         try {
-            let response = await this.getCapabilities(baseUrl, "WMS", version);
+            let response = await this.getCapabilities(baseUrl, "WMS", version, proxyEndpoint);
             if (!response.ok) {
                 throw new Error(`HTTP error: ${response.status}`);
             }
@@ -321,7 +330,7 @@ export class Metadata {
      * a stripped down set of basic capabilities.
      * @param baseUrl - The base URL of the OGC server you want to query
      */
-    static async getWPSCapabilities(baseUrl: string, additionalUrlParams: {} = {}): Promise<BasicServerCapabilities> {
+    static async getWPSCapabilities(baseUrl: string, proxyEndpoint: string = "", additionalUrlParams: {} = {}): Promise<BasicServerCapabilities> {
         let getCapabilitiesURLParams = new URLSearchParams({
             service: 'wps',
             version: '1.1.0',
@@ -333,7 +342,9 @@ export class Metadata {
         let combinedURLParams = Util.Browser.combineURLSearchParams(baseURLParams, getCapabilitiesURLParams, true);
 
         let fetchUrl = `${baseURLasURL.origin}${baseURLasURL.pathname}?${combinedURLParams}`;
-
+        if (proxyEndpoint !== "") {
+            fetchUrl = `${proxyEndpoint}?url=${encodeURIComponent(fetchUrl)}`;
+        }
         try {
             let response = await fetch(fetchUrl);
             if (!response.ok) {
@@ -404,7 +415,7 @@ export class Metadata {
 
     }
 
-    static async hasWPSProcess(baseUrl: string, httpMethod: string, processName: string, additionalUrlParams: {} = {}): Promise<boolean> {
+    static async hasWPSProcess(baseUrl: string, httpMethod: string, processName: string, proxyEndpoint: string = "", additionalUrlParams: {} = {}): Promise<boolean> {
         let describeProcessURLParams = new URLSearchParams({
             service: 'WPS',
             version: '1.1.0',
@@ -417,7 +428,9 @@ export class Metadata {
         let combinedURLParams = Util.Browser.combineURLSearchParams(baseURLParams, describeProcessURLParams, true);
 
         let fetchUrl = `${baseURLasURL.origin}${baseURLasURL.pathname}?${combinedURLParams}`;
-
+        if (proxyEndpoint !== "") {
+            fetchUrl = `${proxyEndpoint}?url=${encodeURIComponent(fetchUrl)}`;
+        }
         try {
             let response = await fetch(fetchUrl,
                 { method: httpMethod }

--- a/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
@@ -17,14 +17,12 @@ export default class AnnotationStylePanel implements SidebarPanel {
     }
 
     init() {
-        console.log(`init called on Annotation Styling (container ${this.container})`);
         this.attachCloseButton();
         this.optionsPanel = document.querySelector(`${this.container} .gifw-annotation-style-options`);
         this.render();
     }
 
     render() {
-        console.log(`render called on Annotation Styling (container ${this.container})`);
         if (this.optionsPanel) {
             if (this.activeStyle) {
                 this.optionsPanel.innerHTML = this.activeStyle.activeTool.optionsHTML;

--- a/GIFrameworkMaps.Web/Scripts/Panels/BasemapsPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/BasemapsPanel.ts
@@ -249,8 +249,12 @@ export class BasemapsPanel implements SidebarPanel {
 
             let layerGroup = this.gifwMapInstance.getLayerGroupOfType(LayerGroupType.Basemap);
             let layerConfig = (layerGroup.layers as Layer[]).filter(l => l.id == eTarget.dataset.gifwAboutBasemap);
+            let proxyEndpoint = "";
+            if (layerConfig[0].proxyMetaRequests) {
+                proxyEndpoint = `${document.location.protocol}//${this.gifwMapInstance.config.appRoot}proxy`;
+            }
             if (layerConfig && layerConfig.length === 1) {
-                CSWMetadataViewer.showMetadataModal(layerConfig[0]);
+                CSWMetadataViewer.showMetadataModal(layerConfig[0], undefined, proxyEndpoint);
             }
             e.preventDefault();
         })

--- a/GIFrameworkMaps.Web/Scripts/Panels/BasemapsPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/BasemapsPanel.ts
@@ -15,14 +15,12 @@ export class BasemapsPanel implements SidebarPanel {
         this.container = container;
     }
     init() {
-        console.log(`init called on Basemaps (container ${this.container})`);
         this.renderBasemapsPanel();
         this.attachCloseButton();
         //this.attachBasemapSelectors();
         //this.attachMetaControls();
     };
     render() {
-        console.log(`render called on Basemaps (container ${this.container})`);
         this.renderBasemapsPanel();
     };
     /*TODO - Make this generic*/

--- a/GIFrameworkMaps.Web/Scripts/Panels/LayerList.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/LayerList.ts
@@ -183,7 +183,11 @@ export class LayerList {
                 let layerConfig = (layerGroup.layers as Layer[]).filter(l => l.id == eTarget.dataset.gifwAboutLayer);
                 if (layerConfig && layerConfig.length === 1) {
                     let isFiltered = this.layersPanelInstance.getLayerFilteredStatus(layer, (olLayer as olLayer), false);
-                    CSWMetadataViewer.showMetadataModal(layerConfig[0], isFiltered);
+                    let proxyEndpoint = "";
+                    if (layerConfig[0].proxyMetaRequests) {
+                        proxyEndpoint = `${document.location.protocol}//${this.gifwMapInstance.config.appRoot}proxy`;
+                    }
+                    CSWMetadataViewer.showMetadataModal(layerConfig[0], isFiltered, proxyEndpoint);
                 }
                 e.preventDefault();
             });

--- a/GIFrameworkMaps.Web/Scripts/Panels/LayersPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/LayersPanel.ts
@@ -45,7 +45,6 @@ export class LayersPanel implements SidebarPanel {
         this.loadingLayers = {};
     }
     init() {
-        console.log(`init called on Layers (container ${this.container})`);
         this.previousZoom = Math.ceil(this.gifwMapInstance.olMap.getView().getZoom());
         this.attachCloseButton();
         this.attachControls();
@@ -66,7 +65,6 @@ export class LayersPanel implements SidebarPanel {
         })
     };
     render() {
-        console.log(`render called on Layers (container ${this.container})`);
         this.updateControlState();
     };
 

--- a/GIFrameworkMaps.Web/Scripts/Panels/LayersPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/LayersPanel.ts
@@ -917,9 +917,9 @@ export class LayersPanel implements SidebarPanel {
             });
         });
         //attach invisible button
-        let invisibileButtons: NodeListOf<HTMLInputElement> = container.querySelectorAll('input[data-gifw-controls-invisible-layer]');
-        invisibileButtons.forEach(invisibileButton => {
-            invisibileButton.addEventListener('change', e => {
+        let invisibleButtons: NodeListOf<HTMLInputElement> = container.querySelectorAll('input[data-gifw-controls-invisible-layer]');
+        invisibleButtons.forEach(invisibleButton => {
+            invisibleButton.addEventListener('change', e => {
                 let element: HTMLInputElement = <HTMLInputElement>(e.currentTarget);
 
                 let layerId = element.dataset.gifwControlsInvisibleLayer;
@@ -971,7 +971,7 @@ export class LayersPanel implements SidebarPanel {
 
                 let layerId = element.dataset.gifwControlsFilterLayer;
 
-                let layer = this.gifwMapInstance.getLayerConfigById(layerId);
+                let layer = this.gifwMapInstance.getLayerConfigById(layerId,[LayerGroupType.Overlay]);
                 e.preventDefault();
                 let layerFilter = new LayerFilter(this, layer);
                 layerFilter.showFilterDialog();
@@ -1017,7 +1017,19 @@ export class LayersPanel implements SidebarPanel {
                     baseUrl = layerSource.getUrl();
                 }
 
-                let styleListPromise = Metadata.getStylesForLayer(baseUrl, featureTypeName);
+                let authKey = Util.Helper.getValueFromObjectByKey(sourceParams, "authkey");
+                let additionalParams = {};
+                if (authKey) {
+                    additionalParams = { authkey: authKey };
+                }
+
+                let proxyEndpoint = "";
+                let layerId = layer.get("layerId");
+                let gifwLayer = this.gifwMapInstance.getLayerConfigById(layerId, [LayerGroupType.Overlay]);
+                if (gifwLayer.proxyMetaRequests) {
+                    proxyEndpoint = `${document.location.protocol}//${this.gifwMapInstance.config.appRoot}proxy`;
+                }
+                let styleListPromise = Metadata.getStylesForLayer(baseUrl, featureTypeName, proxyEndpoint, additionalParams);
                 if (styleListPromise) {
                     styleListPromise.then(styles => {
                         styleModalContent.innerHTML = '';

--- a/GIFrameworkMaps.Web/Scripts/Panels/LegendsPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/LegendsPanel.ts
@@ -13,7 +13,6 @@ export class LegendsPanel implements SidebarPanel {
         this.container = container;
     }
     init() {
-        console.log(`init called on Legends (container ${this.container})`);
         this.attachCloseButton();
         this.gifwMapInstance.olMap.on('moveend', e => {
             //check to see if legends panel is visible before calling for a re-render
@@ -25,7 +24,6 @@ export class LegendsPanel implements SidebarPanel {
         this.render();
     };
     render() {
-        console.log(`render called on Legends (container ${this.container})`);
         let resolution = this.gifwMapInstance.olMap.getView().getResolution();
         this.updateLegend(resolution);
     };

--- a/GIFrameworkMaps.Web/Scripts/Panels/PrintPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/PrintPanel.ts
@@ -25,7 +25,6 @@ export class PrintPanel implements SidebarPanel {
         this.container = container;
     }
     init() {
-        console.log(`init called on Print (container ${this.container})`);
         this.exportInstance = new Export(this.pdfPageSettings, `${document.location.protocol}//${this.gifwMapInstance.config.appRoot}print/configuration/${this.gifwMapInstance.config.id}`);
         this.attachCloseButton();
         this.updateValidationRules();
@@ -34,7 +33,6 @@ export class PrintPanel implements SidebarPanel {
     }
 ;
     render() {
-        console.log(`render called on Print (container ${this.container})`);
     };
     /*TODO - Make this generic*/
     private attachCloseButton():void {

--- a/GIFrameworkMaps.Web/Scripts/Panels/SharePanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/SharePanel.ts
@@ -12,7 +12,6 @@ export class SharePanel implements SidebarPanel {
         this.container = container;
     }
     init() {
-        console.log(`init called on Share (container ${this.container})`);
         this.attachCloseButton();
         this.attachCopyButtons();
 
@@ -27,7 +26,6 @@ export class SharePanel implements SidebarPanel {
         this.render();
     };
     render() {
-        console.log(`render called on Share (container ${this.container})`);
         this.updatePermalink();
     };
     /*TODO - Make this generic*/

--- a/GIFrameworkMaps.Web/Scripts/Search.ts
+++ b/GIFrameworkMaps.Web/Scripts/Search.ts
@@ -58,7 +58,6 @@ export class Search {
         this.searchEndpointURL = searchEndpointURL;
     }
     init(permalinkParams?: Record<string, string>) {
-        console.log(`init called on Search (container ${this.container})`);
         //inject search box into document
         let container = document.querySelector(this.container);
         container.insertAdjacentHTML('beforeend', this.searchBoxHTML);

--- a/GIFrameworkMaps.Web/Scripts/Sidebar.ts
+++ b/GIFrameworkMaps.Web/Scripts/Sidebar.ts
@@ -22,7 +22,6 @@ export class Sidebar {
     }
 
     public open(): void {
-        console.log(`open sidebar called for ${this.name}`);
         let sidebarPanelsContainer = document.querySelector('#gifw-sidebar-right');
         let sidebar: HTMLDivElement = sidebarPanelsContainer.querySelector('#' + this.id);
 
@@ -52,7 +51,6 @@ export class Sidebar {
         
     }
     public close(): void {
-        console.log(`close sidebar called for ${this.name}`);
         Sidebar.close();
         
     }
@@ -75,7 +73,6 @@ export class Sidebar {
 
 
     static close() {
-        console.log(`static close method called`);
         var sidebarPanelsContainer = document.querySelector('#gifw-sidebar-right');
         sidebarPanelsContainer.classList.toggle('show', false);
         var otherSidebars: NodeListOf<HTMLDivElement> = sidebarPanelsContainer.querySelectorAll('.sidebar');

--- a/GIFrameworkMaps.Web/Scripts/SidebarCollection.ts
+++ b/GIFrameworkMaps.Web/Scripts/SidebarCollection.ts
@@ -11,7 +11,6 @@ export class SidebarCollection {
         let actualOrdering: number = 1;
         this.sidebars.sort((a, b) => a.ordering - b.ordering).forEach(sidebar => {
             sidebar.ordering = actualOrdering;
-            console.log(sidebar);
             sidebar.addButton();
             actualOrdering++;
         });

--- a/GIFrameworkMaps.Web/Startup.cs
+++ b/GIFrameworkMaps.Web/Startup.cs
@@ -120,7 +120,7 @@ namespace GIFrameworkMaps.Web
                     Microsoft.Extensions.Primitives.StringValues url;
                     if (queryContext.Collection.TryGetValue("url", out url))
                     {
-                        var error = await forwarder.SendAsync(httpContext, "https://example.com", httpClient, requestOptions, transformer);
+                        var error = await forwarder.SendAsync(httpContext, url, httpClient, requestOptions, transformer);
                         // Check if the proxy operation was successful
                         if (error != ForwarderError.None)
                         {
@@ -338,7 +338,7 @@ namespace GIFrameworkMaps.Web
                     using (var scope = _app.ApplicationServices.CreateScope())
                     {
                         var repo = scope.ServiceProvider.GetRequiredService<ICommonRepository>();
-                        allowedHosts = repo.GetProxyAllowedHosts();
+                        allowedHosts = await repo.GetProxyAllowedHostsAsync();
                     }
                     string decodedUrl = System.Uri.UnescapeDataString(url);
                     Uri requestUri = new Uri(decodedUrl);

--- a/GIFrameworkMaps.Web/Startup.cs
+++ b/GIFrameworkMaps.Web/Startup.cs
@@ -22,6 +22,7 @@ using System;
 using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
 using Yarp.ReverseProxy.Transforms;
+using GIFrameworkMaps.Data.Models;
 
 namespace GIFrameworkMaps.Web
 {
@@ -34,14 +35,11 @@ namespace GIFrameworkMaps.Web
 
         public IConfiguration Configuration { get; }
 
-        //// This method gets called by the runtime. Use this method to add services to the container.
-        //public void ConfigureServices(IServiceCollection services)
-        //{
-            
-        //}
-
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IHttpForwarder forwarder)
+        public void Configure(
+            IApplicationBuilder app, 
+            IWebHostEnvironment env, 
+            IHttpForwarder forwarder)
         {
             app.UseForwardedHeaders();
             if (env.IsDevelopment())
@@ -89,7 +87,9 @@ namespace GIFrameworkMaps.Web
             });
 
             // Setup our own request transform class
-            var transformer = new CustomTransformer(); // or HttpTransformer.Default;
+            
+
+            var transformer = new CustomTransformer(app); // or HttpTransformer.Default;
             var requestOptions = new ForwarderRequestConfig { ActivityTimeout = TimeSpan.FromSeconds(100) };
 
 
@@ -114,14 +114,6 @@ namespace GIFrameworkMaps.Web
                 
                 endpoints.MapControllerRoute("Default_Slug", "{slug1}/{slug2?}/{slug3?}", new { controller = "Map", action = "Index", slug1 = default_version_slug });
                 
-                //Future routes
-                //endpoints.MapControllerRoute("User_Generated", "u/{id}", new { controller = "Map", action = "UserGeneratedMap" });
-                //endpoints.MapControllerRoute("Enhanced_Permalink", "p/{id}", new { controller = "Map", action = "EnhancedPermalink" });
-
-                //endpoints.MapControllerRoute(
-                //    name: "default",
-                //    pattern: "{controller=Home}/{action=Index}/{id?}");
-
                 endpoints.Map("/proxy", async httpContext =>
                 {
                     var queryContext = new QueryTransformContext(httpContext.Request);
@@ -322,22 +314,40 @@ namespace GIFrameworkMaps.Web
         }
         private class CustomTransformer : HttpTransformer
         {
-            public override async ValueTask TransformRequestAsync(HttpContext httpContext,
-                HttpRequestMessage proxyRequest, string destinationPrefix)
+            IApplicationBuilder _app;
+            public CustomTransformer(IApplicationBuilder app)
+            {
+                _app = app;
+            }
+            public override async ValueTask TransformRequestAsync(
+                HttpContext httpContext,
+                HttpRequestMessage proxyRequest, 
+                string destinationPrefix)
             {
                 // Copy all request headers
                 await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix);
 
-                //// Customize the query string:
+                // Customize the query string:
                 var queryContext = new QueryTransformContext(httpContext.Request);
 
                 var url = queryContext.Collection["url"];
                 if (!string.IsNullOrEmpty(url))
                 {
-                    //TODO - Validate against proxy allow list
+                    List<ProxyAllowedHost> allowedHosts;
+                    /*TODO - Injecting the common repository in this way seems a little suspect but does work*/
+                    using (var scope = _app.ApplicationServices.CreateScope())
+                    {
+                        var repo = scope.ServiceProvider.GetRequiredService<ICommonRepository>();
+                        allowedHosts = repo.GetProxyAllowedHosts();
+                    }
                     string decodedUrl = System.Uri.UnescapeDataString(url);
+                    Uri requestUri = new Uri(decodedUrl);
 
-                    proxyRequest.RequestUri = new Uri(decodedUrl);
+                    if(allowedHosts.FirstOrDefault(h => h.Host.ToLower() == requestUri.Host.ToLower()) == null){
+                        return;
+                    }
+
+                    proxyRequest.RequestUri = requestUri;
                     // Suppress the original request header, use the one from the destination Uri.
                     proxyRequest.Headers.Host = null;
                 }


### PR DESCRIPTION
### Summary

This PR adds the ability for layers to proxy their feature and/or map requests through a local proxy hosted in the application.

### Details

Some layers (both those added by admins and ones users add through 'Add layers') are not CORS enabled. Metadata requests (including feature requests, get capabilities requests etc.) will fail due to CORS issues, and map requests will not be able to be printed (due to needing an 'untainted canvas'). This feature allows layers and web service definitions to be marked with 'ProxyMetaRequests' and 'ProxyMapRequests' column in the Layer and WebServiceDefinition table.

The proxy makes use of the YARP proxy, along with a cached database list of 'allowed hosts'. This stops users from being able to proxy any old request through the application. Any proxy request that doesn't match a host in the database list will be rejected.

### Limitations and issues

- YARP is pretty new to me and may not be configured optimally. When proxying map requests, it was found to be slowing down the requests. To mitigate this, layers added from another service through 'Add Layers' will default to single tile requests when ProxyMapRequests is set to true for that service.
- There is a lot of code duplication where the proxy is set and could be much tidier

Closes #7 #20 