### PR TITLE
Add GPS tracker control

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/FeatureQuery/FeatureQueryResultRenderer.ts
+++ b/GIFrameworkMaps.Web/Scripts/FeatureQuery/FeatureQueryResultRenderer.ts
@@ -91,9 +91,10 @@ export class FeatureQueryResultRenderer {
             }
             if (feature.get('gifw-popup-opts') !== undefined) {
                 popupOptions = (feature.get('gifw-popup-opts') as GIFWPopupOptions);
-
-                popupOptions.actions = [...popupOptions.actions.filter(a => a.fixed), ...popupActions]
-                /*popupOptions.actions.push(...popupActions);*/
+                if (popupOptions.actions) {
+                    popupOptions.actions = [...popupOptions.actions.filter(a => a.fixed), ...popupActions];
+                }
+                
             } else {
                 let content = this.getPopupContentFromFeature(feature, null, layer);
                 popupOptions = new GIFWPopupOptions(content, popupActions, [0, 0]);

--- a/GIFrameworkMaps.Web/Scripts/Geolocation.ts
+++ b/GIFrameworkMaps.Web/Scripts/Geolocation.ts
@@ -1,0 +1,142 @@
+import { GIFWMap } from "./Map";
+import { Control as olControl } from "ol/control";
+import Geolocation from "ol/Geolocation";
+import VectorSource from "ol/source/Vector";
+import Feature from "ol/Feature";
+import { LayerGroupType } from "./Interfaces/LayerGroupType";
+import VectorLayer from "ol/layer/Vector";
+import { Fill, Stroke, Style } from "ol/style";
+import CircleStyle from "ol/style/Circle";
+import { Util } from "./Util";
+import { Polygon, Point, LineString} from "ol/geom";
+
+export class GIFWGeolocation extends olControl {
+    gifwMapInstance: GIFWMap;
+    _geolocation: Geolocation;
+    _trackControlElement: HTMLElement;
+    _vectorSource: VectorSource;
+    _locationLayer: VectorLayer<any>;
+    _accuracyFeature: Feature<Polygon>;
+    _locationFeature: Feature<Point>;
+    _pathFeature: Feature<LineString>;
+    constructor(gifwMapInstance: GIFWMap) {
+
+        let geolocationControlElement = document.createElement('div');
+
+        super({
+            element: geolocationControlElement
+        })
+
+        this.gifwMapInstance = gifwMapInstance;
+        this.renderGeolocationControls();
+        this.addUIEvents();
+    }
+
+    public init() {
+        this._vectorSource = new VectorSource();
+
+        this._locationLayer = this.gifwMapInstance.addNativeLayerToMap(this._vectorSource, "Geolocation", (feature: Feature<any>) => {
+            return this.getStyleForGeolocationFeature(feature);
+        }, false, LayerGroupType.SystemNative, undefined, undefined, "__geolocation__");
+        this._geolocation = new Geolocation({
+            // enableHighAccuracy must be set to true to have the heading value.
+            trackingOptions: {
+                enableHighAccuracy: true,
+            },
+            projection: this.gifwMapInstance.olMap.getView().getProjection(),
+        });
+        // handle geolocation error.
+        this._geolocation.on('error', (error) => {
+            console.error(error);
+        });
+        this._geolocation.on('change:accuracyGeometry', () => {
+            console.log('change:accuracyGeometry');
+            if (!this._accuracyFeature) {
+                this._accuracyFeature = new Feature();
+                this._vectorSource.addFeature(this._accuracyFeature);
+            }
+            this._accuracyFeature.setGeometry(this._geolocation.getAccuracyGeometry());
+
+        });
+        this._geolocation.on('change:position', () => {
+            if (!this._locationFeature) {
+                this._locationFeature = new Feature();
+                this._vectorSource.addFeature(this._locationFeature);
+            }
+            this._locationFeature.setGeometry(new Point(this._geolocation.getPosition()))
+        });
+    }
+
+    private renderGeolocationControls() {
+
+        let trackButton = document.createElement('button');
+        trackButton.innerHTML = '<i class="bi bi-cursor"></i>';
+        trackButton.setAttribute('title', 'Track my location');
+        let trackElement = document.createElement('div');
+        trackElement.className = 'gifw-geolocation-control ol-control';
+        trackElement.appendChild(trackButton);
+        this._trackControlElement = trackElement;
+        this.element.appendChild(trackElement);
+    }
+
+    private addUIEvents() {
+        this._trackControlElement.addEventListener('click', e => {
+            if (this._trackControlElement.classList.contains('ol-control-active')) {
+                //deactivate
+                this._trackControlElement.classList.remove('ol-control-active');
+                this._trackControlElement.querySelector('i.bi').className = 'bi bi-cursor';
+                this.gifwMapInstance.resetInteractionsToDefault();
+                this._trackControlElement.querySelector('button').blur();
+                this._geolocation.setTracking(false);
+            } else {
+                //switch layer if it isn't on already
+                if (!this._locationLayer.getVisible()) {
+                    this._locationLayer.setVisible(true);
+                }
+                this._trackControlElement.classList.add('ol-control-active');
+                this._trackControlElement.querySelector('i.bi').className =  'bi bi-cursor-fill';
+                document.getElementById(this.gifwMapInstance.id).dispatchEvent(new Event('gifw-geolocation-start'));
+                this._geolocation.setTracking(true);
+            }
+
+        })
+
+        
+    }
+    private getStyleForGeolocationFeature(feature: Feature<any>) {
+        //const geometry = feature.getGeometry();
+        //const type = geometry.getType();
+        //switch (type) {
+        //    case "Polygon":
+        //    case "MultiPolygon":
+        //        break;
+        //    case "Point":
+        //    case "MultiPoint":
+        //        break;
+        //    case "LineString":
+        //    case "MultiLineString":
+        //        break;
+        //}
+        let rgbColor = Util.Color.hexToRgb(this.gifwMapInstance.config.theme.primaryColour);
+
+        return new Style({
+            fill: new Fill({
+                color: `rgba(${rgbColor.r}, ${rgbColor.g}, ${rgbColor.b}, 0.2)`
+            }),
+            stroke: new Stroke({
+                color: `rgb(${rgbColor.r},${rgbColor.g},${rgbColor.b})`,
+                width: 2,
+            }),
+            image: new CircleStyle({
+                radius: 5,
+                stroke: new Stroke({
+                    color: 'rgba(255, 255, 255, 1)',
+                    width: 2
+                }),
+                fill: new Fill({
+                    color: `rgba(${rgbColor.r}, ${rgbColor.g}, ${rgbColor.b}, 1)`
+                }),
+            }),
+        });
+    }
+}

--- a/GIFrameworkMaps.Web/Scripts/Geolocation.ts
+++ b/GIFrameworkMaps.Web/Scripts/Geolocation.ts
@@ -292,8 +292,8 @@ export class GIFWGeolocation extends olControl {
                 let length = Math.round(getLength(this._pathFeature.getGeometry()));
                 let lengthStr = length.toString();
                 let unit = "m"
-                if (length > 1000) {
-                    length = (length / 100);
+                if (length >= 1000) {
+                    length = (length / 1000);
                     lengthStr = length.toFixed(2);
                     unit = "km";
                 }
@@ -347,7 +347,7 @@ export class GIFWGeolocation extends olControl {
                     this._simModeIndex = 0;
                 }
                 this.olGeolocation.dispatchEvent('change:position')
-            }, 2000);
+            }, 750);
         }
 
     }

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -12,6 +12,7 @@ import { Layer } from "./Interfaces/Layer";
 import { GIFWPopupOverlay } from "./Popups/PopupOverlay";
 import { GIFWLayerGroup } from "./LayerGroup/GIFWLayerGroup";
 import { GIFWContextMenu } from "./ContextMenu";
