### PR TITLE
Remove references to no longer used identity schema

### DIFF
--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20210119155849_AddUsersToVersions.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20210119155849_AddUsersToVersions.cs
@@ -44,13 +44,13 @@ namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_VersionUser", x => new { x.UserId, x.VersionId });
-                    table.ForeignKey(
-                        name: "FK_VersionUser_ApplicationUser_UserId",
-                        column: x => x.UserId,
-                        principalTable: "AspNetUsers",
-                        principalColumn: "Id",
-                        principalSchema: "identity",
-                        onDelete: ReferentialAction.Cascade);
+                    //table.ForeignKey(
+                    //    name: "FK_VersionUser_ApplicationUser_UserId",
+                    //    column: x => x.UserId,
+                    //    principalTable: "AspNetUsers",
+                    //    principalColumn: "Id",
+                    //    principalSchema: "identity",
+                    //    onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_VersionUser_Versions_VersionId",
                         column: x => x.VersionId,

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230112110915_AddTour.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230112110915_AddTour.cs
@@ -12,10 +12,10 @@ namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropForeignKey(
-                name: "FK_VersionUser_ApplicationUser_UserId",
-                schema: "giframeworkmaps",
-                table: "VersionUser");
+            //migrationBuilder.DropForeignKey(
+            //    name: "FK_VersionUser_ApplicationUser_UserId",
+            //    schema: "giframeworkmaps",
+            //    table: "VersionUser");
 
             migrationBuilder.AddColumn<int>(
                 name: "TourDetailsId",
@@ -113,43 +113,43 @@ namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
                 schema: "giframeworkmaps",
                 table: "Versions");
 
-            migrationBuilder.CreateTable(
-                name: "ApplicationUser",
-                schema: "giframeworkmaps",
-                columns: table => new
-                {
-                    Id = table.Column<string>(type: "text", nullable: false),
-                    AccessFailedCount = table.Column<int>(type: "integer", nullable: false),
-                    ConcurrencyStamp = table.Column<string>(type: "text", nullable: true),
-                    Email = table.Column<string>(type: "text", nullable: true),
-                    EmailConfirmed = table.Column<bool>(type: "boolean", nullable: false),
-                    FirstName = table.Column<string>(type: "text", nullable: true),
-                    LastName = table.Column<string>(type: "text", nullable: true),
-                    LockoutEnabled = table.Column<bool>(type: "boolean", nullable: false),
-                    LockoutEnd = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
-                    NormalizedEmail = table.Column<string>(type: "text", nullable: true),
-                    NormalizedUserName = table.Column<string>(type: "text", nullable: true),
-                    PasswordHash = table.Column<string>(type: "text", nullable: true),
-                    PhoneNumber = table.Column<string>(type: "text", nullable: true),
-                    PhoneNumberConfirmed = table.Column<bool>(type: "boolean", nullable: false),
-                    SecurityStamp = table.Column<string>(type: "text", nullable: true),
-                    TwoFactorEnabled = table.Column<bool>(type: "boolean", nullable: false),
-                    UserName = table.Column<string>(type: "text", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_ApplicationUser", x => x.Id);
-                });
+        //    migrationBuilder.CreateTable(
+        //        name: "ApplicationUser",
+        //        schema: "giframeworkmaps",
+        //        columns: table => new
+        //        {
+        //            Id = table.Column<string>(type: "text", nullable: false),
+        //            AccessFailedCount = table.Column<int>(type: "integer", nullable: false),
+        //            ConcurrencyStamp = table.Column<string>(type: "text", nullable: true),
+        //            Email = table.Column<string>(type: "text", nullable: true),
+        //            EmailConfirmed = table.Column<bool>(type: "boolean", nullable: false),
+        //            FirstName = table.Column<string>(type: "text", nullable: true),
+        //            LastName = table.Column<string>(type: "text", nullable: true),
+        //            LockoutEnabled = table.Column<bool>(type: "boolean", nullable: false),
+        //            LockoutEnd = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+        //            NormalizedEmail = table.Column<string>(type: "text", nullable: true),
+        //            NormalizedUserName = table.Column<string>(type: "text", nullable: true),
+        //            PasswordHash = table.Column<string>(type: "text", nullable: true),
+        //            PhoneNumber = table.Column<string>(type: "text", nullable: true),
+        //            PhoneNumberConfirmed = table.Column<bool>(type: "boolean", nullable: false),
+        //            SecurityStamp = table.Column<string>(type: "text", nullable: true),
+        //            TwoFactorEnabled = table.Column<bool>(type: "boolean", nullable: false),
+        //            UserName = table.Column<string>(type: "text", nullable: true)
+        //        },
+        //        constraints: table =>
+        //        {
+        //            table.PrimaryKey("PK_ApplicationUser", x => x.Id);
+        //        });
 
-            migrationBuilder.AddForeignKey(
-                name: "FK_VersionUser_ApplicationUser_UserId",
-                schema: "giframeworkmaps",
-                table: "VersionUser",
-                column: "UserId",
-                principalSchema: "giframeworkmaps",
-                principalTable: "ApplicationUser",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.Cascade);
+        //    migrationBuilder.AddForeignKey(
+        //        name: "FK_VersionUser_ApplicationUser_UserId",
+        //        schema: "giframeworkmaps",
+        //        table: "VersionUser",
+        //        column: "UserId",
+        //        principalSchema: "giframeworkmaps",
+        //        principalTable: "ApplicationUser",
+        //        principalColumn: "Id",
+        //        onDelete: ReferentialAction.Cascade);
         }
     }
 }


### PR DESCRIPTION
This PR tidies up the auto generated migrations so they work even though the 'identity' schema that was briefly used early in the project no longer exists. This would previously generate issues when creating fresh install as there were a few indexes and references left floating around. Now that these have been manually extracted, `Script-Migration` works on a fresh database.

Linked #64 