### PR TITLE
Add ability to turn on multiple search result pins

### DIFF
--- a/GIFrameworkMaps.Web/Views/Map/Partials/Modals/SearchConfiguratorModal.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/Modals/SearchConfiguratorModal.cshtml
@@ -19,7 +19,14 @@
                             <tr><td colspan="3">Getting search options...</td></tr>
                         </tbody>
                     </table>
-
+                    <div class="col-12 mb-2">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" value="" ${this.enableMultipleSearchResultsOnMap ? 'checked' : '' } id="enableMultipleSearchResults">
+                            <label class="form-check-label" for="enableMultipleSearchResults">
+                                Allow multiple search results on map at once
+                            </label>
+                        </div>
+                    </div>
                     <div class="col-12">
                         <button type="submit" name="UpdateAndSearch" class="btn btn-primary">Update and search</button>
                         <button type="button" name="UpdateOnly" class="btn btn-secondary">Update only</button>


### PR DESCRIPTION
This PR adds a configurable option to allow users to keep multiple search results on the page, rather than only ever showing one at a time. 

The option is in the search configuration section and is remembered with a local storage item.