### PR TITLE
Reduce size of search payload

### DIFF
--- a/GIFrameworkMap.Data/Data/Models/Search/RequiredSearch.cs
+++ b/GIFrameworkMap.Data/Data/Models/Search/RequiredSearch.cs
@@ -9,6 +9,7 @@ namespace GIFrameworkMaps.Data.Models.Search
         public bool StopIfFound { get; set; }
         public bool Enabled { get; set; }
         public int Order { get; set; }
-        public SearchDefinition SearchDefinition { get; set; }
+        public string Name { get; set; }
+        public int SearchDefinitionId { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Data/SearchRepository.cs
+++ b/GIFrameworkMap.Data/Data/SearchRepository.cs
@@ -110,23 +110,23 @@ namespace GIFrameworkMaps.Data
                 {
                     if (reqSearch.Enabled)
                     {
-                        var defs = searchDefs.Where(d => d.SearchDefinition.Name == reqSearch.SearchDefinition.Name);
+                        var defs = searchDefs.Where(d => d.SearchDefinitionId == reqSearch.SearchDefinitionId);
                         if (defs is not null & defs.Count() > 0)
                         {
-                            reqSearch.SearchDefinition = defs.First().SearchDefinition;
+                            var selectedDefinition = defs.First().SearchDefinition;
                                                        
-                            if(IsValidSearchTerm(reqSearch))
+                            if(IsValidSearchTerm(selectedDefinition))
                             {
                                 SearchResultCategory searchResultCategory = new SearchResultCategory
                                 {
-                                    CategoryName = reqSearch.SearchDefinition.Title,
+                                    CategoryName = selectedDefinition.Title,
                                     Ordering = reqSearch.Order,
-                                    AttributionHtml = reqSearch.SearchDefinition.AttributionHtml,
-                                    SupressGeom = reqSearch.SearchDefinition.SupressGeom
+                                    AttributionHtml = selectedDefinition.AttributionHtml,
+                                    SupressGeom = selectedDefinition.SupressGeom
                                 };
                                 try
                                 {
-                                    var results = SingleSearch(searchTerm, reqSearch.SearchDefinition);
+                                    var results = SingleSearch(searchTerm, selectedDefinition);
                                     if (results is not null && results.Count() > 0)
                                     {
                                         searchResultCategory.Results = results;
@@ -151,11 +151,11 @@ namespace GIFrameworkMaps.Data
 
 
             //A search term is valid if it's blank or it matches the Required Search's validation regular expression. 
-            bool IsValidSearchTerm(RequiredSearch reqSearch)
+            bool IsValidSearchTerm(SearchDefinition selectedDefinition)
             {
-                if (!string.IsNullOrEmpty(reqSearch.SearchDefinition.ValidationRegex))
+                if (!string.IsNullOrEmpty(selectedDefinition.ValidationRegex))
                 {
-                    var validationRegex = new Regex(reqSearch.SearchDefinition.ValidationRegex);
+                    var validationRegex = new Regex(selectedDefinition.ValidationRegex);
                     return validationRegex.IsMatch(searchTerm);
                 }
                 return true;

--- a/GIFrameworkMaps.Web/Controllers/SearchController.cs
+++ b/GIFrameworkMaps.Web/Controllers/SearchController.cs
@@ -32,7 +32,24 @@ namespace GIFrameworkMaps.Web.Controllers
         public JsonResult Options(int id)
         {
             var searchOpts = _repository.GetSearchDefinitionsByVersion(id);
-            return Json(searchOpts);
+            //convert to smaller payload required for map
+            //This might be better converted with something like AutoMapper
+            //but for now this works
+            List<RequiredSearch> searches = new();
+            
+            foreach(var opt in searchOpts)
+            {
+                searches.Add(new RequiredSearch
+                {
+                    Enabled = opt.Enabled,
+                    Name = opt.SearchDefinition.Name,
+                    Order = opt.Order,
+                    SearchDefinitionId = opt.SearchDefinition.Id,
+                    StopIfFound = opt.StopIfFound
+                });
+            }
+
+            return Json(searches);
         }
     }
 }

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/Search/RequiredSearch.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/Search/RequiredSearch.ts
@@ -1,8 +1,7 @@
-﻿import { SearchDefinition } from "./SearchDefinition";
-
-export interface RequiredSearch {
+﻿export interface RequiredSearch {
     stopIfFound: boolean;
     enabled: boolean;
     order: number;
-    searchDefinition: SearchDefinition;
+    name: string;
+    searchDefinitionId: number;
 }

--- a/GIFrameworkMaps.Web/Scripts/Search.ts
+++ b/GIFrameworkMaps.Web/Scripts/Search.ts
@@ -217,9 +217,11 @@ export class Search {
     */
     private doSearch(searchTerm:string):Promise<SearchResults> {
 
+        let requiredSearches = this.availableSearchDefs.filter(d => { return d.enabled });
+        
         let searchQuery: SearchQuery = {
             query: searchTerm,
-            searches: this.availableSearchDefs.filter(d => { return d.enabled })
+            searches: requiredSearches
         };
 
         let promise = new Promise<SearchResults>((resolve, reject) =>{
@@ -446,9 +448,6 @@ export class Search {
 
                 this.drawSearchResultFeatureOnMap(g,popupContent,popupTitle, this._polyStyle,result.epsg)
             })
-            
-            
-            this._resultsLayer.getSource().addFeatures(geoJson);
         } else if(result.x && result.y) {            
             let resultIcon = new Feature({
                 geometry: new Point([result.x, result.y]),
@@ -565,13 +564,13 @@ export class Search {
             tableBody.innerHTML = '';
             this.availableSearchDefs.sort((a, b) => { return a.order - b.order }).forEach(def => {
                 let row = `<tr>
-                            <td>${def.searchDefinition.name}</td>
+                            <td>${def.name}</td>
                             <td>
-                                <label class="visually-hidden" for="Enabled_${def.searchDefinition.id}">Enable/Disable ${def.searchDefinition.name}</label>
-                                <input type="checkbox" class="form-check-input" name="Enabled_${def.searchDefinition.id}" ${def.enabled ? "checked" : ""} data-gifw-search-def-id="${def.searchDefinition.id}"/></td>
+                                <label class="visually-hidden" for="Enabled_${def.searchDefinitionId}">Enable/Disable ${def.name}</label>
+                                <input type="checkbox" class="form-check-input" name="Enabled_${def.searchDefinitionId}" ${def.enabled ? "checked" : ""} data-gifw-search-def-id="${def.searchDefinitionId}"/></td>
                             <td>
-                                <label class="visually-hidden" for="StopIfFound_${def.searchDefinition.id}">Set search to stop if ${def.searchDefinition.name} is found</label>
-                                <input type="checkbox" class="form-check-input" name="StopIfFound_${def.searchDefinition.id}"${def.stopIfFound ? "checked" : ""} data-gifw-search-def-id="${def.searchDefinition.id}"/>
+                                <label class="visually-hidden" for="StopIfFound_${def.searchDefinitionId}">Set search to stop if ${def.name} is found</label>
+                                <input type="checkbox" class="form-check-input" name="StopIfFound_${def.searchDefinitionId}"${def.stopIfFound ? "checked" : ""} data-gifw-search-def-id="${def.searchDefinitionId}"/>
                             </td>
                            </tr>`;
                 tableBody.insertAdjacentHTML('beforeend', row);
@@ -620,7 +619,7 @@ export class Search {
     private setEnabledSearchDef(searchDefID: number, newState: boolean): void {
         /*TODO could do with some optimization so it doesn't loop through the whole array unnecessarily*/
         this.availableSearchDefs.forEach((def, index, arr) => {
-            if (def.searchDefinition.id === searchDefID) {
+            if (def.searchDefinitionId === searchDefID) {
                 arr[index].enabled = newState;
             }
         })
@@ -629,7 +628,7 @@ export class Search {
     private setStopIfFoundSearchDef(searchDefID: number, newState: boolean): void {
         /*TODO could do with some optimization so it doesn't loop through the whole array unnecessarily*/
         this.availableSearchDefs.forEach((def, index, arr) => {
-            if (def.searchDefinition.id === searchDefID) {
+            if (def.searchDefinitionId === searchDefID) {
                 arr[index].stopIfFound = newState;
             }
         })


### PR DESCRIPTION
This PR reduces the size of the payload when doing searches.

Previously the full search definition details were sent to the client and then sent back with every search, which was unnecessary as we only use a small portion of the data on the client.

This also fixes a minor bug where a console error caused by adding duplicate features to the map was thrown when drawing GeoJSON search results on the map.