### PR TITLE
Create production webpack configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -343,6 +343,7 @@ healthchecksdb
 /GIFrameworkMaps.Web/Scripts/**/*.js.map
 /GIFrameworkMaps.Web/Scripts/**/*.js
 /GIFrameworkMaps.Web/wwwroot/js/bundle.*
+/GIFrameworkMaps.Web/wwwroot/js/*.bundle.*
 /GIFrameworkMaps.Web/ScaffoldingReadMe.txt
 #files added by jsPdf
 /GIFrameworkMaps.Web/wwwroot/js/vendors-node_modules_html2canvas_dist_html2canvas_js.bundle.js.map

--- a/GIFrameworkMaps.Web/GIFrameworkMaps.Web.csproj
+++ b/GIFrameworkMaps.Web/GIFrameworkMaps.Web.csproj
@@ -17,7 +17,9 @@
 
   <ItemGroup>
     <None Remove="Scripts\app.ts" />
-    <None Remove="webpack.config.js" />
+    <None Remove="webpack.common.js" />
+    <None Remove="webpack.dev.js" />
+    <None Remove="webpack.prod.js" />
   </ItemGroup>
 
   <ItemGroup>
@@ -63,7 +65,9 @@
 
   <ItemGroup>
     <TypeScriptCompile Include="Scripts\app.ts" />
-    <TypeScriptCompile Include="webpack.config.js" />
+    <TypeScriptCompile Include="webpack.prod.js" />
+    <TypeScriptCompile Include="webpack.dev.js" />
+    <TypeScriptCompile Include="webpack.common.js" />
   </ItemGroup>
 
 </Project>

--- a/GIFrameworkMaps.Web/package-lock.json
+++ b/GIFrameworkMaps.Web/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "giframeworkmaps",
       "version": "1.0.0",
-      "license": "OGL-UK-3.0",
+      "license": "MIT",
       "dependencies": {
         "@microsoft/applicationinsights-web": "2.8.9",
         "@microsoft/signalr": "7.0.0",
@@ -41,7 +41,8 @@
         "ts-loader": "9.4.2",
         "typescript": "4.9.4",
         "webpack": "5.75.0",
-        "webpack-cli": "5.0.1"
+        "webpack-cli": "5.0.1",
+        "webpack-merge": "5.8.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/GIFrameworkMaps.Web/package.json
+++ b/GIFrameworkMaps.Web/package.json
@@ -1,15 +1,16 @@
 {
   "name": "giframeworkmaps",
   "version": "1.0.0",
-  "description": "A .NET 6 based web map using OpenLayers, Bootstrap, Entity Framework Core and Identity Framework",
+  "description": "A .NET based web map built with OpenLayers and Bootstrap",
   "repository": "https://dev.azure.com/dccgisvsts/GIFrameworkMaps",
-  "license": "OGL-UK-3.0",
+  "license": "MIT",
   "main": "index.js",
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build:webpack": "webpack",
-    "watch:webpack": "webpack --watch",
+    "build:webpack": "webpack --config webpack.dev.js",
+    "watch:webpack": "webpack --config webpack.dev.js --watch",
+    "build:webpack-prod": "webpack --config webpack.prod.js",
     "audit": "npm audit",
     "audit fix": "npm audit fix",
     "outdated": "npm outdated"
@@ -30,7 +31,7 @@
     "jspdf": "2.5.1",
     "luxon": "3.2.1",
     "nunjucks": "3.2.3",
-    "ol": "7.2.2", 
+    "ol": "7.2.2",
     "ol-contextmenu": "5.1.1",
     "proj4": "2.8.0",
     "shepherd.js": "11.0.1",
@@ -47,7 +48,8 @@
     "ts-loader": "9.4.2",
     "typescript": "4.9.4",
     "webpack": "5.75.0",
-    "webpack-cli": "5.0.1"
+    "webpack-cli": "5.0.1",
+    "webpack-merge": "5.8.0"
   },
   "-vs-binding": {
     "ProjectOpened": [

--- a/GIFrameworkMaps.Web/webpack.common.js
+++ b/GIFrameworkMaps.Web/webpack.common.js
@@ -1,9 +1,7 @@
 ﻿const path = require('path');
 
 module.exports = {
-    mode: 'development',
     entry: './Scripts/app.ts',
-    devtool: 'source-map',
     module: {
         rules: [
             {

--- a/GIFrameworkMaps.Web/webpack.dev.js
+++ b/GIFrameworkMaps.Web/webpack.dev.js
@@ -1,0 +1,8 @@
+﻿const path = require('path');
+const { merge } = require("webpack-merge");
+const common = require("./webpack.common.js");
+
+module.exports = merge(common, {
+    mode: 'development',
+    devtool: 'source-map'
+});

--- a/GIFrameworkMaps.Web/webpack.prod.js
+++ b/GIFrameworkMaps.Web/webpack.prod.js
@@ -1,0 +1,13 @@
+﻿const path = require('path');
+const { merge } = require("webpack-merge");
+const common = require("./webpack.common.js");
+
+module.exports = merge(common, {
+    mode: 'production',
+    /*hints disabled due to bundle size
+     *ongoing issue to reduce bundle size/split
+     * https://github.com/Dorset-Council-UK/GIFramework-Maps/issues/42*/
+    performance: {
+        hints: false
+    }
+});


### PR DESCRIPTION
This PR tweaks the webpack configuration to use a common config with the merge plugin. This allows there to be a prod and dev config which can be used in build pipelines for dev and prod versions.