### PR TITLE
Management pages - bounds section added

### DIFF
--- a/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
@@ -31,6 +31,7 @@ namespace GIFrameworkMaps.Data
         public DbSet<Models.WebLayerServiceDefinition> WebLayerServiceDefinitions { get; set; }
         public DbSet<Models.ProxyAllowedHost> ProxyAllowedHosts{get;set;}
         public DbSet<Models.Attribution> Attribution { get; set; }
+        public DbSet<Models.Bound> Bound { get; set; }
         public DbSet<Models.LayerSource> LayerSource { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/GIFrameworkMap.Data/Data/IApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/IApplicationDbContext.cs
@@ -23,5 +23,6 @@ namespace GIFrameworkMaps.Data
         DbSet<Models.WebLayerServiceDefinition> WebLayerServiceDefinitions { get; set; }
         DbSet<Models.ProxyAllowedHost> ProxyAllowedHosts { get; set; }
         DbSet<Models.Attribution> Attribution { get; set; }
+        DbSet<Models.Bound> Bound { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Data/IManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/IManagementRepository.cs
@@ -9,5 +9,7 @@ namespace GIFrameworkMaps.Data
         bool PurgeCache();
         Task<Attribution> GetAttribution(int id);
         Task<List<Attribution>> GetAttributions();
+        Task<Bound> GetBound(int id);
+        Task<List<Bound>> GetBounds();
     }
 }

--- a/GIFrameworkMap.Data/Data/ManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/ManagementRepository.cs
@@ -40,6 +40,22 @@ namespace GIFrameworkMaps.Data
             return attribution;
         }
 
+        public async Task<List<Bound>> GetBounds()
+        {
+            var bounds = await _context.Bound
+                .AsNoTracking()
+                .ToListAsync();
+
+            return bounds;
+        }
+
+        public async Task<Bound> GetBound(int id)
+        {
+            var bound = await _context.Bound.FirstOrDefaultAsync(a => a.Id == id);
+
+            return bound;
+        }
+
         /// <summary>
         /// Purges the .NET memory cache
         /// </summary>