+import { GIFWGeolocation } from "./Geolocation";
 import Geometry from "ol/geom/Geometry";
 import { v4 as uuidv4 } from 'uuid';
 import { LayerGroupType } from "./Interfaces/LayerGroupType";
@@ -84,9 +85,11 @@ export class GIFWMap {
         let annotateControl = new Annotate(this);
         // add info click
         let infoControl = new FeatureQuery(this)
+        //add geolocation
+        let geolocationControl = new GIFWGeolocation(this);
 
-        this.customControls.push(mousePosition, contextMenu, measureControl, annotateControl, infoControl);
-        let controls: olControl.Control[] = [attribution, scaleline, mousePosition.control, contextMenu.control, measureControl, rotateControl, annotateControl, infoControl];
+        this.customControls.push(mousePosition, contextMenu, measureControl, annotateControl, infoControl, geolocationControl);
+        let controls: olControl.Control[] = [attribution, scaleline, mousePosition.control, contextMenu.control, measureControl, rotateControl, annotateControl, infoControl, geolocationControl];
         //TODO - MESSY!
         var sidebarCollection = new gifwSidebarCollection.SidebarCollection(this.sidebars);
         sidebarCollection.initSidebarCollection();
@@ -311,6 +314,7 @@ export class GIFWMap {
 
         measureControl.init();
         infoControl.init();
+        geolocationControl.init();
 
         let search = new Search('#search-container', this, `${document.location.protocol}//${this.config.appRoot}search/options/${this.config.id}`, `${document.location.protocol}//${this.config.appRoot}search`);
 

--- a/GIFrameworkMaps.Web/Scripts/Panels/LayersPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/LayersPanel.ts
@@ -624,15 +624,7 @@ export class LayersPanel implements SidebarPanel {
                 }
             }
 
-            let visibilityNotification = new Util.Alert(1, Util.AlertSeverity.Info, 'Layer visibility', notificationText, '#gifw-layer-range-toast');
-            /*NOTE: This is the only way I could get the progress bar to reset consistently on show of toast*/
-            /*Main issue was when toast is hidden automatically due to 'atomic' setting, no events are fired*/
-            (document.querySelector('#gifw-layer-range-toast .progress-bar') as HTMLElement).style.transition = 'none';
-            (document.querySelector('#gifw-layer-range-toast .progress-bar') as HTMLElement).style.width = '0%';
-            visibilityNotification.show();
-            (document.querySelector('#gifw-layer-range-toast .progress-bar') as HTMLElement).style.transition = 'width 4s linear';
-            (document.querySelector('#gifw-layer-range-toast .progress-bar') as HTMLElement).style.width = '100%';
-            
+            Util.Alert.showTimedToast('Layer out of range', notificationText, Util.AlertSeverity.Warning);            
             
         }
     }

