### PR TITLE
Add CodeQL code quality actions

### DIFF
--- a/.github/codeql/codeql-ts-config.yml
+++ b/.github/codeql/codeql-ts-config.yml
@@ -1,0 +1,6 @@
+name : CodeQL TypeScript Configuration
+
+paths:
+  - GIFrameworkMaps.Web/Scripts
+paths-ignore:
+  - GIFrameworkMaps.Web/wwwroot

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp', 'javascript' ]
+        language: [ 'csharp' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
@@ -66,9 +66,24 @@ jobs:
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    - run: |
-         echo "Run, Build Application using script"
-         dotnet build
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: npm install
+      run: npm install
+      working-directory: 'GIFrameworkMaps.Web'
+    - name: Install webpack
+      run: npm i -g webpack webpack-cli
+      working-directory: 'GIFrameworkMaps.Web'
+    - name: webpack
+      run: webpack --config webpack.dev.js
+      working-directory: 'GIFrameworkMaps.Web'
+    - name: Build
+      run: dotnet build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,76 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '22 2 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp', 'javascript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #     echo "Run, Build Application using script"
+    #     ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,28 +32,18 @@ jobs:
       uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
+    - name: Initialize CodeQL (JS)
+      if: ${{ matrix.language == 'javascript' }}
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+        config-file: ./.github/codeql/codeql-ts-config.yml
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+    - name: Initialize CodeQL
+      if: ${{ matrix.language != 'javascript' }}
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
@@ -74,15 +64,9 @@ jobs:
     - name: Build
       run: dotnet build
 
-    - name: Perform CodeQL Analysis (JavaScript)
+    - name: Perform CodeQL Analysis
       if: ${{ matrix.language == 'javascript' }}
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:${{matrix.language}}"
-        config-file: ./.github/codeql/codeql-ts-config.yml
-        
-    - name: Perform CodeQL Analysis
-      if: ${{ matrix.language != 'javascript' }}
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp' ]
+        language: [ 'csharp', 'javascript' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,9 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
-  pull_request:
+  #pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    #branches: [ "main" ]
   schedule:
     - cron: '25 2 * * 1'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,6 @@ jobs:
       run: dotnet build
 
     - name: Perform CodeQL Analysis
-      if: ${{ matrix.language == 'javascript' }}
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,8 @@
 name: "CodeQL"
 
 on:
-  #temporarily disable push changes
-  #push:
-  #  branches: [ "main" ]
+  push:
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,19 +1,9 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
+  #temporarily disable push changes
+  #push:
+  #  branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
@@ -85,7 +75,15 @@ jobs:
     - name: Build
       run: dotnet build
 
+    - name: Perform CodeQL Analysis (JavaScript)
+      if: ${{ matrix.language == 'javascript' }}
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"
+        config-file: ./.github/codeql/codeql-ts-config.yml
+        
     - name: Perform CodeQL Analysis
+      if: ${{ matrix.language != 'javascript' }}
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
   schedule:
-    - cron: '22 2 * * 5'
+    - cron: '25 2 * * 1'
 
 jobs:
   analyze:
@@ -57,8 +57,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -66,9 +66,9 @@ jobs:
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+    - run: |
+         echo "Run, Build Application using script"
+         dotnet build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/GIFrameworkMaps.Web/Scripts/ContextMenu.ts
+++ b/GIFrameworkMaps.Web/Scripts/ContextMenu.ts
@@ -1,6 +1,6 @@
 ﻿import * as olProj from "ol/proj";
 import { GIFWMousePositionControl } from "../Scripts/MousePositionControl";
-import { Streetview } from "./streetview";
+import { Streetview } from "./Streetview";
 const ContextMenu = require("ol-contextmenu");
 
 export class GIFWContextMenu {

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -29,7 +29,7 @@ import proj4 from 'proj4';
 import { FeatureQuery } from "./FeatureQuery/FeatureQuery";
 import AnnotationStylePanel from "./Panels/AnnotationStylePanel";
 import { Search } from "./Search";
-import { Streetview } from "./streetview";
+import { Streetview } from "./Streetview";
 import { VersionViewModel } from "./Interfaces/VersionViewModel";
 import { WebLayerService } from "./WebLayerService";
 


### PR DESCRIPTION
## Summary
This PR adds the CodeQL code scanning GitHub action to scan the C# and TypeScript code for common security vulnerabilities and issues - https://github.com/github/codeql-action

## Notes 

- [Autobuild](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages#about-autobuild-for-codeql) would not work for the C# code, so it is manually built before the code scanning step
- To make sure CodeQL just reads the actual TypeScript source files, and not static and compiled JS, there is a config file that makes sure it only looks in `/Scripts` when parsing files
- Since this is built and runs on Ubuntu machines, the casing of 'streetview' had to be corrected otherwise the build failed
- This is set to run on a schedule at 02:25, only on Monday. It could be run on every PR into main, but it can take a while to run the analysis, so a regular job seemed more appropriate