### PR TITLE
Admin - Layers

### DIFF
--- a/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
@@ -35,6 +35,7 @@ namespace GIFrameworkMaps.Data
         public DbSet<Models.Theme> Theme { get; set; }
         public DbSet<Models.Bound> Bound { get; set; }
         public DbSet<Models.LayerSource> LayerSource { get; set; }
+        public DbSet<Models.LayerSourceType> LayerSourceType { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
@@ -36,6 +36,7 @@ namespace GIFrameworkMaps.Data
         public DbSet<Models.Bound> Bound { get; set; }
         public DbSet<Models.LayerSource> LayerSource { get; set; }
         public DbSet<Models.LayerSourceType> LayerSourceType { get; set; }
+        public DbSet<Models.LayerSourceOption> LayerSourceOption { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/GIFrameworkMap.Data/Data/IApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/IApplicationDbContext.cs
@@ -27,5 +27,6 @@ namespace GIFrameworkMaps.Data
         DbSet<Models.Bound> Bound { get; set; }
         DbSet<Models.Category> Category { get; set; }
         DbSet<Models.LayerSource> LayerSource { get; set; }
+        DbSet<Models.LayerSourceType> LayerSourceType { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Data/IApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/IApplicationDbContext.cs
@@ -28,5 +28,6 @@ namespace GIFrameworkMaps.Data
         DbSet<Models.Category> Category { get; set; }
         DbSet<Models.LayerSource> LayerSource { get; set; }
         DbSet<Models.LayerSourceType> LayerSourceType { get; set; }
+        DbSet<Models.LayerSourceOption> LayerSourceOption { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Data/IManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/IManagementRepository.cs
@@ -24,5 +24,7 @@ namespace GIFrameworkMaps.Data
         Task<LayerSource> GetLayerSource(int id);
         Task<List<LayerSource>> GetLayerSources();
         Task<LayerSourceOption> GetLayerSourceOption(int id);
+        Task<List<Category>> GetLayerCategories();
+        Task<Category> GetLayerCategory(int id);
     }
 }

--- a/GIFrameworkMap.Data/Data/IManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/IManagementRepository.cs
@@ -23,5 +23,6 @@ namespace GIFrameworkMaps.Data
         Task<List<Layer>> GetLayers();
         Task<LayerSource> GetLayerSource(int id);
         Task<List<LayerSource>> GetLayerSources();
+        Task<LayerSourceOption> GetLayerSourceOption(int id);
     }
 }

--- a/GIFrameworkMap.Data/Data/IManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/IManagementRepository.cs
@@ -19,5 +19,9 @@ namespace GIFrameworkMaps.Data
         Task<List<WelcomeMessage>> GetWelcomeMessages();
         Task<WebLayerServiceDefinition> GetWebLayerServiceDefinition(int id);
         Task<List<WebLayerServiceDefinition>> GetWebLayerServiceDefinitions();
+        Task<Layer> GetLayer(int id);
+        Task<List<Layer>> GetLayers();
+        Task<LayerSource> GetLayerSource(int id);
+        Task<List<LayerSource>> GetLayerSources();
     }
 }

--- a/GIFrameworkMap.Data/Data/ManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/ManagementRepository.cs
@@ -113,13 +113,47 @@ namespace GIFrameworkMaps.Data
             return webLayerServiceDefinitions;
         }
 
+        public async Task<Layer> GetLayer(int id)
+        {
+            var layer = await _context.Layer
+                .Include(l => l.LayerSource)
+                .FirstOrDefaultAsync(a => a.Id == id);
+
+            return layer;
+        }
+
+        public async Task<List<Layer>> GetLayers()
+        {
+            var layers = await _context.Layer
+                .AsNoTracking()
+                .ToListAsync();
+
+            return layers;
+        }
+
+        public async Task<LayerSource> GetLayerSource(int id)
+        {
+            var layerSource = await _context.LayerSource.FirstOrDefaultAsync(a => a.Id == id);
+
+            return layerSource;
+        }
+
+        public async Task<List<LayerSource>> GetLayerSources()
+        {
+            var layerSources = await _context.LayerSource
+                .AsNoTracking()
+                .ToListAsync();
+
+            return layerSources;
+        }
+
         public async Task<WebLayerServiceDefinition> GetWebLayerServiceDefinition(int id)
         {
             var webLayerServiceDefinition = await _context.WebLayerServiceDefinitions.FirstOrDefaultAsync(a => a.Id == id);
 
             return webLayerServiceDefinition;
         }
-        
+
         /// <summary>
         /// Purges the .NET memory cache
         /// </summary>

--- a/GIFrameworkMap.Data/Data/ManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/ManagementRepository.cs
@@ -133,7 +133,9 @@ namespace GIFrameworkMaps.Data
 
         public async Task<LayerSource> GetLayerSource(int id)
         {
-            var layerSource = await _context.LayerSource.FirstOrDefaultAsync(a => a.Id == id);
+            var layerSource = await _context.LayerSource
+                .Include(s => s.LayerSourceOptions)
+                .FirstOrDefaultAsync(a => a.Id == id);
 
             return layerSource;
         }

--- a/GIFrameworkMap.Data/Data/ManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/ManagementRepository.cs
@@ -149,6 +149,13 @@ namespace GIFrameworkMaps.Data
             return layerSources;
         }
 
+        public async Task<LayerSourceOption> GetLayerSourceOption(int id)
+        {
+            var layerSource = await _context.LayerSourceOption
+                .FirstOrDefaultAsync(a => a.Id == id);
+
+            return layerSource;
+        }
         public async Task<WebLayerServiceDefinition> GetWebLayerServiceDefinition(int id)
         {
             var webLayerServiceDefinition = await _context.WebLayerServiceDefinitions.FirstOrDefaultAsync(a => a.Id == id);

--- a/GIFrameworkMap.Data/Data/ManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/ManagementRepository.cs
@@ -1,4 +1,5 @@
 ﻿using GIFrameworkMaps.Data.Models;
+using GIFrameworkMaps.Data.Models.ViewModels.Management;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -161,6 +162,27 @@ namespace GIFrameworkMaps.Data
             var webLayerServiceDefinition = await _context.WebLayerServiceDefinitions.FirstOrDefaultAsync(a => a.Id == id);
 
             return webLayerServiceDefinition;
+        }
+
+        public async Task<Category> GetLayerCategory(int id)
+        {
+            var layerCategory = await _context.Category
+                .Include(c => c.Layers)
+                .Include(c => c.ParentCategory)
+                .FirstOrDefaultAsync(a => a.Id == id);
+
+            return layerCategory;
+        }
+
+        public async Task<List<Category>> GetLayerCategories()
+        {
+            var layerCategories = await _context.Category
+                .Include(c => c.Layers)
+                .Include(c => c.ParentCategory)
+                .AsNoTracking()
+                .ToListAsync();
+
+            return layerCategories;
         }
 
         /// <summary>

--- a/GIFrameworkMap.Data/Data/Models/Category.cs
+++ b/GIFrameworkMap.Data/Data/Models/Category.cs
@@ -14,6 +14,7 @@ namespace GIFrameworkMaps.Data.Models
         public string Name { get; set; }
         public string Description { get; set; }
         public int Order { get; set; }
+        [Display(Name="Parent Category (optional)")]
         public int? ParentCategoryId { get; set; }
         public List<CategoryLayer> Layers { get; set; }
         public Category ParentCategory { get; set; }

--- a/GIFrameworkMap.Data/Data/Models/Category.cs
+++ b/GIFrameworkMap.Data/Data/Models/Category.cs
@@ -15,7 +15,7 @@ namespace GIFrameworkMaps.Data.Models
         public string Description { get; set; }
         public int Order { get; set; }
         public int? ParentCategoryId { get; set; }