--- a/GIFrameworkMap.Data/Data/Models/Bound.cs
+++ b/GIFrameworkMap.Data/Data/Models/Bound.cs
@@ -1,16 +1,37 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace GIFrameworkMaps.Data.Models
 {
     public class Bound
     {
         public int Id { get; set; }
+
+        [Required]
         [MaxLength(100)]
         public string Name { get; set; }
+
+        [Required]
         public string Description { get; set; }
+
+        [Required]
+        [DisplayName ("Bottom left X co-ordinate")]
+        [Range(-20037508.34, 20037508.34)]
         public decimal BottomLeftX { get; set; }
+
+        [Required]
+        [DisplayName("Bottom left Y co-ordinate")]
+        [Range(-20048966.1, 20048966.1)]
         public decimal BottomLeftY { get; set; }
+
+        [Required]
+        [DisplayName("Top right X co-ordinate")]
+        [Range(-20037508.34, 20037508.34)]
         public decimal TopRightX { get; set; }
+
+        [Required]
+        [DisplayName("Top right Y co-ordinate")]
+        [Range(-20048966.1, 20048966.1)]
         public decimal TopRightY { get; set; }
 
     }

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementBoundController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementBoundController.cs
@@ -1,0 +1,159 @@
+﻿using GIFrameworkMaps.Data;
+using GIFrameworkMaps.Data.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace GIFrameworkMaps.Web.Controllers.Management
+{
+    [Authorize(Roles = "GIFWAdmin")]
+    public class ManagementBoundController : Controller
+    {
+        //dependancy injection
+        /*NOTE: A repository pattern is used for much basic data access across the project
+         * however, write and update are done directly on the context based on the advice here
+         * https://learn.microsoft.com/en-us/aspnet/mvc/overview/getting-started/getting-started-with-ef-using-mvc/advanced-entity-framework-scenarios-for-an-mvc-web-application#create-an-abstraction-layer
+         * */
+        private readonly ILogger<ManagementBoundController> _logger;
+        private readonly IManagementRepository _repository;
+        private readonly ApplicationDbContext _context;
+        public ManagementBoundController(
+            ILogger<ManagementBoundController> logger,
+            IManagementRepository repository,
+            ApplicationDbContext context
+            )
+        {
+            _logger = logger;
+            _repository = repository;
+            _context = context;
+        }
+
+        // GET: Bound
+        public async Task<IActionResult> Index()
+        {
+            var bounds = await _repository.GetBounds();
+            return View(bounds);
+        }
+
+        // GET: Bound/Create
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        //POST: Bound/Create
+        [HttpPost, ActionName("Create")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CreatePost(Bound bound)
+        {
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Add(bound);
+                    await _context.SaveChangesAsync();
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogError(ex, "Bound creation failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            return View(bound);
+        }
+
+        // GET: Bound/Edit/1
+        public async Task<IActionResult> Edit(int id)
+        {
+            var bound = await _repository.GetBound(id);
+
+            if (bound == null)
+            {
+                return NotFound();
+            }
+
+            return View(bound);
+        }
+
+        // POST: Attribution/Edit/1
+        [HttpPost, ActionName("Edit")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> EditPost(int id)
+        {
+            var attributionToUpdate = await _context.Attribution.FirstOrDefaultAsync(a => a.Id == id);
+
+            if (await TryUpdateModelAsync(
+                attributionToUpdate,
+                "",
+                a => a.Name, a=> a.AttributionHTML))
+            {
+
+                try
+                {
+                    await _context.SaveChangesAsync();
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex )
+                {
+                    _logger.LogError(ex, "Attribution edit failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            return View(attributionToUpdate);
+        }
+
+        // GET: Attribution/Delete/1
+        public async Task<IActionResult> Delete(int id)
+        {
+            var bound = await _repository.GetBound(id);
+
+            if (bound == null)
+            {
+                return NotFound();
+            }
+
+            return View(bound);
+        }
+
+        // POST: Attribution/Delete/1
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirm(int id)
+        {
+            var attributionToDelete = await _context.Attribution.FirstOrDefaultAsync(a => a.Id == id);
+            var linkedLayers = await _context.LayerSource.Where(l => l.Attribution.Id == id).ToListAsync();
+            if (linkedLayers.Count == 0)
+            {
+                try
+                {
+                    _context.Attribution.Remove(attributionToDelete);
+                    await _context.SaveChangesAsync();
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogError(ex, "Attribution delete failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            else
+            {
+                ModelState.AddModelError("", "There are layers in use that use this attribution, so you cannot delete it.");
+            }
+            return View(attributionToDelete);
+        }
+
+
+    }
+}

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementBoundController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementBoundController.cs
@@ -82,17 +82,17 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             return View(bound);
         }
 
-        // POST: Attribution/Edit/1
+        // POST: Bound/Edit/1
         [HttpPost, ActionName("Edit")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> EditPost(int id)
         {
-            var attributionToUpdate = await _context.Attribution.FirstOrDefaultAsync(a => a.Id == id);
+            var boundToUpdate = await _context.Bound.FirstOrDefaultAsync(a => a.Id == id);
 
             if (await TryUpdateModelAsync(
-                attributionToUpdate,
+                boundToUpdate,
                 "",
-                a => a.Name, a=> a.AttributionHTML))
+                a => a.Name, a=> a.Description, a => a.BottomLeftX, a => a.BottomLeftY, a => a.TopRightX, a => a.TopRightY))
             {
 
                 try
@@ -102,16 +102,16 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 }
                 catch (DbUpdateException ex )
                 {
-                    _logger.LogError(ex, "Attribution edit failed");
+                    _logger.LogError(ex, "Bound edit failed");
                     ModelState.AddModelError("", "Unable to save changes. " +
                         "Try again, and if the problem persists, " +
                         "contact your system administrator.");
                 }
             }
-            return View(attributionToUpdate);
+            return View(boundToUpdate);
         }
 
-        // GET: Attribution/Delete/1
+        // GET: Bound/Delete/1
         public async Task<IActionResult> Delete(int id)
         {
             var bound = await _repository.GetBound(id);
@@ -124,34 +124,34 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             return View(bound);
         }
 
-        // POST: Attribution/Delete/1
+        // POST: Bound/Delete/1
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirm(int id)
         {
-            var attributionToDelete = await _context.Attribution.FirstOrDefaultAsync(a => a.Id == id);
-            var linkedLayers = await _context.LayerSource.Where(l => l.Attribution.Id == id).ToListAsync();
-            if (linkedLayers.Count == 0)
-            {
+            var boundToDelete = await _context.Bound.FirstOrDefaultAsync(a => a.Id == id);
+            //var linkedLayers = await _context.LayerSource.Where(l => l.Bound.Id == id).ToListAsync();
+            //if (linkedLayers.Count == 0)
+            //{
                 try
                 {
-                    _context.Attribution.Remove(attributionToDelete);
+                    _context.Bound.Remove(boundToDelete);
                     await _context.SaveChangesAsync();
                     return RedirectToAction(nameof(Index));
                 }
                 catch (DbUpdateException ex)
                 {
-                    _logger.LogError(ex, "Attribution delete failed");
+                    _logger.LogError(ex, "Bound delete failed");
                     ModelState.AddModelError("", "Unable to save changes. " +
                         "Try again, and if the problem persists, " +
                         "contact your system administrator.");
                 }
-            }
-            else
-            {
-                ModelState.AddModelError("", "There are layers in use that use this attribution, so you cannot delete it.");
-            }
-            return View(attributionToDelete);
+            //}
+            //else
+            //{
+            //    ModelState.AddModelError("", "There are layers in use that use this bound, so you cannot delete it.");
+            //}
+            return View(boundToDelete);
         }
 
 

--- a/GIFrameworkMaps.Web/Startup.cs
+++ b/GIFrameworkMaps.Web/Startup.cs
@@ -111,6 +111,11 @@ namespace GIFrameworkMaps.Web
                     pattern: "Management/Attribution/{action=Index}/{id?}",
                     defaults: new { controller = "ManagementAttribution", action = "Index" });
 
+                endpoints.MapControllerRoute(
+                   name: "ManagementInterface-Bound",
+                   pattern: "Management/Bound/{action=Index}/{id?}",
+                   defaults: new { controller = "ManagementBound", action = "Index" });
+
                 endpoints.MapControllerRoute("General_Map_Redirect", "Map", new { controller = "Map", action = "RedirectToGeneral" });
                 
                 endpoints.MapControllerRoute(

--- a/GIFrameworkMaps.Web/Views/Management/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/Management/Index.cshtml
@@ -68,7 +68,7 @@
         <div class="col">
             <div class="card link-card h-100">
                 <div class="card-body">
-                    <a href="@Url.Action("Index", "ManagementAttribution")" class="stretched-link">
+                    <a asp-action="Index" asp-controller="ManagementAttribution" class="stretched-link">
                         <h4 class="card-title"><i class="bi bi-c-circle"></i> Attributions</h4>
                         <p class="card-text">Manage attributions available in @appName</p>
                     </a>
@@ -79,7 +79,7 @@
         <div class="col">
             <div class="card link-card h-100">
                 <div class="card-body">
-                    <a href="#" class="stretched-link">
+                    <a asp-action="Index" asp-controller="ManagementBound" class="stretched-link">
                         <h4 class="card-title"><i class="bi bi-bounding-box-circles"></i> Bounds</h4>
                         <p class="card-text">Manage the bounds available in @appName</p>
                     </a>
@@ -112,7 +112,7 @@
         <div class="col">
             <div class="card link-card h-100">
                 <div class="card-body">
-                    <a href="@Url.Action("Index","ManagementSystem")" class="stretched-link">
+                    <a asp-action="Index" asp-controller="ManagementSystem" class="stretched-link">
                         <h4 class="card-title"><i class="bi bi-gear"></i> System</h4>
                         <p class="card-text">Check and update system settings and cache</p>
                     </a>
@@ -123,7 +123,7 @@
         <div class="col">
             <div class="card link-card h-100">
                 <div class="card-body">
-                    <a href="@Url.Action("BroadcastMessage","Management")" class="stretched-link">
+                    <a asp-action="BroadcastMessage" asp-controller="Management" class="stretched-link">
                         <h4 class="card-title"><i class="bi bi-broadcast-pin"></i> Broadcast</h4>
                         <p class="card-text">Broadcast a message to @appName users</p>
                     </a>

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Create.cshtml
@@ -1,6 +1,6 @@
-﻿@model GIFrameworkMaps.Data.Models.Attribution
+﻿@model GIFrameworkMaps.Data.Models.Bound
 @{
-    ViewData["Title"] = $"Create new attribution";
+    ViewData["Title"] = $"Create new bound";
 }
 
 <h1>@ViewData["Title"]</h1>
@@ -15,10 +15,29 @@
                 <span asp-validation-for="Name" class="text-danger"></span>
             </div>
             <div class="mb-3">
-                <label asp-for="AttributionHTML" class="control-label"></label>
-                <textarea asp-for="AttributionHTML" class="form-control"></textarea>
-                <div class="form-text">Use the placeholder {{CURRENT_YEAR}} to add the current year automatically</div>
-                <span asp-validation-for="AttributionHTML" class="text-danger"></span>
+                <label asp-for="Description" class="control-label"></label>
+                <input asp-for="Description" class="form-control" />
+                <span asp-validation-for="Description" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="BottomLeftX" class="control-label"></label>
+                <input asp-for="BottomLeftX" class="form-control" />
+                <span asp-validation-for="BottomLeftX" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="BottomLeftY" class="control-label"></label>
+                <input asp-for="BottomLeftY" class="form-control" />
+                <span asp-validation-for="BottomLeftY" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="TopRightX" class="control-label"></label>
+                <input asp-for="TopRightX" class="form-control" />
+                <span asp-validation-for="TopRightX" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="TopRightY" class="control-label"></label>
+                <input asp-for="TopRightY" class="form-control" />
+                <span asp-validation-for="TopRightY" class="text-danger"></span>
             </div>
             <div class="mb-3">
                 <input type="submit" value="Create" class="btn btn-primary" />

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Create.cshtml
@@ -1,0 +1,37 @@
+﻿@model GIFrameworkMaps.Data.Models.Attribution
+@{
+    ViewData["Title"] = $"Create new attribution";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<div class="row mt-2">
+    <div class="col-md-8">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+            <div class="mb-3">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="AttributionHTML" class="control-label"></label>
+                <textarea asp-for="AttributionHTML" class="form-control"></textarea>
+                <div class="form-text">Use the placeholder {{CURRENT_YEAR}} to add the current year automatically</div>
+                <span asp-validation-for="AttributionHTML" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <input type="submit" value="Create" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Cancel</a>
+</div>
+
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Create.cshtml
@@ -19,6 +19,9 @@
                 <input asp-for="Description" class="form-control" />
                 <span asp-validation-for="Description" class="text-danger"></span>
             </div>
+            <div class="alert alert-info" role="alert">
+                The bounds are defined in Web Mercator format.
+            </div>
             <div class="mb-3">
                 <label asp-for="BottomLeftX" class="control-label"></label>
                 <input asp-for="BottomLeftX" class="form-control" />

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Delete.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Delete.cshtml
@@ -1,0 +1,28 @@
+﻿@model GIFrameworkMaps.Data.Models.Attribution
+@{
+    ViewData["Title"] = $"Delete attribution '{Model.Name}'";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row mt-2">
+    <h2>Are you sure you want to delete this attribution?</h2>
+    <p class="lead">This action cannot be undone.</p>
+    <p>If layers are still using this attribution, you will not be able to delete it. Reassign layers to different attributions before deleting the attribution.</p>
+
+    <form asp-action="Delete">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+        <input type="hidden" asp-for="Id" />
+        <div class="mb-3">
+            <input type="submit" value="Delete" class="btn btn-danger" />
+        </div>
+    </form>
+
+</div>
+
+<div>
+    <a asp-action="Index">Cancel</a>
+</div>
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Delete.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Delete.cshtml
@@ -7,7 +7,7 @@
 <div class="row mt-2">
     <h2>Are you sure you want to delete this bound?</h2>
     <p class="lead">This action cannot be undone.</p>
-    <p>If layers are still using this attribution, you will not be able to delete it. Reassign layers to different bounds before deleting the bound.</p>
+    <p>If layers are still using this bound, you will not be able to delete it. Reassign layers to different bounds before deleting the bound.</p>
 
     <form asp-action="Delete">
         <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Delete.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Delete.cshtml
@@ -1,13 +1,13 @@
-﻿@model GIFrameworkMaps.Data.Models.Attribution
+﻿@model GIFrameworkMaps.Data.Models.Bound
 @{
-    ViewData["Title"] = $"Delete attribution '{Model.Name}'";
+    ViewData["Title"] = $"Delete bound '{Model.Name}'";
 }
 
 <h1>@ViewData["Title"]</h1>
 <div class="row mt-2">
-    <h2>Are you sure you want to delete this attribution?</h2>
+    <h2>Are you sure you want to delete this bound?</h2>
     <p class="lead">This action cannot be undone.</p>
-    <p>If layers are still using this attribution, you will not be able to delete it. Reassign layers to different attributions before deleting the attribution.</p>
+    <p>If layers are still using this attribution, you will not be able to delete it. Reassign layers to different bounds before deleting the bound.</p>
 
     <form asp-action="Delete">
         <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Edit.cshtml
@@ -1,6 +1,6 @@
-﻿@model GIFrameworkMaps.Data.Models.Attribution
+﻿@model GIFrameworkMaps.Data.Models.Bound
 @{
-    ViewData["Title"] = $"Edit attribution '{Model.Name}'";
+    ViewData["Title"] = $"Edit bound '{Model.Name}'";
 }
 
 <h1>@ViewData["Title"]</h1>
@@ -15,10 +15,29 @@
                 <span asp-validation-for="Name" class="text-danger"></span>
             </div>
             <div class="mb-3">
-                <label asp-for="AttributionHTML" class="control-label"></label>
-                <textarea asp-for="AttributionHTML" class="form-control"></textarea>
-                <div class="form-text">Use the placeholder {{CURRENT_YEAR}} to add the current year automatically</div>
-                <span asp-validation-for="AttributionHTML" class="text-danger"></span>
+                <label asp-for="Description" class="control-label"></label>
+                <input asp-for="Description" class="form-control" />
+                <span asp-validation-for="Description" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="BottomLeftX" class="control-label"></label>
+                <input asp-for="BottomLeftX" class="form-control" />
+                <span asp-validation-for="BottomLeftX" class="text-danger"></span>
+            </div>
+             <div class="mb-3">
+                <label asp-for="BottomLeftY" class="control-label"></label>
+                <input asp-for="BottomLeftY" class="form-control" />
+                <span asp-validation-for="BottomLeftY" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="TopRightX" class="control-label"></label>
+                <input asp-for="TopRightX" class="form-control" />
+                <span asp-validation-for="TopRightX" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="TopRightY" class="control-label"></label>
+                <input asp-for="TopRightY" class="form-control" />
+                <span asp-validation-for="TopRightY" class="text-danger"></span>
             </div>
             <div class="mb-3">
                 <input type="submit" value="Save" class="btn btn-primary btn-lg" />

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Edit.cshtml
@@ -1,0 +1,37 @@
+﻿@model GIFrameworkMaps.Data.Models.Attribution
+@{
+    ViewData["Title"] = $"Edit attribution '{Model.Name}'";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row mt-2 mb-2">
+    <div class="col-md-8">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+            <input type="hidden" asp-for="Id" />
+            <div class="mb-3">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="AttributionHTML" class="control-label"></label>
+                <textarea asp-for="AttributionHTML" class="form-control"></textarea>
+                <div class="form-text">Use the placeholder {{CURRENT_YEAR}} to add the current year automatically</div>
+                <span asp-validation-for="AttributionHTML" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <input type="submit" value="Save" class="btn btn-primary btn-lg" />
+                <a asp-action="Index" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+        
+    </div>
+</div>
+<a asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger">Delete</a>
+
+
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Edit.cshtml
@@ -19,6 +19,9 @@
                 <input asp-for="Description" class="form-control" />
                 <span asp-validation-for="Description" class="text-danger"></span>
             </div>
+            <div class="alert alert-info" role="alert">
+                The bounds are defined in Web Mercator format.
+            </div>
             <div class="mb-3">
                 <label asp-for="BottomLeftX" class="control-label"></label>
                 <input asp-for="BottomLeftX" class="form-control" />

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Index.cshtml
@@ -1,0 +1,39 @@
+﻿@model List<GIFrameworkMaps.Data.Models.Bound>
+@{
+    ViewData["Title"] = "Bounds";
+}
+
+<partial name="ManagementPartials/BackToManagementHome" />
+
+<h1>@ViewData["Title"]</h1>
+<p class="lead">Create, edit and delete bounds</p>
+
+<a href="@Url.Action("Create")" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Add new bound</a>
+
+@if (Model != null)
+{
+    <table class="table table-bordered table-striped mt-2">
+        <thead>
+            <tr>
+                <th>ID</th><th>Name</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (GIFrameworkMaps.Data.Models.Bound bound in Model.OrderBy(a => a.Id))
+            {
+                <tr>
+                    <td>@bound.Id</td>
+                    <td>@Html.ActionLink(bound.Name, "Edit", new { id = bound.Id })</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+else
+{
+    <div class="alert alert-warning">No bounds have been created yet</div>
+}
+
+            
+
+


### PR DESCRIPTION
Bounds section added to management pages. 

Admins can create, edit or delete map bounds here instead of having to directly edit the database. Basic validation also added so that incorrect or blank values can't be added.