### PR TITLE
Fixes issue with themes without logos displaying a broken logo image

### DIFF
--- a/GIFrameworkMap.Data/Data/Models/Theme.cs
+++ b/GIFrameworkMap.Data/Data/Models/Theme.cs
@@ -20,7 +20,7 @@ namespace GIFrameworkMaps.Data.Models
 
         [RegularExpression("(https?:\\/\\/)([\\w\\-])+\\.{1}([a-zA-Z]{2,63})([\\/\\w-]*)*\\/?\\??([^#\\n\\r]*)?#?([^\\n\\r]*)")]
         [DisplayName("URL for your logo")]
-        public string LogoURL { get; set; }
+        public string? LogoURL { get; set; }
 
         [RegularExpression("(https?:\\/\\/)([\\w\\-])+\\.{1}([a-zA-Z]{2,63})([\\/\\w-]*)*\\/?\\??([^#\\n\\r]*)?#?([^\\n\\r]*)")]
         [DisplayName("URL for your custom favicon (this is optional)")]

--- a/GIFrameworkMaps.Web/Views/Shared/_MapLayout.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/_MapLayout.cshtml
@@ -38,7 +38,12 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark border-bottom box-shadow">
             <div class="container-fluid gx-0">
-                <span class="navbar-brand"><img src="@ViewData["LogoURL"]" class="d-inline-block align-top" height="30" alt="Logo" />@ViewData["VersionName"]</span>
+                <span class="navbar-brand">
+                    @if (!String.IsNullOrEmpty(Convert.ToString(ViewData["LogoURL"])))
+                    {
+                        <img src="@ViewData["LogoURL"]" class="d-inline-block align-top" height="30" alt="Logo" />
+                    }
+                    @ViewData["VersionName"]</span>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Themes without a logo URL will now display correctly with only the app name showing, instead of showing a broken logo image.

Before fix:
![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/8bafcbec-b0e8-4021-8415-8ee8546d2721)

After fix:
![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/f2b94bc8-d7f9-47d5-a07f-8d16fa49e4fc)


Closes #62