-        public virtual List<CategoryLayer> Layers { get; set; }
+        public List<CategoryLayer> Layers { get; set; }
         public Category ParentCategory { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Data/Models/Layer.cs
+++ b/GIFrameworkMap.Data/Data/Models/Layer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
@@ -12,19 +13,34 @@ namespace GIFrameworkMaps.Data.Models
         public int Id { get; set; }
         [MaxLength(200)]
         public string Name { get; set; }
+        [Display(Name = "Minimum viewable zoom level (optional)")]
         public int? MinZoom { get; set; }
+        [Display(Name = "Maximum viewable zoom level (optional)")]
         public int? MaxZoom { get; set; }
+        [Display(Name= "Restricted bounds (optional)")]
+        public int? BoundId { get; set; }
         public Bound? Bound { get; set; }
+        [Display(Name = "Layer Z-Index")]
         public int ZIndex { get; set; }
-        public int DefaultOpacity { get; set; }
-        public int DefaultSaturation { get; set; }
-        public bool Queryable { get; set; }
+        [Display(Name = "Default Opacity")]
+        [Range(0, 100)]
+        public int DefaultOpacity { get; set; } = 100;
+        [Display(Name = "Default Saturation")]
+        [Range(0, 100)]
+        public int DefaultSaturation { get; set; } = 100;
+        public bool Queryable { get; set; } = true;
+        [Display(Name = "Info Template")]
         public string? InfoTemplate { get; set; }
+        [Display(Name = "Info List Template")]
         public string? InfoListTitleTemplate { get; set; }
         public bool Filterable { get; set; } = true;
+        [Display(Name = "Default filter is editable")]
         public bool DefaultFilterEditable { get; set; } = false;
+        [Display(Name = "Proxy Metadata Requests")]
         public bool ProxyMetaRequests { get; set; }
+        [Display(Name = "Proxy Map Requests")]
         public bool ProxyMapRequests { get; set; }
+        public int LayerSourceId { get; set; }
         public LayerSource LayerSource { get; set; }
         //public virtual List<Category> Categories { get; set; }
 

--- a/GIFrameworkMap.Data/Data/Models/LayerSource.cs
+++ b/GIFrameworkMap.Data/Data/Models/LayerSource.cs
@@ -19,7 +19,11 @@ namespace GIFrameworkMaps.Data.Models
         [MaxLength(100)]
         public string Name { get; set; }
         public string Description { get; set; }
+        [Display(Name="Attribution")]
+        public int AttributionId { get; set; }
         public Attribution Attribution { get; set; }
+        [Display(Name = "Layer Type")]
+        public int LayerSourceTypeId { get; set; }
         public LayerSourceType LayerSourceType { get; set; }
         public List<LayerSourceOption> LayerSourceOptions { get; set; } 
     }

--- a/GIFrameworkMap.Data/Data/Models/LayerSourceOption.cs
+++ b/GIFrameworkMap.Data/Data/Models/LayerSourceOption.cs
@@ -13,5 +13,6 @@ namespace GIFrameworkMaps.Data.Models
         [MaxLength(100)]
         public string Name { get; set; }
         public string Value { get; set; }
