### PR TITLE
Remove Origin and Cookie headers when proxying requests

### DIFF
--- a/GIFrameworkMaps.Web/Startup.cs
+++ b/GIFrameworkMaps.Web/Startup.cs
@@ -348,8 +348,9 @@ namespace GIFrameworkMaps.Web
                     }
 
                     proxyRequest.RequestUri = requestUri;
-                    // Suppress the original request header, use the one from the destination Uri.
+                    //Transform request headers
                     proxyRequest.Headers.Host = null;
+                    proxyRequest.Headers.Remove("Cookie");
                 }
                 else
                 {

--- a/GIFrameworkMaps.Web/Startup.cs
+++ b/GIFrameworkMaps.Web/Startup.cs
@@ -350,6 +350,7 @@ namespace GIFrameworkMaps.Web
                     proxyRequest.RequestUri = requestUri;
                     //Transform request headers
                     proxyRequest.Headers.Host = null;
+                    proxyRequest.Headers.Remove("Origin");
                     proxyRequest.Headers.Remove("Cookie");
                 }
                 else


### PR DESCRIPTION
This PR removes the Origin and Cookie HTTP headers from proxied requests.

This prevents issues with destination servers not handling cookies or deploying CORS based blocks when proxying.

This should not cause any issues as the proxy is only deployed sparingly.