### PR TITLE
Admin - web layer service definition management added

### DIFF
--- a/GIFrameworkMap.Data/Data/IManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/IManagementRepository.cs
@@ -17,5 +17,7 @@ namespace GIFrameworkMaps.Data
         Task<List<Theme>> GetThemes();
         Task<WelcomeMessage> GetWelcomeMessage(int id);
         Task<List<WelcomeMessage>> GetWelcomeMessages();
+        Task<WebLayerServiceDefinition> GetWebLayerServiceDefinition(int id);
+        Task<List<WebLayerServiceDefinition>> GetWebLayerServiceDefinitions();
     }
 }

--- a/GIFrameworkMap.Data/Data/ManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/ManagementRepository.cs
@@ -104,6 +104,22 @@ namespace GIFrameworkMaps.Data
             return welcomeMessage;
         }
 
+        public async Task<List<WebLayerServiceDefinition>> GetWebLayerServiceDefinitions()
+        {
+            var webLayerServiceDefinitions = await _context.WebLayerServiceDefinitions
+                .AsNoTracking()
+                .ToListAsync();
+
+            return webLayerServiceDefinitions;
+        }
+
+        public async Task<WebLayerServiceDefinition> GetWebLayerServiceDefinition(int id)
+        {
+            var webLayerServiceDefinition = await _context.WebLayerServiceDefinitions.FirstOrDefaultAsync(a => a.Id == id);
+
+            return webLayerServiceDefinition;
+        }
+
         /// <summary>
         /// Purges the .NET memory cache
         /// </summary>