--- a/GIFrameworkMaps.Web/Scripts/UserSettings.ts
+++ b/GIFrameworkMaps.Web/Scripts/UserSettings.ts
@@ -8,12 +8,24 @@ export class UserSettings {
      * @param versionId Optional GIFramework Maps Version ID number used to specifiy which version the key applies to
      *                  Will be appended on to the end of the key param e.g. `keyName-2` for versionId = 2
      *                  Useful when a setting can be different between versions
+     * @param acceptableValues Optional array of acceptable values. If the items value is not in the acceptableValues array, 
+     *                         it will be removed from localStorage and null will be returned
+     *                         Must be an array of case sensitive strings (even if you convert to boolean/ints afterwards) 
      * @returns {string} The item as a string, or null if not found or localStorage unavailable
      * */
-    static getItem(key: string, versionId: number = 0): string {
+    static getItem(key: string, versionId: number = 0, acceptableValues: string[] = []): string {
         if (Util.Browser.storageAvailable('localStorage')) {
             if (versionId !== 0) {
                 key = `${key}-${versionId}`;
+            }
+            if (acceptableValues.length !== 0) {
+                const item = localStorage.getItem(key);
+                if (item !== null && acceptableValues.indexOf(item) !== -1) {
+                    return item;
+                } else {
+                    localStorage.removeItem(key);
+                    return null;
+                }
             }
             return localStorage.getItem(key)
         }

--- a/GIFrameworkMaps.Web/Scripts/Util.ts
+++ b/GIFrameworkMaps.Web/Scripts/Util.ts
@@ -595,6 +595,22 @@ export namespace Util {
             )
             alert.show();
         }
+
+        static showTimedToast(title: string, content: string, severity: AlertSeverity = AlertSeverity.Info) {
+            let alert = new Util.Alert(
+                Util.AlertType.Toast,
+                severity,
+                title,
+                content,
+                "#gifw-timed-toast"
+            );
+            (document.querySelector('#gifw-timed-toast .progress-bar') as HTMLElement).style.transition = 'none';
+            (document.querySelector('#gifw-timed-toast .progress-bar') as HTMLElement).style.width = '0%';
+            alert.show();
+            (document.querySelector('#gifw-timed-toast .progress-bar') as HTMLElement).style.transition = 'width 4s linear';
+            (document.querySelector('#gifw-timed-toast .progress-bar') as HTMLElement).style.width = '100%';
+
+        }
     }
 
     export class Mapping {

--- a/GIFrameworkMaps.Web/Views/Map/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Index.cshtml
@@ -97,6 +97,8 @@
 
     <partial name="Partials/Modals/AlternateStyleModal" />
 
+    <partial name="Partials/Modals/GeolocationOptionsModal" />
+
     <partial name="Partials/Modals/WelcomeMessageModal" model="Model.WelcomeMessage" />
 }
 @section Scripts{

--- a/GIFrameworkMaps.Web/Views/Map/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Index.cshtml
@@ -99,6 +99,8 @@
 
     <partial name="Partials/Modals/GeolocationOptionsModal" />
 
+    <partial name="Partials/Modals/GeolocationExportModal" />
+
     <partial name="Partials/Modals/WelcomeMessageModal" model="Model.WelcomeMessage" />
 }
 @section Scripts{

--- a/GIFrameworkMaps.Web/Views/Map/Partials/ErrorNotifications.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/ErrorNotifications.cshtml
@@ -41,7 +41,7 @@
 </div>
 
 <div class="toast-container position-absolute p-3 bottom-0 start-0">
-    <div class="toast hide" role="alert" aria-live="assertive" aria-atomic="true" data-bs-autohide="true" data-bs-delay="4000" id="gifw-layer-range-toast">
+    <div class="toast hide" role="alert" aria-live="assertive" aria-atomic="true" data-bs-autohide="true" data-bs-delay="4000" id="gifw-timed-toast">
         <div class="d-flex">
             <div class="toast-body">
                 <span></span>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/Modals/GeolocationExportModal.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/Modals/GeolocationExportModal.cshtml
@@ -6,7 +6,7 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <p>Total track length: <span id="geolocation-export-track-length"></span></p>
+                <p>Total track length (approximate): <span id="geolocation-export-track-length"></span></p>
                 <div class="col-12 mb-2">
                     <p>Download a GPX file of your track</p>
                     <button id="geolocation-export-track-btn" class="btn btn-primary btn-lg">Download GPX</button>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/Modals/GeolocationExportModal.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/Modals/GeolocationExportModal.cshtml
@@ -1,0 +1,21 @@
+﻿<div class="modal" tabindex="-1" id="geolocation-export-modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Export track</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p>Total track length: <span id="geolocation-export-track-length"></span></p>
+                <div class="col-12 mb-2">
+                    <p>Download a GPX file of your track</p>
+                    <button id="geolocation-export-track-btn" class="btn btn-primary btn-lg">Download GPX</button>
+                </div>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/Modals/GeolocationOptionsModal.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/Modals/GeolocationOptionsModal.cshtml
@@ -1,0 +1,38 @@
+﻿<div class="modal" tabindex="-1" id="geolocation-options-modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Tracking options</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="col-12 mb-2">
+
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" value="" checked id="geolocationScreenLock">
+                        <label class="form-check-label" for="geolocationScreenLock">
+                            Keep screen awake
+                        </label>
+                        <div id="geolocationScreenLockHelpText" class="form-text">
+                            Applies to mobile devices only. Prevents the screen from going to sleep.
+                        </div>
+                    </div>
+
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" value="" checked id="geolocationDrawTrack">
+                        <label class="form-check-label" for="geolocationDrawTrack">
+                            Draw track
+                        </label>
+                        <div id="geolocationDrawTrackHelpText" class="form-text">
+                            Draws a line on the map showing the path you have travelled which you can save as a GPX file when finished.
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Start tracking</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/Modals/GeolocationOptionsModal.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/Modals/GeolocationOptionsModal.cshtml
@@ -9,7 +9,7 @@
                 <div class="col-12 mb-2">
 
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="" checked id="geolocationScreenLock">
+                        <input class="form-check-input" type="checkbox" value="" id="geolocationScreenLock">
                         <label class="form-check-label" for="geolocationScreenLock">
                             Keep screen awake
                         </label>
@@ -19,12 +19,28 @@
                     </div>
 
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" value="" checked id="geolocationDrawTrack">
+                        <input class="form-check-input" type="checkbox" value="" id="geolocationDrawTrack">
                         <label class="form-check-label" for="geolocationDrawTrack">
                             Draw track
                         </label>
                         <div id="geolocationDrawTrackHelpText" class="form-text">
                             Draws a line on the map showing the path you have travelled which you can save as a GPX file when finished.
+                        </div>
+                    </div>
+
+                    <div>
+                        <label for="geolocationAccuracyThreshold" class="form-label">Location accuracy threshold</label>
+                        <div class="row">
+                            <div class="col-sm-8 col-md-6">
+                                <select class="form-select form-select-sm" id="geolocationAccuracyThreshold">
+                                    <option value="10">High (10m)</option>
+                                    <option value="20">Medium (20m)</option>
+                                    <option value="50">Low (50m)</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div id="geolocationAccuracyThresholdHelpText" class="form-text">
+                            Accuracy threshold in metres. If the accuracy of your location is worse than this, we'll keep trying until we have a better signal.
                         </div>
                     </div>
                 </div>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/Modals/GeolocationOptionsModal.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/Modals/GeolocationOptionsModal.cshtml
@@ -43,6 +43,7 @@
                             Accuracy threshold in metres. If the accuracy of your location is worse than this, we'll keep trying until we have a better signal.
                         </div>
                     </div>
+                    <div class="alert small p-2 alert-info mt-2 mb-0"><span class="bi bi-info-circle"></span> Click the geolocation button again to stop tracking</div>
                 </div>
 
             </div>

--- a/GIFrameworkMaps.Web/package-lock.json
+++ b/GIFrameworkMaps.Web/package-lock.json
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@types/bootstrap": "5.2.6",
+        "@types/dom-screen-wake-lock": "1.0.1",
         "@types/luxon": "3.1.0",
         "@types/nunjucks": "3.2.1",
         "@types/proj4": "2.5.2",
@@ -517,6 +518,12 @@
       "dependencies": {
         "@popperjs/core": "^2.9.2"
       }
+    },
+    "node_modules/@types/dom-screen-wake-lock": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dom-screen-wake-lock/-/dom-screen-wake-lock-1.0.1.tgz",
+      "integrity": "sha512-WJQas3OFGcC8AeMzaa7FwzzbNNfanuV2R12kQYNp4BkUMghsRz5JxJ5RgVhJifhw7t0s6LvRSWZArmKbMDZ+5g==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.4.5",
@@ -3142,6 +3149,12 @@
       "requires": {
         "@popperjs/core": "^2.9.2"
       }
+    },
+    "@types/dom-screen-wake-lock": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dom-screen-wake-lock/-/dom-screen-wake-lock-1.0.1.tgz",
+      "integrity": "sha512-WJQas3OFGcC8AeMzaa7FwzzbNNfanuV2R12kQYNp4BkUMghsRz5JxJ5RgVhJifhw7t0s6LvRSWZArmKbMDZ+5g==",
+      "dev": true
     },
     "@types/eslint": {
       "version": "8.4.5",

--- a/GIFrameworkMaps.Web/package.json
+++ b/GIFrameworkMaps.Web/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/bootstrap": "5.2.6",
+    "@types/dom-screen-wake-lock": "1.0.1",
     "@types/luxon": "3.1.0",
     "@types/nunjucks": "3.2.1",
     "@types/proj4": "2.5.2",

--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -434,14 +434,13 @@
 }
 /*Specialist reverse timeout bar for the layer out of range messages*/
 /*Tranistion timing should match bs toast delay timing on the element itself*/
