### PR TITLE
Allow hiding of login button by version

### DIFF
--- a/GIFrameworkMap.Data/Data/Models/Version.cs
+++ b/GIFrameworkMap.Data/Data/Models/Version.cs
@@ -21,6 +21,7 @@ namespace GIFrameworkMaps.Data.Models
         public string Slug { get; set; }
         public bool Enabled { get; set; }
         public bool RequireLogin { get; set; }
+        public bool ShowLogin { get; set; }
         public string RedirectionURL { get; set; }
         public string HelpURL { get; set; }
         public string FeedbackURL { get; set; }

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/VersionViewModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/VersionViewModel.cs
@@ -15,6 +15,7 @@ namespace GIFrameworkMaps.Data.Models.ViewModels
         public List<BasemapViewModel> Basemaps { get; set; }
         public string HelpURL { get; set; }
         public string FeedbackURL { get; set; }
+        public bool ShowLogin { get; set; }
         public Theme Theme { get; set; }
         public Bound Bound { get; set; }
         public WelcomeMessage WelcomeMessage { get; set; }

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230130110213_AddShowLoginToVersion.Designer.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230130110213_AddShowLoginToVersion.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GIFrameworkMaps.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230130110213_AddShowLoginToVersion")]
+    partial class AddShowLoginToVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230130110213_AddShowLoginToVersion.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230130110213_AddShowLoginToVersion.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddShowLoginToVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowLogin",
+                schema: "giframeworkmaps",
+                table: "Versions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ShowLogin",
+                schema: "giframeworkmaps",
+                table: "Versions");
+        }
+    }
+}

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/VersionViewModel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/VersionViewModel.ts
@@ -14,6 +14,7 @@ export interface VersionViewModel {
     basemaps: Basemap[];
     helpURL: string;
     feedbackURL: string;
+    showLogin: boolean,
     theme: Theme;
     bound: Bound;
     welcomeMessage: WelcomeMessage;

--- a/GIFrameworkMaps.Web/Startup.cs
+++ b/GIFrameworkMaps.Web/Startup.cs
@@ -181,6 +181,7 @@ namespace GIFrameworkMaps.Web
                         Name = "General",
                         Description = "The general version",
                         RequireLogin = false,
+                        ShowLogin = true,
                         Enabled = true,
                         Slug = "general",
                         Bound = ukBound,

--- a/GIFrameworkMaps.Web/Views/Map/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Index.cshtml
@@ -14,6 +14,7 @@
     ViewData["CustomFaviconURL"] = Model.Theme.CustomFaviconURL;
     ViewData["ToSLink"] = configuration.GetValue<string>("GIFrameworkMaps:ToSLink");
     ViewData["PrivacyLink"] = configuration.GetValue<string>("GIFrameworkMaps:PrivacyLink");
+    ViewData["ShowLogin"] = Model.ShowLogin;
     Layout = "_MapLayout";
 }
 <main id="giframeworkMapContainer" class="giframeworkMapContainer">

--- a/GIFrameworkMaps.Web/Views/Shared/_LoginPartial.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/_LoginPartial.cshtml
@@ -1,15 +1,17 @@
 ﻿@using System.Security.Principal
 
-<ul class="navbar-nav">
-    @if (User.Identity.IsAuthenticated)
-    {
+@if (Convert.ToBoolean(ViewData["ShowLogin"]) || User.Identity.IsAuthenticated)
+{
+    <ul class="navbar-nav">
+        @if (User.Identity.IsAuthenticated)
+        {
         <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#"><i class="bi-person-circle"></i> @User.Identity.Name</a>
             <ul class="dropdown-menu dropdown-menu-end">
                 <li><a class="dropdown-item" id="my-account" asp-area="" asp-controller="Account" asp-action="Index">My account</a></li>
                 @if (User.IsInRole("GIFWAdmin"))
                 {
-                    <li><a class="dropdown-item" id="management"  asp-area="" asp-controller="Management" asp-action="Index">Manage application</a></li>
+                <li><a class="dropdown-item" id="management" asp-area="" asp-controller="Management" asp-action="Index">Manage application</a></li>
                 }
                 <li><hr class="dropdown-divider"></li>
                 <li>
@@ -18,11 +20,12 @@
             </ul>
         </li>
 
-    }
-    else
-    {
+        }
+        else
+        {
         <li class="nav-item">
             <a class="nav-link" id="login" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignIn">Login/Register</a>
         </li>
-    }
-</ul>
+        }
+    </ul>
+}

--- a/GIFrameworkMaps.Web/Views/Shared/_MapLayout.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/_MapLayout.cshtml
@@ -65,12 +65,7 @@
                         }
                         
                     </ul>
-                    @{
-                        if (Model.ShowLogin == true)
-                        {
                             <partial name="_LoginPartial" />
-                        }
-                    }
                 </div>
             </div>
         </nav>

--- a/GIFrameworkMaps.Web/Views/Shared/_MapLayout.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/_MapLayout.cshtml
@@ -65,7 +65,12 @@
                         }
                         
                     </ul>
-                    <partial name="_LoginPartial" />
+                    @{
+                        if (Model.ShowLogin == true)
+                        {
+                            <partial name="_LoginPartial" />
+                        }
+                    }
                 </div>
             </div>
         </nav>


### PR DESCRIPTION
The login button can now be shown or hidden depending on which version of GIFrameworkMaps is being used.

When `ShowLogin = true` the login button will appear as normal. 
When `ShowLogin = false` the login button simply won't appear.

There is a column for this in the Versions table in the database where we will be able to customise this setting for each version.

Closes #37