--- a/GIFrameworkMap.Data/Data/Models/WebLayerServiceDefinition.cs
+++ b/GIFrameworkMap.Data/Data/Models/WebLayerServiceDefinition.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
@@ -10,18 +11,33 @@ namespace GIFrameworkMaps.Data.Models
     public class WebLayerServiceDefinition
     {
         public int Id { get; set; }
+
         [Required]
         public string Name { get; set; }
+
+        [DisplayName("Description (optional)")]
         public string Description { get; set; }
+
         [Required]
+        [DisplayName("URL")]
+        [RegularExpression("(https?:\\/\\/)([\\w\\-])+\\.{1}([a-zA-Z]{2,63})([\\/\\w-]*)*\\/?\\??([^#\\n\\r]*)?#?([^\\n\\r]*)")]
         public string Url { get; set; }
+
         [Required]
         public ServiceType Type { get; set; }
+
+        [DisplayName("Version (optional)")]
         public string Version { get; set; }
+
+        [DisplayName("Category (optional)")]
         public string Category { get; set; }
+
         [Required]
+        [DisplayName("Sort order")]
         public int SortOrder { get; set; }
+
         public bool ProxyMetaRequests { get; set; }
+
         public bool ProxyMapRequests { get; set; }
     }
 

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementWebLayerServiceDefinitionController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementWebLayerServiceDefinitionController.cs
@@ -1,0 +1,161 @@
+﻿using GIFrameworkMaps.Data;
+using GIFrameworkMaps.Data.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace GIFrameworkMaps.Web.Controllers.Management
+{
+    [Authorize(Roles = "GIFWAdmin")]
+    public class ManagementWebLayerServiceDefinitionController : Controller
+    {
+        //dependancy injection
+        /*NOTE: A repository pattern is used for much basic data access across the project
+         * however, write and update are done directly on the context based on the advice here
+         * https://learn.microsoft.com/en-us/aspnet/mvc/overview/getting-started/getting-started-with-ef-using-mvc/advanced-entity-framework-scenarios-for-an-mvc-web-application#create-an-abstraction-layer
+         * */
+        private readonly ILogger<ManagementWebLayerServiceDefinitionController> _logger;
+        private readonly IManagementRepository _repository;
+        private readonly ApplicationDbContext _context;
+        public ManagementWebLayerServiceDefinitionController(
+            ILogger<ManagementWebLayerServiceDefinitionController> logger,
+            IManagementRepository repository,
+            ApplicationDbContext context
+            )
+        {
+            _logger = logger;
+            _repository = repository;
+            _context = context;
+        }
+
+        // GET: WebLayerServiceDefinition
+        public async Task<IActionResult> Index()
+        {
+            var webLayerServiceDefinitions = await _repository.GetWebLayerServiceDefinitions();
+            return View(webLayerServiceDefinitions);
+        }
+
+        // GET: WebLayerServiceDefinition/Create
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        //POST: WebLayerServiceDefinition/Create
+        [HttpPost, ActionName("Create")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CreatePost(WebLayerServiceDefinition webLayerServiceDefinition)
+        {
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Add(webLayerServiceDefinition);
+                    await _context.SaveChangesAsync();
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogError(ex, "Web layer service definition creation failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            return View(webLayerServiceDefinition);
+        }
+
+        // GET: WebLayerServiceDefinition/Edit/1
+        public async Task<IActionResult> Edit(int id)
+        {
+            var webLayerServiceDefinition = await _repository.GetWebLayerServiceDefinition(id);
+
+            if (webLayerServiceDefinition == null)
+            {
+                return NotFound();
+            }
+
+            return View(webLayerServiceDefinition);
+        }
+
+        // POST: WebLayerServiceDefinition/Edit/1
+        [HttpPost, ActionName("Edit")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> EditPost(int id)
+        {
+            var webLayerServiceDefinitionToUpdate = await _context.WebLayerServiceDefinitions.FirstOrDefaultAsync(a => a.Id == id);
+
+            if (await TryUpdateModelAsync(
+                webLayerServiceDefinitionToUpdate,
+                "",
+                a => a.Name, 
+                a => a.Description, 
+                a => a.Url, 
+                a => a.Type, 
+                a => a.Version, 
+                a => a.Category, 
+                a => a.SortOrder, 
+                a => a.ProxyMapRequests, 
+                a => a.ProxyMetaRequests))
+            {
+
+                try
+                {
+                    await _context.SaveChangesAsync();
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex )
+                {
+                    _logger.LogError(ex, "Web layer service definition edit failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            return View(webLayerServiceDefinitionToUpdate);
+        }
+
+        // GET: WebLayerServiceDefinition/Delete/1
+        public async Task<IActionResult> Delete(int id)
+        {
+            var webLayerServiceDefinition = await _repository.GetWebLayerServiceDefinition(id);
+
+            if (webLayerServiceDefinition == null)
+            {
+                return NotFound();
+            }
+
+            return View(webLayerServiceDefinition);
+        }
+
+        // POST: WebLayerServiceDefinition/Delete/1
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirm(int id)
+        {
+            var webLayerServiceDefinitionToDelete = await _context.WebLayerServiceDefinitions.FirstOrDefaultAsync(a => a.Id == id);
+           
+                try
+                {
+                    _context.WebLayerServiceDefinitions.Remove(webLayerServiceDefinitionToDelete);
+                    await _context.SaveChangesAsync();
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogError(ex, "Web layer service definition delete failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+           
+            return View(webLayerServiceDefinitionToDelete);
+        }
+
+
+    }
+}

--- a/GIFrameworkMaps.Web/Startup.cs
+++ b/GIFrameworkMaps.Web/Startup.cs
@@ -131,6 +131,11 @@ namespace GIFrameworkMaps.Web
                    pattern: "Management/WelcomeMessage/{action=Index}/{id?}",
                    defaults: new { controller = "WelcomeMessage", action = "Index" });
 
+                endpoints.MapControllerRoute(
+                   name: "ManagementInterface-WebLayerServiceDefinition",
+                   pattern: "Management/System/WebLayerServiceDefinition/{action=Index}/{id?}",
+                   defaults: new { controller = "WebLayerServiceDefinition", action = "Index" });
+
                 endpoints.MapControllerRoute("General_Map_Redirect", "Map", new { controller = "Map", action = "RedirectToGeneral" });
                 
                 endpoints.MapControllerRoute(

--- a/GIFrameworkMaps.Web/Views/ManagementSystem/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementSystem/Index.cshtml
@@ -20,9 +20,9 @@
 <div class="row">
     <h2>Web layer service definitions</h2>
     <p>Create, edit and delete web layer service definitions</p>
-    <form asp-controller="ManagementWebServiceLayerDefinition" method="get">
+    <p>
         <a href="@Url.Action("Index","ManagementWebLayerServiceDefinition")" class="btn btn-primary"><i class="bi"></i> Manage web layer service definitions</a>
-    </form>
+    </p>
 </div>
 
             

--- a/GIFrameworkMaps.Web/Views/ManagementSystem/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementSystem/Index.cshtml
@@ -13,7 +13,15 @@
     <p>Click the big red button below to clear the in memory cache for the application.</p>
     <p>All cached objects will be purged and will need to be retrieved from storage again.</p>
     <form asp-controller="ManagementSystem" asp-action="PurgeCache" method="post">
-        <input type="submit" class="btn btn-danger" value="Purge Memory Cache"/>
+        <input type="submit" class="btn btn-danger" value="Purge Memory Cache" />
+    </form>
+</div>
+<br>
+<div class="row">
+    <h2>Web layer service definitions</h2>
+    <p>Create, edit and delete web layer service definitions</p>
+    <form asp-controller="ManagementWebServiceLayerDefinition" method="get">
+        <a href="@Url.Action("Index","ManagementWebLayerServiceDefinition")" class="btn btn-primary"><i class="bi"></i> Manage web layer service definitions</a>
     </form>
 </div>
 

--- a/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Create.cshtml
@@ -1,0 +1,84 @@
+﻿@model GIFrameworkMaps.Data.Models.WebLayerServiceDefinition
+@{
+    ViewData["Title"] = $"Create new web layer service definition";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<div class="row mt-2">
+    <div class="col-md-8">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+            <div class="mb-3">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Description" class="control-label"></label>
+                <input asp-for="Description" class="form-control" />
+                <span asp-validation-for="Description" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Url" class="control-label"></label>
+                <input asp-for="Url" class="form-control" type="url" />
+                <span asp-validation-for="Url" class="text-danger"></span>
+            </div>
+
+              <div class="mb-3">
+                <label asp-for="Type" class="control-label"></label>
+                <select asp-for="Type" class="form-select">
+                    <option value="WMS">WMS</option>
+                    <option value="WFS">WFS</option>
+                    <option value="OWS">OWS</option>
+                    <option value="WMTS">WMTS</option>
+                </select>
+                <span asp-validation-for="Type" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Version" class="control-label"></label>
+                <input asp-for="Version" class="form-control" />
+                <span asp-validation-for="Version" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Category" class="control-label"></label>
+                <input asp-for="Category" class="form-control" />
+                <span asp-validation-for="Category" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="SortOrder" class="control-label"></label>
+                <input asp-for="SortOrder" class="form-control" />
+                <span asp-validation-for="SortOrder" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input asp-for="ProxyMapRequests" class="form-check-input" type="checkbox" />
+                <label asp-for="ProxyMapRequests" class="control-label"> Enable proxy map requests?</label>
+                <span asp-validation-for="ProxyMapRequests" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input asp-for="ProxyMetaRequests" class="form-check-input" type="checkbox" />
+                <label asp-for="ProxyMetaRequests" class="control-label"> Enable proxy metadata requests?</label>
+                <span asp-validation-for="ProxyMetaRequests" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input type="submit" value="Create" class="btn btn-lg btn-primary" />
+                <a asp-action="Index" class="btn btn-link">Cancel</a>
+
+            </div>
+        </form>
+    </div>
+</div>
+
+
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Delete.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Delete.cshtml
@@ -1,0 +1,27 @@
+﻿@model GIFrameworkMaps.Data.Models.WebLayerServiceDefinition
+@{
+    ViewData["Title"] = $"Delete web service layer definition '{Model.Name}'";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row mt-2">
+    <h2>Are you sure you want to delete this web service layer definition?</h2>
+    <p class="lead">This action cannot be undone.</p>
+
+    <form asp-action="Delete">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+        <input type="hidden" asp-for="Id" />
+        <div class="mb-3">
+            <input type="submit" value="Delete" class="btn btn-danger" />
+        </div>
+    </form>
+
+</div>
+
+<div>
+    <a asp-action="Index">Cancel</a>
+</div>
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Edit.cshtml
@@ -1,0 +1,84 @@
+﻿@model GIFrameworkMaps.Data.Models.WebLayerServiceDefinition
+@{
+    ViewData["Title"] = $"Edit web service layer definition '{Model.Name}'";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row mt-2 mb-2">
+    <div class="col-md-8">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+            <input type="hidden" asp-for="Id" />
+            <div class="mb-3">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Description" class="control-label"></label>
+                <input asp-for="Description" class="form-control" />
+                <span asp-validation-for="Description" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Url" class="control-label"></label>
+                <input asp-for="Url" class="form-control" type="url" />
+                <span asp-validation-for="Url" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Type" class="control-label"></label>
+                <select asp-for="Type" class="form-select">
+                    <option value="WMS">WMS</option>
+                    <option value="WFS">WFS</option>
+                    <option value="OWS">OWS</option>
+                    <option value="WMTS">WMTS</option>
+                </select>
+                <span asp-validation-for="Type" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Version" class="control-label"></label>
+                <input asp-for="Version" class="form-control" />
+                <span asp-validation-for="Version" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Category" class="control-label"></label>
+                <input asp-for="Category" class="form-control" />
+                <span asp-validation-for="Category" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="SortOrder" class="control-label"></label>
+                <input asp-for="SortOrder" class="form-control" />
+                <span asp-validation-for="SortOrder" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input asp-for="ProxyMapRequests" class="form-check-input" type="checkbox" />
+                <label asp-for="ProxyMapRequests" class="control-label"> Enable proxy map requests?</label>
+                <span asp-validation-for="ProxyMapRequests" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input asp-for="ProxyMetaRequests" class="form-check-input" type="checkbox" />
+                <label asp-for="ProxyMetaRequests" class="control-label"> Enable proxy metadata requests?</label>
+                <span asp-validation-for="ProxyMetaRequests" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <input type="submit" value="Save" class="btn btn-primary btn-lg" />
+                <a asp-action="Index" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+        
+    </div>
+</div>
+<a asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger">Delete</a>
+
+
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Index.cshtml
@@ -1,0 +1,40 @@
+﻿@model List<GIFrameworkMaps.Data.Models.WebLayerServiceDefinition>
+@{
+    ViewData["Title"] = "Web layer service definitions";
+}
+
+<partial name="ManagementPartials/BackToManagementHome" />
+
+<h1>@ViewData["Title"]</h1>
+<p class="lead">Create, edit and delete web layer service definitions</p>
+
+<a href="@Url.Action("Create")" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Add new web layer service definition</a>
+
+@if (Model != null)
+{
+    <table class="table table-bordered table-striped mt-2">
+        <thead>
+            <tr>
+                <th>ID</th><th>Name</th><th>Category</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (GIFrameworkMaps.Data.Models.WebLayerServiceDefinition webLayerServiceDefinition in Model.OrderBy(a => a.Id))
+            {
+                <tr>
+                    <td>@webLayerServiceDefinition.Id</td>
+                    <td>@Html.ActionLink(webLayerServiceDefinition.Name, "Edit", new { id = webLayerServiceDefinition.Id })</td>
+                    <td>@webLayerServiceDefinition.Category</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+else
+{
+    <div class="alert alert-warning">No web layer service definitions have been created yet</div>
+}
+
+            
+
+


### PR DESCRIPTION
Options to create, edit and delete web layer service definitions made available in the admin console.

Once in the management area, go to System to find the link to manage these.

Closes #34