-#gifw-layer-range-toast .progress-bar {
+#gifw-timed-toast .progress-bar {
     background-color: #e9ecef;
     transition: width 4s linear;
 }
-#gifw-layer-range-toast .progress {
-    
+#gifw-timed-toast .progress {
     background-color: var(--primary-color);
-    height:2px;
+    height: 2px;
 }
 /*dragover effects*/
 .giframeworkMap.dragover::after {

--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -108,12 +108,18 @@
     left: .5rem;
     top: 20.5em;
 }
+.giframeworkMap .gifw-geolocation-control.gifw-geolocation-recentre-control {
+    left: 2.75rem;
+}
 
 .giframeworkMap .ol-control button {
     background-color: var(--primary-color-transparent-50);
-    color:white;
-    width:2rem;
-    height:2rem;
+    color: white;
+    width: 2rem;
+    height: 2rem;
+}
+.giframeworkMap .gifw-geolocation-recentre-control button {
+    width: 100%;
 }
 .giframeworkMap .ol-control button:disabled {
     filter:grayscale(1);

--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -103,6 +103,12 @@
     left: 7.25rem;
 }
 
+.giframeworkMap .gifw-geolocation-control {
+    right: unset;
+    left: .5rem;
+    top: 20.5em;
+}
+
 .giframeworkMap .ol-control button {
     background-color: var(--primary-color-transparent-50);
     color:white;


### PR DESCRIPTION
## Summary

This PR adds a simple GPS tracker control, that will allow users to track their location on the map and optionally create a downloadable route of their track. This slightly differs from the old implementation which provided two options, one to do a one off 'where am I' style check, and one to track the user. I felt the one off check wasn't that useful and wasn't worth the extra UI overhead required. This also vaguely aligns to how Google Maps does it, they just start tracking, they don't bother with the one off check.

## Details

A new control has been added to the left side controls.
![Geolocation control](https://user-images.githubusercontent.com/28754239/234339964-70d6eb63-6be3-4f76-a6c5-0a6d908e4c37.png)
Upon clicking the control, users will be asked how they want the tracking to work. There are a few options which are all remembered using the UserSettings class.
![Geolocation options modal](https://user-images.githubusercontent.com/28754239/234343396-d24fd5d3-bf11-49cb-b2e4-cc0e8d45923a.png)
- Keep screen awake - This uses the [Screen Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API) to keep a users screen from locking when it isn't touched. This allows the map to stay on screen and log their track accurately. 
- Draw track - This continuously draws a track showing where the user has been. When the user finishes tracking, they will get the option to download it as GPX file (and will also get the option by clicking the track on the map)
- Location Accuracy Threshold - The threshold that must be met for the tracking to begin/register a new position. 

Once they hit Start tracking, the browser will request permission if required and start tracking. 
![Geolocation active example](https://user-images.githubusercontent.com/28754239/234344501-ae4a5ac2-cb0d-4ce7-8e02-8d2eaf2f3c45.png)
The map will zoom and follow the location automatically. If a user moves the map elsewhere a small button will appear to give them the option of recentring on their location.
Clicking the geolocation button again will stop the tracking session and (if they selected to draw a path) give the user the option to download the track.

## Other changes made related to this
- The UserSettings function `getItem` now has an optional array of `acceptedValues` that can be passed in. If item retrieved does not match something from the array, it will be deleted from storage, allowing it to self repair if it was corrupted or edited by users. 
- Fixed a small bug where popups with not actions would not render
- Added a generic 'timed toast' utility. This was previously used for the 'layer out of range' notifications, but was specific to that functionality. It has now been made generic and more reusable.

## A note on 'Simulation mode'
Testing geolocation in a development environment can be tricky. DevTools only allows you to override the lat/lon of a location, it sets the accuracy to 150m and you can't override the heading. To this end, there is a bunch of commented out code in this tool that allows you to fire up a simulation mode. The simulation mode simply overrides the OpenLayers `getPosition`, `getHeading` and `getAccuracy` functions with values from a set of values at the bottom of the file. This gives you a nice simulated walk around Borough gardens, with random heading and accuracy values. It's been commented out to make sure it gets removed by webpack for prod, but is available for development by simply uncommenting the various sections.

Feedback much appreciated, although I admit testing can be tricky without deploying to an environment you can access with your phone.