+        public int LayerSourceId { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/Management/CategoryEditModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/Management/CategoryEditModel.cs
@@ -1,0 +1,22 @@
+﻿using GIFrameworkMaps.Data.Models;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GIFrameworkMaps.Data.Models.ViewModels.Management
+{
+    public class CategoryEditModel
+    {
+        public GIFrameworkMaps.Data.Models.Category Category { get; set; }
+        public SelectList AvailableParentCategories { get; set; }
+
+        public List<int> SelectedLayers { get; set; }
+        
+        public List<Layer> AvailableLayers { get; set; }
+
+    }
+}

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/Management/LayerCreateModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/Management/LayerCreateModel.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GIFrameworkMaps.Data.Models.ViewModels.Management
+{
+    public class LayerCreateModel
+    {
+        public GIFrameworkMaps.Data.Models.Layer Layer { get; set; }
+        public SelectList AvailableBounds { get; set; }
+    }
+}

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/Management/LayerEditModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/Management/LayerEditModel.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GIFrameworkMaps.Data.Models.ViewModels.Management
+{
+    public class LayerEditModel
+    {
+        public GIFrameworkMaps.Data.Models.Layer Layer { get; set; }
+        public SelectList AvailableBounds { get; set; }
+    }
+}

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/Management/LayerSourceEditModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/Management/LayerSourceEditModel.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GIFrameworkMaps.Data.Models.ViewModels.Management
+{
+    public class LayerSourceEditModel
+    {
+        public GIFrameworkMaps.Data.Models.LayerSource LayerSource { get; set; }
+        public SelectList AvailableAttributions { get; set; }
+        public SelectList AvailableLayerSourceTypes { get; set; }
+    }
+}

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/Management/LayerSourceOptionEditModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/Management/LayerSourceOptionEditModel.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GIFrameworkMaps.Data.Models.ViewModels.Management
+{
+    public class LayerSourceOptionEditModel
+    {
+        public GIFrameworkMaps.Data.Models.LayerSourceOption LayerSourceOption { get; set; }
+        public GIFrameworkMaps.Data.Models.LayerSource LayerSource { get; set; }
+
+    }
+}

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerCategoryController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerCategoryController.cs
@@ -1,0 +1,242 @@
+﻿using GIFrameworkMaps.Data;
+using GIFrameworkMaps.Data.Models;
+using GIFrameworkMaps.Data.Models.ViewModels.Management;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
+
+namespace GIFrameworkMaps.Web.Controllers.Management
+{
+    [Authorize(Roles = "GIFWAdmin")]
+    public class ManagementLayerCategoryController : Controller
+    {
+        //dependancy injection
+        /*NOTE: A repository pattern is used for much basic data access across the project
+         * however, write and update are done directly on the context based on the advice here
+         * https://learn.microsoft.com/en-us/aspnet/mvc/overview/getting-started/getting-started-with-ef-using-mvc/advanced-entity-framework-scenarios-for-an-mvc-web-application#create-an-abstraction-layer
+         * */
+        private readonly ILogger<ManagementLayerCategoryController> _logger;
+        private readonly IManagementRepository _repository;
+        private readonly ApplicationDbContext _context;
+        public ManagementLayerCategoryController(
+            ILogger<ManagementLayerCategoryController> logger,
+            IManagementRepository repository,
+            ApplicationDbContext context
+            )
+        {
+            _logger = logger;
+            _repository = repository;
+            _context = context;
+        }
+
+        // GET: Version
+        public async Task<IActionResult> Index()
+        {
+            var attributions = await _repository.GetLayerCategories();
+            return View(attributions);
+        }
+
+        // GET: Version/Create
+        public IActionResult Create()
+        {
+            var category = new Data.Models.Category();
+            var editModel = new CategoryEditModel() { Category = category };
+            RebuildViewModel(ref editModel, category);
+            return View(editModel);
+        }
+
+        //POST: Version/Create
+        [HttpPost, ActionName("Create")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CreatePost(CategoryEditModel editModel, int[] selectedLayers)
+        {
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Add(editModel.Category);
+                    UpdateCategoryLayers(selectedLayers, editModel.Category);
+                    await _context.SaveChangesAsync();
+                    
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogError(ex, "Layer Category creation failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+
+            editModel = new CategoryEditModel() { Category = editModel.Category };
+            RebuildViewModel(ref editModel, editModel.Category);
+            return View(editModel);
+        }
+
+        // GET: Version/Edit/1
+        public async Task<IActionResult> Edit(int id)
+        {
+            var category = await _context.Category
+                .Include(c => c.ParentCategory)
+                .Include(c => c.Layers)
+                .FirstOrDefaultAsync(v => v.Id == id);
+
+            if (category == null)
+            {
+                return NotFound();
+            }
+            var editModel = new CategoryEditModel() { Category = category };
+            RebuildViewModel(ref editModel, category);
+            return View(editModel);
+        }
+
+        // POST: Version/Edit/1
+        [HttpPost, ActionName("Edit")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> EditPost(int id, int[] selectedLayers)
+        {
+            var categoryToUpdate = await _context.Category
+                .Include(c => c.ParentCategory)
+                .Include(c => c.Layers)
+                .FirstOrDefaultAsync(v => v.Id == id);
+
+            var editModel = new CategoryEditModel() { Category = categoryToUpdate };
+
+            if (await TryUpdateModelAsync(
+                editModel.Category,
+                "Category",
+                a => a.Name,
+                a => a.Description,
+                a => a.Order,
+                a => a.ParentCategoryId
+                ))
+            {
+
+                try
+                {
+                    UpdateCategoryLayers(selectedLayers, categoryToUpdate);
+                    await _context.SaveChangesAsync();
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex )
+                {
+                    _logger.LogError(ex, "Layer Category edit failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            
+            RebuildViewModel(ref editModel, categoryToUpdate);
+            return View(editModel);
+        }
+
+        // GET: Version/Delete/1
+        public async Task<IActionResult> Delete(int id)
+        {
+            var category = await _repository.GetLayerCategory(id);
+
+            if (category == null)
+            {
+                return NotFound();
+            }
+
+            return View(category);
+        }
+
+        // POST: Version/Delete/1
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirm(int id)
+        {
+            var categoryToDelete = await _context.Category.FirstOrDefaultAsync(a => a.Id == id);
+            try
+            {
+                _context.Category.Remove(categoryToDelete);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+            catch (DbUpdateException ex)
+            {
+                _logger.LogError(ex, "Layer Category delete failed");
+                ModelState.AddModelError("", "Unable to save changes. " +
+                    "Try again, and if the problem persists, " +
+                    "contact your system administrator.");
+            }
+            return View(categoryToDelete);
+        }
+
+        private void UpdateCategoryLayers(int[] selectedLayers, Data.Models.Category categoryToUpdate)
+        {
+            if (selectedLayers == null)
+            {
+                categoryToUpdate.Layers = new List<CategoryLayer>();
+                return;
+            }
+
+            var selectedCaegoriesHS = new HashSet<int>(selectedLayers);
+            var versionCategories = new HashSet<int>();
+            if (categoryToUpdate.Layers != null)
+            {
+                versionCategories = new HashSet<int>(categoryToUpdate.Layers.Select(c => c.LayerId));
+            }
+
+            foreach (var layer in _context.Layer)
+            {
+                if (selectedCaegoriesHS.Contains(layer.Id))
+                {
+                    if (!versionCategories.Contains(layer.Id))
+                    {
+                        if (categoryToUpdate.Layers == null)
+                        {
+                            categoryToUpdate.Layers = new List<CategoryLayer>();
+                        }
+                        categoryToUpdate.Layers.Add(new CategoryLayer
+                        {
+                            CategoryId = categoryToUpdate.Id,
+                            LayerId = layer.Id
+                        });
+                    }
+                }
+                else
+                {
+
+                    if (versionCategories.Contains(layer.Id))
+                    {
+                        CategoryLayer categoryLayerToRemove = categoryToUpdate.Layers.FirstOrDefault(i => i.LayerId == layer.Id);
+                        _context.Remove(categoryLayerToRemove);
+                    }
+                }
+            }
+        }
+
+        private void RebuildViewModel(ref Data.Models.ViewModels.Management.CategoryEditModel model, Data.Models.Category category)
+        {
+            
+            var categories = _context.Category.Where(c => c.Id != category.Id).OrderBy(t => t.Name).ToList();
+            var layers = _context.Layer.OrderBy(l => l.Name).ToList();
+
+            model.AvailableParentCategories = new SelectList(categories, "Id", "Name", category.ParentCategoryId);
+
+            model.AvailableLayers = layers;
+            if (category.Layers != null)
+            {
+                model.SelectedLayers = category.Layers.Select(c => c.LayerId).ToList();
+            }
+            ViewData["SelectedLayers"] = model.SelectedLayers;
+            ViewData["AllLayers"] = model.AvailableLayers;
+        }
+
+    }
+}

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerController.cs
@@ -69,7 +69,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 LayerSource = layerSource
             };
             LayerEditModel editModel = new() { Layer = layer };
-
+            RebuildViewModel(ref editModel, layer);
             return View(editModel);
         }
 
@@ -84,7 +84,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 {
                     _context.Add(editModel.Layer);
                     await _context.SaveChangesAsync();
-                    return RedirectToAction(nameof(Index));
+                    return RedirectToAction(nameof(List));
                 }
                 catch (DbUpdateException ex)
                 {

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerController.cs
@@ -1,0 +1,203 @@
+﻿using GIFrameworkMaps.Data;
+using GIFrameworkMaps.Data.Models;
+using GIFrameworkMaps.Data.Models.ViewModels.Management;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace GIFrameworkMaps.Web.Controllers.Management
+{
+    [Authorize(Roles = "GIFWAdmin")]
+    public class ManagementLayerController : Controller
+    {
+        //dependancy injection
+        /*NOTE: A repository pattern is used for much basic data access across the project
+         * however, write and update are done directly on the context based on the advice here
+         * https://learn.microsoft.com/en-us/aspnet/mvc/overview/getting-started/getting-started-with-ef-using-mvc/advanced-entity-framework-scenarios-for-an-mvc-web-application#create-an-abstraction-layer
+         * */
+        private readonly ILogger<ManagementLayerController> _logger;
+        private readonly IManagementRepository _repository;
+        private readonly ApplicationDbContext _context;
+        public ManagementLayerController(
+            ILogger<ManagementLayerController> logger,
+            IManagementRepository repository,
+            ApplicationDbContext context
+            )
+        {
+            _logger = logger;
+            _repository = repository;
+            _context = context;
+        }
+
+        // GET: Layer
+        public IActionResult Index()
+        {
+            return View();
+        }
+
+        // GET: Layer
+        public async Task<IActionResult> List()
+        {
+            var layers  = await _repository.GetLayers();
+            return View(layers);
+        }
+
+        public async Task<IActionResult> Create()
+        {
+            var layerSources = await _repository.GetLayerSources();
+            return View(layerSources);
+        }
+
+        // GET: Layer/Create/{layerSourceId}
+        public async Task<IActionResult> CreateFromSource(int id)
+        {
+            //get the layer source
+            var layerSource = await _repository.GetLayerSource(id);
+
+            if(layerSource == null)
+            {
+                return NotFound();
+            }
+            var layer = new Layer { 
+                LayerSourceId = id, 
+                LayerSource = layerSource
+            };
+            LayerEditModel editModel = new() { Layer = layer };
+
+            return View(editModel);
+        }
+
+        //POST: Layer/Create
+        [HttpPost, ActionName("CreateFromSource")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CreatePost(LayerEditModel editModel)
+        {
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Add(editModel.Layer);
+                    await _context.SaveChangesAsync();
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogError(ex, "Layer creation failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            RebuildViewModel(ref editModel, editModel.Layer);
+            return View(editModel);
+        }
+
+        // GET: Layer/Edit/1
+        public async Task<IActionResult> Edit(int id)
+        {
+            var layer = await _repository.GetLayer(id);
+
+            if (layer == null)
+            {
+                return NotFound();
+            }
+
+            var editModel = new LayerEditModel { Layer = layer };
+            RebuildViewModel(ref editModel, layer);
+            return View(editModel);
+        }
+
+        // POST: Layer/Edit/1
+        [HttpPost, ActionName("Edit")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> EditPost(int id)
+        {
+            var layerToUpdate = await _context.Layer.FirstOrDefaultAsync(a => a.Id == id);
+
+            if (await TryUpdateModelAsync(
+                layerToUpdate,
+                "Layer",
+                a => a.Name,
+                a => a.BoundId,
+                a => a.MaxZoom,
+                a => a.MinZoom,
+                a => a.ZIndex,
+                a => a.DefaultOpacity,
+                a => a.DefaultSaturation,
+                a => a.InfoTemplate,
+                a => a.InfoListTitleTemplate,
+                a => a.Queryable,
+                a => a.DefaultFilterEditable,
+                a => a.Filterable,
+                a => a.ProxyMapRequests,
+                a => a.ProxyMetaRequests))
+            {
+
+                try
+                {
+                    await _context.SaveChangesAsync();
+                    return RedirectToAction(nameof(List));
+                }
+                catch (DbUpdateException ex )
+                {
+                    _logger.LogError(ex, "Layer edit failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            return View(layerToUpdate);
+        }
+
+        // GET: Layer/Delete/1
+        public async Task<IActionResult> Delete(int id)
+        {
+            var layer = await _repository.GetLayer(id);
+
+            if (layer == null)
+            {
+                return NotFound();
+            }
+
+            return View(layer);
+        }
+
+        // POST: Layer/Delete/1
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirm(int id)
+        {
+            var layerToDelete = await _context.Layer.FirstOrDefaultAsync(a => a.Id == id);
+
+            try
+            {
+                _context.Layer.Remove(layerToDelete);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(List));
+            }
+            catch (DbUpdateException ex)
+            {
+                _logger.LogError(ex, "Layer delete failed");
+                ModelState.AddModelError("", "Unable to save changes. " +
+                    "Try again, and if the problem persists, " +
+                    "contact your system administrator.");
+            }
+
+            return View(layerToDelete);
+        }
+
+        private void RebuildViewModel(ref Data.Models.ViewModels.Management.LayerEditModel model, Data.Models.Layer layer)
+        {
+            var bounds = _context.Bound.OrderBy(t => t.Name).ToList();
+            
+            model.AvailableBounds = new SelectList(bounds, "Id", "Name", layer.BoundId);
+        }
+
+    }
+}

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerSourceController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerSourceController.cs
@@ -1,0 +1,174 @@
+﻿using GIFrameworkMaps.Data;
+using GIFrameworkMaps.Data.Models;
+using GIFrameworkMaps.Data.Models.ViewModels.Management;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Drawing.Printing;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
+
+namespace GIFrameworkMaps.Web.Controllers.Management
+{
+    [Authorize(Roles = "GIFWAdmin")]
+    public class ManagementLayerSourceController : Controller
+    {
+        //dependancy injection
+        /*NOTE: A repository pattern is used for much basic data access across the project
+         * however, write and update are done directly on the context based on the advice here
+         * https://learn.microsoft.com/en-us/aspnet/mvc/overview/getting-started/getting-started-with-ef-using-mvc/advanced-entity-framework-scenarios-for-an-mvc-web-application#create-an-abstraction-layer
+         * */
+        private readonly ILogger<ManagementLayerSourceController> _logger;
+        private readonly IManagementRepository _repository;
+        private readonly ApplicationDbContext _context;
+        public ManagementLayerSourceController(
+            ILogger<ManagementLayerSourceController> logger,
+            IManagementRepository repository,
+            ApplicationDbContext context
+            )
+        {
+            _logger = logger;
+            _repository = repository;
+            _context = context;
+        }
+
+        // GET: LayerSource
+        public async Task<IActionResult> Index()
+        {
+            var layers = await _repository.GetLayerSources();
+            return View(layers);
+        }
+
+        public IActionResult Create()
+        {
+            var layerSource = new LayerSource();
+            var editModel = new LayerSourceEditModel();
+            RebuildViewModel(ref editModel, layerSource);
+            return View(editModel);
+        }
+
+        //POST: LayerSource/Create
+        [HttpPost, ActionName("Create")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CreatePost(LayerSourceEditModel editModel)
+        {
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Add(editModel.LayerSource);
+                    await _context.SaveChangesAsync();
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogError(ex, "Layer source creation failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            RebuildViewModel(ref editModel, editModel.LayerSource);
+            return View(editModel);
+        }
+
+        // GET: LayerSource/Edit/1
+        public async Task<IActionResult> Edit(int id)
+        {
+            var layerSource = await _repository.GetLayerSource(id);
+
+            if (layerSource == null)
+            {
+                return NotFound();
+            }
+
+            var editModel = new LayerSourceEditModel { LayerSource = layerSource };
+            RebuildViewModel(ref editModel, layerSource);
+            return View(editModel);
+        }
+
+        // POST: LayerSource/Edit/1
+        [HttpPost, ActionName("Edit")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> EditPost(int id)
+        {
+            var sourceToUpdate = await _context.LayerSource.FirstOrDefaultAsync(a => a.Id == id);
+
+            if (await TryUpdateModelAsync(
+                sourceToUpdate,
+                "LayerSource",
+                a => a.Name,
+                a => a.Description,
+                a => a.AttributionId,
+                a => a.LayerSourceTypeId))
+            {
+
+                try
+                {
+                    await _context.SaveChangesAsync();
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex )
+                {
+                    _logger.LogError(ex, "Layer source edit failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            return View(sourceToUpdate);
+        }
+
+        // GET: LayerSource/Delete/1
+        public async Task<IActionResult> Delete(int id)
+        {
+            var layerSource = await _repository.GetLayerSource(id);
+
+            if (layerSource == null)
+            {
+                return NotFound();
+            }
+
+            return View(layerSource);
+        }
+
+        // POST: Layer/Delete/1
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirm(int id)
+        {
+            var sourceToDelete = await _context.LayerSource.FirstOrDefaultAsync(a => a.Id == id);
+
+            try
+            {
+                _context.LayerSource.Remove(sourceToDelete);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+            catch (DbUpdateException ex)
+            {
+                _logger.LogError(ex, "Layer source delete failed");
+                ModelState.AddModelError("", "Unable to save changes. " +
+                    "Try again, and if the problem persists, " +
+                    "contact your system administrator.");
+            }
+
+            return View(sourceToDelete);
+        }
+
+        private void RebuildViewModel(ref Data.Models.ViewModels.Management.LayerSourceEditModel model, Data.Models.LayerSource layerSource)
+        {
+            var attributions = _context.Attribution.OrderBy(t => t.Name).ToList();
+            var layerSourceTypes = _context.LayerSourceType.OrderBy(t => t.Name).ToList();
+
+            model.AvailableAttributions = new SelectList(attributions, "Id", "Name", layerSource.AttributionId);
+            model.AvailableLayerSourceTypes = new SelectList(layerSourceTypes, "Id", "Name", layerSource.LayerSourceTypeId);
+        }
+
+    }
+}

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementVersionController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementVersionController.cs
@@ -24,11 +24,11 @@ namespace GIFrameworkMaps.Web.Controllers.Management
          * however, write and update are done directly on the context based on the advice here
          * https://learn.microsoft.com/en-us/aspnet/mvc/overview/getting-started/getting-started-with-ef-using-mvc/advanced-entity-framework-scenarios-for-an-mvc-web-application#create-an-abstraction-layer
          * */
-        private readonly ILogger<ManagementAttributionController> _logger;
+        private readonly ILogger<ManagementVersionController> _logger;
         private readonly IManagementRepository _repository;
         private readonly ApplicationDbContext _context;
         public ManagementVersionController(
-            ILogger<ManagementAttributionController> logger,
+            ILogger<ManagementVersionController> logger,
             IManagementRepository repository,
             ApplicationDbContext context
             )
@@ -45,7 +45,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             return View(attributions);
         }
 
-        // GET: Attribution/Create
+        // GET: Version/Create
         public IActionResult Create()
         {
             var version = new Data.Models.Version();
@@ -54,7 +54,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             return View(editModel);
         }
 
-        //POST: Attribution/Create
+        //POST: Version/Create
         [HttpPost, ActionName("Create")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> CreatePost(VersionEditModel editModel, 

--- a/GIFrameworkMaps.Web/Program.cs
+++ b/GIFrameworkMaps.Web/Program.cs
@@ -59,7 +59,10 @@ builder.Services.AddHttpClient();
 builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddDbContext<ApplicationDbContext>(
-    options => options.UseNpgsql("name=ConnectionStrings:GIFrameworkMaps", x => x.MigrationsHistoryTable("__EFMigrationsHistory", "giframeworkmaps")));
+    options => {
+        options.UseNpgsql("name=ConnectionStrings:GIFrameworkMaps", x => x.MigrationsHistoryTable("__EFMigrationsHistory", "giframeworkmaps"));
+        options.EnableSensitiveDataLogging(true);
+    });
 
 /*TODO Not sure about this line. Is this correct?
  Seems to be the only way to get AutoMapper set up in the Data Access project*/

--- a/GIFrameworkMaps.Web/Startup.cs
+++ b/GIFrameworkMaps.Web/Startup.cs
@@ -136,6 +136,11 @@ namespace GIFrameworkMaps.Web
                    pattern: "Management/System/WebLayerServiceDefinition/{action=Index}/{id?}",
                    defaults: new { controller = "WebLayerServiceDefinition", action = "Index" });
 
+                endpoints.MapControllerRoute(
+                   name: "ManagementInterface-Layer",
+                   pattern: "Management/Layer/{action=Index}/{id?}",
+                   defaults: new { controller = "ManagementLayer", action = "Index" });
+
                 endpoints.MapControllerRoute("General_Map_Redirect", "Map", new { controller = "Map", action = "RedirectToGeneral" });
                 
                 endpoints.MapControllerRoute(

--- a/GIFrameworkMaps.Web/Startup.cs
+++ b/GIFrameworkMaps.Web/Startup.cs
@@ -41,6 +41,7 @@ namespace GIFrameworkMaps.Web
             IWebHostEnvironment env, 
             IHttpForwarder forwarder)
         {
+
             app.UseForwardedHeaders();
             if (env.IsDevelopment())
             {
@@ -145,6 +146,11 @@ namespace GIFrameworkMaps.Web
                    name: "ManagementInterface-LayerSource",
                    pattern: "Management/LayerSource/{action=Index}/{id?}",
                    defaults: new { controller = "ManagementLayerSource", action = "Index" });
+
+                endpoints.MapControllerRoute(
+                   name: "ManagementInterface-LayerCategory",
+                   pattern: "Management/LayerCategory/{action=Index}/{id?}",
+                   defaults: new { controller = "ManagementLayerCategory", action = "Index" });
 
                 endpoints.MapControllerRoute("General_Map_Redirect", "Map", new { controller = "Map", action = "RedirectToGeneral" });
                 

--- a/GIFrameworkMaps.Web/Startup.cs
+++ b/GIFrameworkMaps.Web/Startup.cs
@@ -141,6 +141,11 @@ namespace GIFrameworkMaps.Web
                    pattern: "Management/Layer/{action=Index}/{id?}",
                    defaults: new { controller = "ManagementLayer", action = "Index" });
 
+                endpoints.MapControllerRoute(
+                   name: "ManagementInterface-LayerSource",
+                   pattern: "Management/LayerSource/{action=Index}/{id?}",
+                   defaults: new { controller = "ManagementLayerSource", action = "Index" });
+
                 endpoints.MapControllerRoute("General_Map_Redirect", "Map", new { controller = "Map", action = "RedirectToGeneral" });
                 
                 endpoints.MapControllerRoute(

--- a/GIFrameworkMaps.Web/Views/Management/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/Management/Index.cshtml
@@ -1,5 +1,4 @@
-﻿@model List<GIFrameworkMaps.Data.Models.Version>
-@using Microsoft.Extensions.Configuration;
+﻿@using Microsoft.Extensions.Configuration;
 @inject IConfiguration configuration;
 @{
     string appName = configuration.GetValue<string>("GIFrameworkMaps:appName");
@@ -24,7 +23,7 @@
         <div class="col">
             <div class="card link-card h-100">
                 <div class="card-body">
-                    <a href="#" class="stretched-link">
+                    <a asp-action="Index" asp-controller="ManagementLayer" class="stretched-link">
                         <h4 class="card-title"><i class="bi bi-geo"></i> Layers</h4>
                         <p class="card-text">Manage layers consumed by @appName</p>
                     </a>

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/Create.cshtml
@@ -1,0 +1,36 @@
+﻿@model List<GIFrameworkMaps.Data.Models.LayerSource>
+@{
+    ViewData["Title"] = "Create layer";
+}
+
+<h1>@ViewData["Title"]</h1>
+<p class="lead">Choose a layer source to create a layer from</p>
+
+
+@if (Model != null)
+{
+    <table class="table table-bordered table-striped mt-2">
+        <thead>
+            <tr>
+                <th>ID</th><th>Name</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (GIFrameworkMaps.Data.Models.LayerSource layer in Model.OrderBy(a => a.Name))
+        {
+            <tr>
+                <td>@layer.Id</td>
+                <td>@Html.ActionLink(layer.Name, "CreateFromSource", new { id = layer.Id })</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+else
+{
+    <div class="alert alert-warning">No layer sources have been created yet</div>
+}
+
+
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
@@ -7,7 +7,7 @@
 
 <div class="row mt-2">
     <div class="col-md-8 col-lg-6">
-        <form asp-action="Create">
+        <form asp-action="CreateFromSource">
             <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
             <input type="hidden" asp-for="Layer.Id" />
             <input type="hidden" asp-for="Layer.LayerSourceId"/>

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
@@ -1,0 +1,129 @@
+﻿@model GIFrameworkMaps.Data.Models.ViewModels.Management.LayerEditModel
+@{
+    ViewData["Title"] = $"Create new layer";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<div class="row mt-2">
+    <div class="col-md-8 col-lg-6">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+            <input type="hidden" asp-for="Layer.Id" />
+            <input type="hidden" asp-for="Layer.LayerSourceId"/>
+            <div class="mb-3">
+                <label asp-for="Layer.Name" class="control-label"></label>
+                <input asp-for="Layer.Name" class="form-control" />
+                <span asp-validation-for="Layer.Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Layer.MinZoom" class="control-label"></label>
+                <input asp-for="Layer.MinZoom" class="form-control" />
+                <span asp-validation-for="Layer.MinZoom" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Layer.MaxZoom" class="control-label"></label>
+                <input asp-for="Layer.MaxZoom" class="form-control" />
+                <span asp-validation-for="Layer.MaxZoom" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Layer.ZIndex" class="control-label"></label>
+                <input asp-for="Layer.ZIndex" class="form-control" />
+                <span asp-validation-for="Layer.ZIndex" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Layer.InfoListTitleTemplate" class="control-label"></label>
+                <input asp-for="Layer.InfoListTitleTemplate" class="form-control" />
+                <span asp-validation-for="Layer.InfoListTitleTemplate" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Layer.InfoTemplate" class="control-label"></label>
+                <textarea asp-for="Layer.InfoTemplate" class="form-control" rows="5"></textarea>
+                <span asp-validation-for="Layer.InfoTemplate" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input asp-for="Layer.Queryable" class="form-check-input" />
+                <label asp-for="Layer.Queryable" class="form-check-label"></label>
+                <span asp-validation-for="Layer.Queryable" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input asp-for="Layer.Filterable" class="form-check-input" />
+                <label asp-for="Layer.Filterable" class="form-check-label"></label>
+                <span asp-validation-for="Layer.Filterable" class="text-danger"></span>
+            </div>
+
+
+            <!--Collapse-->
+
+            <a href="#advancedSettings" class="btn btn-outline-secondary my-3" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="advancedSettings">Advanced settings</a>
+
+            <div class="collapse border-start border-bottom border-5 ps-3 mb-3" id="advancedSettings">
+
+                <div class="mb-3">
+                    <label asp-for="Layer.BoundId" class="control-label"></label>
+                    <select asp-for="Layer.BoundId" asp-items="Model.AvailableBounds" class="form-select">
+                        <option value="">Not bounded</option>
+                    </select>
+                    <span class="form-text">Restricts map rendering and querying outside of these bounds. </span>
+                    <span asp-validation-for="Layer.BoundId" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Layer.DefaultOpacity" class="control-label"></label>
+                    <input asp-for="Layer.DefaultOpacity" type="range" class="form-range" min="0" max="100" />
+                    <span asp-validation-for="Layer.DefaultOpacity" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Layer.DefaultSaturation" class="control-label"></label>
+                    <input asp-for="Layer.DefaultSaturation" type="range" class="form-range" min="0" max="100" />
+                    <span asp-validation-for="Layer.DefaultSaturation" class="text-danger"></span>
+                </div>
+
+
+                <div class="mb-3">
+                    <input asp-for="Layer.DefaultFilterEditable" class="form-check-input" />
+                    <label asp-for="Layer.DefaultFilterEditable" class="form-check-label"></label>
+                    <p class="form-text">Whether any default filters applied to the layer source are editable by end users. </p>
+
+                    <span asp-validation-for="Layer.DefaultFilterEditable" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <input asp-for="Layer.ProxyMapRequests" class="form-check-input" />
+                    <label asp-for="Layer.ProxyMapRequests" class="form-check-label"></label>
+                    <span asp-validation-for="Layer.ProxyMapRequests" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <input asp-for="Layer.ProxyMetaRequests" class="form-check-input" />
+                    <label asp-for="Layer.ProxyMetaRequests" class="form-check-label"></label>
+                    <span asp-validation-for="Layer.ProxyMetaRequests" class="text-danger"></span>
+                </div>
+
+            </div>
+
+            <div class="mb-3">
+                <input type="submit" value="Create" class="btn btn-primary btn-lg" />
+                <a asp-action="List" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+    <div class="col-md-4 col-lg-6">
+        <h2>Source details</h2>
+        <table class="table table-sm table-striped">
+            <tbody>
+                <tr><th>ID</th><td>@Model.Layer.LayerSource.Id</td></tr>
+                <tr><th>Name</th><td>@Model.Layer.LayerSource.Name</td></tr>
+                <tr><th>Description</th><td>@Model.Layer.LayerSource.Description</td></tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/Delete.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/Delete.cshtml
@@ -1,0 +1,28 @@
+﻿@model GIFrameworkMaps.Data.Models.Layer
+@{
+    ViewData["Title"] = $"Delete layer '{Model.Name}'";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row mt-2">
+    <h2>Are you sure you want to delete this layer?</h2>
+    <p class="lead">This action cannot be undone.</p>
+    
+
+    <form asp-action="Delete">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+        <input type="hidden" asp-for="Id" />
+        <div class="mb-3">
+            <input type="submit" value="Delete" class="btn btn-danger" />
+        </div>
+    </form>
+
+</div>
+
+<div>
+    <a asp-action="List">Cancel</a>
+</div>
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
@@ -1,0 +1,135 @@
+﻿@model GIFrameworkMaps.Data.Models.ViewModels.Management.LayerEditModel
+@{
+    ViewData["Title"] = $"Edit layer '{Model.Layer.Name}'";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row mt-2 mb-2">
+    <div class="col-md-8 col-lg-6">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+            <input type="hidden" asp-for="Layer.Id" />
+            <div class="mb-3">
+                <label asp-for="Layer.Name" class="control-label"></label>
+                <input asp-for="Layer.Name" class="form-control" />
+                <span asp-validation-for="Layer.Name" class="text-danger"></span>
+            </div>
+            
+            <div class="mb-3">
+                <label asp-for="Layer.MinZoom" class="control-label"></label>
+                <input asp-for="Layer.MinZoom" class="form-control" />
+                <span asp-validation-for="Layer.MinZoom" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Layer.MaxZoom" class="control-label"></label>
+                <input asp-for="Layer.MaxZoom" class="form-control" />
+                <span asp-validation-for="Layer.MaxZoom" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Layer.ZIndex" class="control-label"></label>
+                <input asp-for="Layer.ZIndex" class="form-control" />
+                <span asp-validation-for="Layer.ZIndex" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Layer.InfoListTitleTemplate" class="control-label"></label>
+                <input asp-for="Layer.InfoListTitleTemplate" class="form-control" />
+                <span asp-validation-for="Layer.InfoListTitleTemplate" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Layer.InfoTemplate" class="control-label"></label>
+                <textarea asp-for="Layer.InfoTemplate" class="form-control" rows="5"></textarea>
+                <span asp-validation-for="Layer.InfoTemplate" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input asp-for="Layer.Queryable" class="form-check-input" />
+                <label asp-for="Layer.Queryable" class="form-check-label"></label>
+                <span asp-validation-for="Layer.Queryable" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input asp-for="Layer.Filterable" class="form-check-input" />
+                <label asp-for="Layer.Filterable" class="form-check-label"></label>
+                <span asp-validation-for="Layer.Filterable" class="text-danger"></span>
+            </div>
+
+
+            <!--Collapse-->
+
+            <a href="#advancedSettings" class="btn btn-outline-secondary my-3" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="advancedSettings">Advanced settings</a>
+
+            <div class="collapse border-start border-bottom border-5 ps-3 mb-3" id="advancedSettings">
+
+                <div class="mb-3">
+                    <label asp-for="Layer.BoundId" class="control-label"></label>
+                    <select asp-for="Layer.BoundId" asp-items="Model.AvailableBounds" class="form-select">
+                        <option value="">Not bounded</option>
+                    </select>
+                    <span class="form-text">Restricts map rendering and querying outside of these bounds. </span>
+                    <span asp-validation-for="Layer.BoundId" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Layer.DefaultOpacity" class="control-label"></label>
+                    <input asp-for="Layer.DefaultOpacity" type="range" class="form-range" min="0" max="100" />
+                    <span asp-validation-for="Layer.DefaultOpacity" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Layer.DefaultSaturation" class="control-label"></label>
+                    <input asp-for="Layer.DefaultSaturation" type="range" class="form-range" min="0" max="100"/>
+                    <span asp-validation-for="Layer.DefaultSaturation" class="text-danger"></span>
+                </div>
+
+
+                <div class="mb-3">
+                    <input asp-for="Layer.DefaultFilterEditable" class="form-check-input" />
+                    <label asp-for="Layer.DefaultFilterEditable" class="form-check-label"></label>
+                    <p class="form-text">Whether any default filters applied to the layer source are editable by end users. </p>
+
+                    <span asp-validation-for="Layer.DefaultFilterEditable" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <input asp-for="Layer.ProxyMapRequests" class="form-check-input" />
+                    <label asp-for="Layer.ProxyMapRequests" class="form-check-label"></label>
+                    <span asp-validation-for="Layer.ProxyMapRequests" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <input asp-for="Layer.ProxyMetaRequests" class="form-check-input" />
+                    <label asp-for="Layer.ProxyMetaRequests" class="form-check-label"></label>
+                    <span asp-validation-for="Layer.ProxyMetaRequests" class="text-danger"></span>
+                </div>
+
+            </div>
+
+            <div class="mb-3">
+                <input type="submit" value="Save" class="btn btn-primary btn-lg" />
+                <a asp-action="List" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+        
+    </div>
+    <div class="col-md-4 col-lg-6">
+        <h2>Source details</h2>
+        <table class="table table-sm table-striped">
+            <tbody>
+                <tr><th>ID</th><td>@Model.Layer.LayerSource.Id</td></tr>
+                <tr><th>Name</th><td>@Model.Layer.LayerSource.Name</td></tr>
+                <tr><th>Description</th><td>@Model.Layer.LayerSource.Description</td></tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+<a asp-action="Delete" asp-route-id="@Model.Layer.Id" class="btn btn-danger">Delete</a>
+
+
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/Index.cshtml
@@ -15,7 +15,7 @@
         <div class="col">
             <div class="card link-card h-100">
                 <div class="card-body">
-                    <a href="#" class="stretched-link">
+                    <a asp-action="Index" asp-controller="ManagementLayerSource" class="stretched-link">
                         <h4 class="card-title"><i class="bi bi-database-fill"></i> Layer Sources</h4>
                     </a>
                     <p class="card-text">Manage the sources of your layers</p>

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/Index.cshtml
@@ -1,0 +1,46 @@
+﻿@using Microsoft.Extensions.Configuration;
+@inject IConfiguration configuration;
+@{
+    string appName = configuration.GetValue<string>("GIFrameworkMaps:appName");
+    ViewData["Title"] = "Layers";
+}
+
+<partial name="ManagementPartials/BackToManagementHome" />
+
+<h1>@ViewData["Title"]</h1>
+<p class="lead">Manage the layers consumed by @appName</p>
+
+<div class="container">
+    <div class="row row-cols-1 row-cols-md-3 g-4">
+        <div class="col">
+            <div class="card link-card h-100">
+                <div class="card-body">
+                    <a href="#" class="stretched-link">
+                        <h4 class="card-title"><i class="bi bi-database-fill"></i> Layer Sources</h4>
+                    </a>
+                    <p class="card-text">Manage the sources of your layers</p>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card link-card h-100">
+                <div class="card-body">
+                    <a asp-action="List" asp-controller="ManagementLayer" class="stretched-link">
+                        <h4 class="card-title"><i class="bi bi-geo"></i> Layer Details</h4>
+                    </a>
+                    <p class="card-text">Manage how your layers work in @appName</p>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card link-card h-100">
+                <div class="card-body">
+                    <a href="#" class="stretched-link">
+                        <h4 class="card-title"><i class="bi bi-folder-fill"></i> Layer Categories</h4>
+                    </a>
+                    <p class="card-text">Manage the categories that your layers are organised into</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/Index.cshtml
@@ -35,7 +35,7 @@
         <div class="col">
             <div class="card link-card h-100">
                 <div class="card-body">
-                    <a href="#" class="stretched-link">
+                    <a asp-action="Index" asp-controller="ManagementLayerCategory" class="stretched-link">
                         <h4 class="card-title"><i class="bi bi-folder-fill"></i> Layer Categories</h4>
                     </a>
                     <p class="card-text">Manage the categories that your layers are organised into</p>

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/List.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/List.cshtml
@@ -1,0 +1,39 @@
+﻿@model List<GIFrameworkMaps.Data.Models.Layer>
+@{
+    ViewData["Title"] = "Layers";
+}
+
+<partial name="ManagementPartials/BackToManagementLayers" />
+
+<h1>@ViewData["Title"]</h1>
+<p class="lead">Create, edit and delete layers</p>
+
+<a href="@Url.Action("Create")" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Add new layer</a>
+
+@if (Model != null)
+{
+    <table class="table table-bordered table-striped mt-2">
+        <thead>
+            <tr>
+                <th>ID</th><th>Name</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (GIFrameworkMaps.Data.Models.Layer layer in Model.OrderBy(a => a.Name))
+        {
+            <tr>
+                <td>@layer.Id</td>
+                <td>@Html.ActionLink(layer.Name, "Edit", new { id = layer.Id })</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+else
+{
+    <div class="alert alert-warning">No layers have been created yet</div>
+}
+
+
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Create.cshtml
@@ -1,0 +1,64 @@
+﻿@model GIFrameworkMaps.Data.Models.ViewModels.Management.CategoryEditModel
+@{
+    ViewData["Title"] = $"Create new layer category";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<a asp-action="Index">Cancel</a>
+
+<form asp-action="Create">
+    <div class="row mt-4">
+        <div class="col-md-6">
+
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+            <div class="mb-3">
+                <label asp-for="Category.Name" class="control-label"></label>
+                <input asp-for="Category.Name" class="form-control" />
+                <span asp-validation-for="Category.Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Category.Description" class="control-label"></label>
+                <textarea asp-for="Category.Description" class="form-control"></textarea>
+                <span asp-validation-for="Category.Description" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Category.Order" class="control-label"></label>
+                <input asp-for="Category.Order" class="form-control" />
+                <span asp-validation-for="Category.Order" class="text-danger"></span>
+            </div>
+
+
+            <div class="mb-3">
+                <label asp-for="Category.ParentCategoryId" class="control-label"></label>
+                <select asp-for="Category.ParentCategoryId" asp-items="Model.AvailableParentCategories" class="form-select">
+                    <option value="">None</option>
+                </select>
+                <span asp-validation-for="Category.ParentCategoryId" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input type="submit" value="Create" class="btn btn-lg btn-primary" />
+                <a asp-action="Index" class="btn btn-link">Cancel</a>
+            </div>
+
+        </div>
+        <div class="col-md-6">
+            <div class="card mb-2">
+                <div class="card-header">
+                    Layers
+                </div>
+                <div class="card-body">
+                    <partial name="ManagementPartials/CategoryLayerList" model="Model" view-data="ViewData" />
+                </div>
+            </div>
+        </div>
+    </div>
+</form>
+
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Delete.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Delete.cshtml
@@ -1,0 +1,27 @@
+﻿@model GIFrameworkMaps.Data.Models.Version
+@{
+    ViewData["Title"] = $"Delete version '{Model.Name}'";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row mt-2">
+    <h2>Are you sure you want to delete this version?</h2>
+    <p class="lead">This action cannot be undone.</p>
+    <p>It may be safer to just disable the version, or redirect it elsewhere.</p>
+    <form asp-action="Delete">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+        <input type="hidden" asp-for="Id" />
+        <div class="mb-3">
+            <input type="submit" value="Delete" class="btn btn-danger" />
+        </div>
+    </form>
+
+</div>
+
+<div>
+    <a asp-action="Index">Cancel</a>
+</div>
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Edit.cshtml
@@ -1,0 +1,67 @@
+﻿@model GIFrameworkMaps.Data.Models.ViewModels.Management.CategoryEditModel
+@{
+    ViewData["Title"] = $"Edit category '{Model.Category.Name}'";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<a asp-action="Index">Cancel</a>
+
+<form asp-action="Edit">
+    <div class="row mt-4 mb-2">
+        <div class="col-md-6">
+
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+            <div class="mb-3">
+                <label asp-for="Category.Name" class="control-label"></label>
+                <input asp-for="Category.Name" class="form-control" />
+                <span asp-validation-for="Category.Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Category.Description" class="control-label"></label>
+                <textarea asp-for="Category.Description" class="form-control"></textarea>
+                <span asp-validation-for="Category.Description" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Category.Order" class="control-label"></label>
+                <input asp-for="Category.Order" class="form-control" />
+                <span asp-validation-for="Category.Order" class="text-danger"></span>
+            </div>
+
+
+            <div class="mb-3">
+                <label asp-for="Category.ParentCategoryId" class="control-label"></label>
+                <select asp-for="Category.ParentCategoryId" asp-items="Model.AvailableParentCategories" class="form-select">
+                    <option value="">None</option>
+                </select>
+                <span asp-validation-for="Category.ParentCategoryId" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input type="submit" value="Save" class="btn btn-lg btn-primary" />
+                <a asp-action="Index" class="btn btn-link">Cancel</a>
+            </div>
+            <a asp-action="Delete" asp-route-id="@Model.Category.Id" class="btn btn-danger">Delete</a>
+
+        </div>
+        <div class="col-md-6">
+            <div class="card mb-2">
+                <div class="card-header">
+                    Layers
+                </div>
+                <div class="card-body">
+                    <partial name="ManagementPartials/CategoryLayerList" model="Model" view-data="ViewData" />
+                </div>
+            </div>
+        </div>
+    </div>
+
+</form>
+
+
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Index.cshtml
@@ -1,0 +1,41 @@
+﻿@model List<GIFrameworkMaps.Data.Models.Category>
+@{
+    ViewData["Title"] = "Layer Categories";
+}
+
+<partial name="ManagementPartials/BackToManagementLayers" />
+
+<h1>@ViewData["Title"]</h1>
+<p class="lead">Create, edit and delete layer categories</p>
+
+<a href="@Url.Action("Create")" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Create new category</a>
+
+@if (Model != null)
+{
+    <table class="table table-bordered table-striped mt-2">
+        <thead>
+            <tr>
+                <th>ID</th><th>Name</th><th>No. Layers</th><th>Parent category</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (GIFrameworkMaps.Data.Models.Category category in Model.OrderBy(a => a.Name))
+            {
+                <tr>
+                    <td>@category.Id</td>
+                    <td>@Html.ActionLink(category.Name, "Edit", new { id = category.Id })</td>
+                    <td>@category.Layers.Count</td>
+                    <td>@(category.ParentCategory == null ? "Not a child" : Html.ActionLink(category.ParentCategory.Name, "Edit", new { id = category.ParentCategory.Id }))</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+else
+{
+    <div class="alert alert-warning">No categories have been created yet</div>
+}
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Index.cshtml
@@ -25,7 +25,7 @@
                     <td>@category.Id</td>
                     <td>@Html.ActionLink(category.Name, "Edit", new { id = category.Id })</td>
                     <td>@category.Layers.Count</td>
-                    <td>@(category.ParentCategory == null ? "Not a child" : Html.ActionLink(category.ParentCategory.Name, "Edit", new { id = category.ParentCategory.Id }))</td>
+                    <td>@(category.ParentCategory == null ? "" : Html.ActionLink(category.ParentCategory.Name, "Edit", new { id = category.ParentCategory.Id }))</td>
                 </tr>
             }
         </tbody>

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/Create.cshtml
@@ -33,6 +33,11 @@
                 <span asp-validation-for="LayerSource.AttributionId" class="text-danger"></span>
             </div>
 
+            <div class="mb-3 form-check">
+                <input id="AddOption" name="AddOption" value="true" checked class="form-check-input" type="checkbox" />
+                <label for="AddOption" class="form-check-label">Create layer source option on save</label>
+            </div>
+
             <div class="mb-3">
                 <input type="submit" value="Save" class="btn btn-primary btn-lg" />
                 <a asp-action="Index" class="btn btn-link">Cancel</a>
@@ -40,7 +45,10 @@
         </form>
 
     </div>
-
+    <div class="col-md-4 col-lg-6">
+        <h2>Layer Source Options</h2>
+        <div class="alert alert-info">Options can be added after saving the basic details</div>
+    </div>
 </div>
 
 

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/Create.cshtml
@@ -1,0 +1,49 @@
+﻿@model GIFrameworkMaps.Data.Models.ViewModels.Management.LayerSourceEditModel
+@{
+    ViewData["Title"] = "Create layer source";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<div class="row mt-2 mb-2">
+    <div class="col-md-8 col-lg-6">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+            <div class="mb-3">
+                <label asp-for="LayerSource.Name" class="control-label"></label>
+                <input asp-for="LayerSource.Name" class="form-control" />
+                <span asp-validation-for="LayerSource.Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="LayerSource.Description" class="control-label"></label>
+                <textarea asp-for="LayerSource.Description" class="form-control"></textarea>
+                <span asp-validation-for="LayerSource.Description" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="LayerSource.LayerSourceTypeId" class="control-label"></label>
+                <select asp-for="LayerSource.LayerSourceTypeId" asp-items="Model.AvailableLayerSourceTypes" class="form-select"></select>
+                <span asp-validation-for="LayerSource.LayerSourceTypeId" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="LayerSource.AttributionId" class="control-label"></label>
+                <select asp-for="LayerSource.AttributionId" asp-items="Model.AvailableAttributions" class="form-select"></select>
+                <span asp-validation-for="LayerSource.AttributionId" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input type="submit" value="Save" class="btn btn-primary btn-lg" />
+                <a asp-action="Index" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+
+    </div>
+
+</div>
+
+
+
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/CreateOption.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/CreateOption.cshtml
@@ -1,0 +1,45 @@
+﻿@model GIFrameworkMaps.Data.Models.ViewModels.Management.LayerSourceOptionEditModel
+@{
+    ViewData["Title"] = "Create layer source option";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<div class="row mt-2 mb-2">
+    <div class="col-md-8 col-lg-6">
+        <form asp-action="CreateOption">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+
+            <input type="hidden" asp-for="LayerSourceOption.LayerSourceId" />
+
+            <div class="mb-3">
+                <label asp-for="LayerSourceOption.Name" class="control-label"></label>
+                <input asp-for="LayerSourceOption.Name" class="form-control" />
+                <span asp-validation-for="LayerSourceOption.Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="LayerSourceOption.Value" class="control-label"></label>
+                <textarea asp-for="LayerSourceOption.Value" class="form-control" rows="5"></textarea>
+                <span asp-validation-for="LayerSourceOption.Value" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3 form-check">
+                <input id="AddAnother" name="AddAnother" value="true" class="form-check-input" type="checkbox" />
+                <label for="AddAnother" class="form-check-label">Add another option on save</label>
+            </div>
+
+            <div class="mb-3">
+                <input type="submit" value="Save" class="btn btn-primary btn-lg" />
+                <a asp-action="Edit" asp-route-id="@Model.LayerSourceOption.LayerSourceId" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+
+    </div>
+
+</div>
+
+
+
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/Delete.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/Delete.cshtml
@@ -1,0 +1,28 @@
+﻿@model GIFrameworkMaps.Data.Models.LayerSource
+@{
+    ViewData["Title"] = $"Delete layer source '{Model.Name}'";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row mt-2">
+    <h2>Are you sure you want to delete this layer source?</h2>
+    <p class="lead">This action cannot be undone.</p>
+    
+
+    <form asp-action="Delete">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+        <input type="hidden" asp-for="Id" />
+        <div class="mb-3">
+            <input type="submit" value="Delete" class="btn btn-danger" />
+        </div>
+    </form>
+
+</div>
+
+<div>
+    <a asp-action="List">Cancel</a>
+</div>
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/DeleteOption.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/DeleteOption.cshtml
@@ -1,0 +1,29 @@
+﻿@model GIFrameworkMaps.Data.Models.ViewModels.Management.LayerSourceOptionEditModel
+@{
+    ViewData["Title"] = $"Delete layer source option";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row mt-2">
+    <h2>Are you sure you want to delete this layer source option?</h2>
+    <p class="lead">This action cannot be undone.</p>
+    
+    <p>Deleting option '@Model.LayerSourceOption.Name' from source '@Model.LayerSource.Name'</p>
+
+    <form asp-action="DeleteOption">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+        <input type="hidden" asp-for="LayerSourceOption.Id" />
+        <div class="mb-3">
+            <input type="submit" value="Delete" class="btn btn-danger" />
+        </div>
+    </form>
+
+</div>
+
+<div>
+    <a asp-action="Edit" asp-route-id="@Model.LayerSourceOption.LayerSourceId">Cancel</a>
+</div>
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/Edit.cshtml
@@ -43,14 +43,19 @@
     <div class="col-md-4 col-lg-6">
         <h2>Layer Source Options</h2>
         <div class="table-responsive">
-        <table class="table table-sm table-striped">
-            @foreach(var opt in Model.LayerSource.LayerSourceOptions)
-            {
-                    <tr><td><a href="#"><span class="bi bi-pencil"></span></a></td><th>@opt.Name</th><td>@opt.Value</td></tr>
-            }
+            <table class="table table-sm table-striped">
+                @foreach(var opt in Model.LayerSource.LayerSourceOptions)
+                {
+                        <tr>
+                            <td><a asp-action="EditOption" asp-route-id="@opt.Id"><span class="bi bi-pencil"></span></a></td>
+                            <th>@opt.Name</th>
+                            <td style="white-space:pre-line"><code>@opt.Value</code></td></tr>
+                }
             
-        </table>
+            </table>
         </div>
+        <a href="@Url.Action("CreateOption",new {id = Model.LayerSource.Id})" class="btn btn-outline-secondary">Add option</a>
+
     </div>
     
 </div>

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/Edit.cshtml
@@ -1,0 +1,63 @@
+﻿@model GIFrameworkMaps.Data.Models.ViewModels.Management.LayerSourceEditModel
+@{
+    ViewData["Title"] = $"Edit layer source '{Model.LayerSource.Name}'";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row mt-2 mb-2">
+    <div class="col-md-8 col-lg-6">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+            <input type="hidden" asp-for="LayerSource.Id" />
+            <div class="mb-3">
+                <label asp-for="LayerSource.Name" class="control-label"></label>
+                <input asp-for="LayerSource.Name" class="form-control" />
+                <span asp-validation-for="LayerSource.Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="LayerSource.Description" class="control-label"></label>
+                <textarea asp-for="LayerSource.Description" class="form-control"></textarea>
+                <span asp-validation-for="LayerSource.Description" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="LayerSource.LayerSourceTypeId" class="control-label"></label>
+                <select asp-for="LayerSource.LayerSourceTypeId" asp-items="Model.AvailableLayerSourceTypes" class="form-select"></select>
+                <span asp-validation-for="LayerSource.LayerSourceTypeId" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="LayerSource.AttributionId" class="control-label"></label>
+                <select asp-for="LayerSource.AttributionId" asp-items="Model.AvailableAttributions" class="form-select"></select>
+                <span asp-validation-for="LayerSource.AttributionId" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input type="submit" value="Save" class="btn btn-primary btn-lg" />
+                <a asp-action="Index" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+        
+    </div>
+    <div class="col-md-4 col-lg-6">
+        <h2>Layer Source Options</h2>
+        <div class="table-responsive">
+        <table class="table table-sm table-striped">
+            @foreach(var opt in Model.LayerSource.LayerSourceOptions)
+            {
+                    <tr><td><a href="#"><span class="bi bi-pencil"></span></a></td><th>@opt.Name</th><td>@opt.Value</td></tr>
+            }
+            
+        </table>
+        </div>
+    </div>
+    
+</div>
+<a asp-action="Delete" asp-route-id="@Model.LayerSource.Id" class="btn btn-danger">Delete</a>
+
+
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/EditOption.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/EditOption.cshtml
@@ -1,0 +1,43 @@
+﻿@model GIFrameworkMaps.Data.Models.ViewModels.Management.LayerSourceOptionEditModel
+@{
+    ViewData["Title"] = "Edit layer source option";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<div class="row mt-2 mb-2">
+    <div class="col-md-8 col-lg-6">
+        <form asp-action="EditOption">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+
+            <input type="hidden" asp-for="LayerSourceOption.LayerSourceId" />
+
+            <div class="mb-3">
+                <label asp-for="LayerSourceOption.Name" class="control-label"></label>
+                <input asp-for="LayerSourceOption.Name" class="form-control" />
+                <span asp-validation-for="LayerSourceOption.Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="LayerSourceOption.Value" class="control-label"></label>
+                <textarea asp-for="LayerSourceOption.Value" class="form-control" rows="5"></textarea>
+                <span asp-validation-for="LayerSourceOption.Value" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input type="submit" value="Save" class="btn btn-primary btn-lg" />
+                <a asp-action="Edit" asp-route-id="@Model.LayerSourceOption.LayerSourceId" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+
+    </div>
+
+</div>
+
+<a asp-action="Delete" asp-route-id="@Model.LayerSourceOption.Id" class="btn btn-danger">Delete</a>
+
+
+
+
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/EditOption.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/EditOption.cshtml
@@ -34,7 +34,7 @@
 
 </div>
 
-<a asp-action="Delete" asp-route-id="@Model.LayerSourceOption.Id" class="btn btn-danger">Delete</a>
+<a asp-action="DeleteOption" asp-route-id="@Model.LayerSourceOption.Id" class="btn btn-danger">Delete</a>
 
 
 

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/Index.cshtml
@@ -1,0 +1,37 @@
+﻿@model List<GIFrameworkMaps.Data.Models.LayerSource>
+@{
+    ViewData["Title"] = $"Manage layer sources";
+}
+
+<partial name="ManagementPartials/BackToManagementLayers" />
+
+<h1>@ViewData["Title"]</h1>
+
+<a href="@Url.Action("Create")" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Add new layer source</a>
+
+@if (Model != null)
+{
+    <table class="table table-bordered table-striped mt-2">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (GIFrameworkMaps.Data.Models.LayerSource layerSource in Model.OrderBy(a => a.Name))
+            {
+                <tr>
+                    <td>@layerSource.Id</td>
+                    <td>@Html.ActionLink(layerSource.Name, "Edit", new { id = layerSource.Id })</td>
+                    <td>@layerSource.Description.Substring(0,Math.Min(layerSource.Description.Length,100))@(layerSource.Description.Length > 100 ? "..." : "")</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+else
+{
+    <div class="alert alert-warning">No layer sources have been created yet</div>
+}

--- a/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/BackToManagementLayers.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/BackToManagementLayers.cshtml
@@ -1,0 +1,1 @@
+﻿<p><a href="@Url.Action("Index","ManagementLayer")"><i class="bi bi-arrow-left-circle"></i> Back to layers</a></p>

--- a/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/CategoryLayerList.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/CategoryLayerList.cshtml
@@ -1,0 +1,15 @@
+﻿@model GIFrameworkMaps.Data.Models.ViewModels.Management.CategoryEditModel
+
+@foreach (var layer in Model.AvailableLayers)
+{
+    bool isChecked = Model.SelectedLayers != null && Model.SelectedLayers.Where(b => b == layer.Id).Count() != 0;
+    <div class="form-check">
+        <input type="checkbox"
+            class="form-check-input"
+           name="SelectedLayers"
+            value="@layer.Id"
+            id="SelectedLayers__@layer.Id"
+        @(Html.Raw(isChecked ? "checked=\"checked\"" : "")) />
+        <label class="form-check-label" for="SelectedLayers__@layer.Id">@layer.Name</label>
+    </div>
+}

--- a/GIFrameworkMaps.Web/Views/Shared/_Layout.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/_Layout.cshtml
@@ -34,6 +34,12 @@
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Map" asp-action="Index">Map</a>
                         </li>
+                        @if (User.IsInRole("GIFWAdmin"))
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link" asp-controller="Management" asp-action="Index">Manage application</a>
+                            </li>
+                        }
                     </ul>
                     <partial name="_LoginPartial" />
                 </div>


### PR DESCRIPTION
This PR adds (very) basic layer management to the management interface.

You can add, edit and delete layer sources, layer source options, layers and layer categories. The interface is very basic and requires knowledge of how the application works. We will need a 'wizard' to help users through adding a layer and making use GetCapabilities from the mapping servers to fill in details automatically, but for now this is an OK alternative.