### PR TITLE
Welcome messages can now be set to be pop-up windows or fullscreen.

### DIFF
--- a/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
@@ -2,6 +2,7 @@
 using GIFrameworkMaps.Data.Models.Authorization;
 using GIFrameworkMaps.Data.Models.Tour;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Graph.Beta.Models;
 
 namespace GIFrameworkMaps.Data
 {
@@ -50,6 +51,7 @@ namespace GIFrameworkMaps.Data
             modelBuilder.Entity<VersionPrintConfiguration>().HasKey(v => new { v.PrintConfigurationId, v.VersionId });
             modelBuilder.Entity<ApplicationUserRole>().HasKey(u => new { u.UserId, u.ApplicationRoleId });
             modelBuilder.Entity<WelcomeMessage>().Property(w => w.Frequency).HasDefaultValue(-1);
+            modelBuilder.Entity<WelcomeMessage>().Property(w => w.ModalSize).HasDefaultValue("modal-lg");
             modelBuilder.Entity<WelcomeMessage>().Property(w => w.DismissOnButtonOnly).HasDefaultValue(false);
             modelBuilder.Entity<TourDetails>().Property(w => w.Frequency).HasDefaultValue(-1);
             modelBuilder.Entity<WebLayerServiceDefinition>().Property(w => w.Type).HasConversion<string>();

--- a/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
@@ -2,7 +2,6 @@
 using GIFrameworkMaps.Data.Models.Authorization;
 using GIFrameworkMaps.Data.Models.Tour;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Graph.Beta.Models;
 
 namespace GIFrameworkMaps.Data
 {

--- a/GIFrameworkMap.Data/Data/Models/WelcomeMessage.cs
+++ b/GIFrameworkMap.Data/Data/Models/WelcomeMessage.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.CompilerServices;
+using Microsoft.Graph.Beta.Models;
 
 namespace GIFrameworkMaps.Data.Models
 {
@@ -26,6 +27,10 @@ namespace GIFrameworkMaps.Data.Models
 
         [DisplayName("Update date")]
         public DateTimeOffset UpdateDate { get; set; }
+
+        [DefaultValue("modal-lg")]
+        [DisplayName("How large do you want your welcome message to be?")]
+        public string ModalSize { get; set; }
 
         [DisplayName("Dismiss button text")]
         public string DismissText{ get; set; }

--- a/GIFrameworkMap.Data/Data/Models/WelcomeMessage.cs
+++ b/GIFrameworkMap.Data/Data/Models/WelcomeMessage.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.CompilerServices;
-using Microsoft.Graph.Beta.Models;
 
 namespace GIFrameworkMaps.Data.Models
 {

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230526104345_AddModalSizeToWelcomeMessages.Designer.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230526104345_AddModalSizeToWelcomeMessages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GIFrameworkMaps.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230526104345_AddModalSizeToWelcomeMessages")]
+    partial class AddModalSizeToWelcomeMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230526104345_AddModalSizeToWelcomeMessages.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230526104345_AddModalSizeToWelcomeMessages.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddModalSizeToWelcomeMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ModalSize",
+                schema: "giframeworkmaps",
+                table: "WelcomeMessages",
+                type: "text",
+                nullable: true,
+                defaultValue: "modal-lg");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ModalSize",
+                schema: "giframeworkmaps",
+                table: "WelcomeMessages");
+        }
+    }
+}

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementWelcomeMessageController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementWelcomeMessageController.cs
@@ -95,6 +95,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 a => a.Content, 
                 a => a.Frequency, 
                 a => a.UpdateDate, 
+                a => a.ModalSize,
                 a => a.DismissOnButtonOnly, 
                 a => a.DismissText))
             {

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/WelcomeMessage.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/WelcomeMessage.ts
@@ -4,5 +4,6 @@ export interface WelcomeMessage {
     name: string;
     content: string;
     frequency: number;
+    modalSize: number;
     updateDate: Date;
 }

--- a/GIFrameworkMaps.Web/Views/ManagementWelcomeMessage/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWelcomeMessage/Create.cshtml
@@ -41,6 +41,14 @@
                 <span asp-validation-for="Frequency" class="text-danger"></span>
             </div>
             <div class="mb-3">
+                <label asp-for="ModalSize" class="control-label"></label>
+                <select asp-for="ModalSize" class="form-select">
+                    <option value="modal-lg">Pop-up window</option>
+                    <option value="modal-fullscreen">Full screen</option>
+                </select>
+                <span asp-validation-for="ModalSize" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
                 <label asp-for="UpdateDate" class="control-label"></label>
                 <input asp-for="UpdateDate" type="datetime-local" class="form-control" />
                 <div class="form-text">A date when this message has been updated enough to re-show it to the user.</div>

--- a/GIFrameworkMaps.Web/Views/ManagementWelcomeMessage/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWelcomeMessage/Edit.cshtml
@@ -41,6 +41,14 @@
                 <span asp-validation-for="Frequency" class="text-danger"></span>
             </div>
             <div class="mb-3">
+                <label asp-for="ModalSize" class="control-label"></label>
+                <select asp-for="ModalSize" class="form-select">
+                    <option value="modal-lg">Pop-up window</option>
+                    <option value="modal-fullscreen">Full screen</option>
+                </select>
+                <span asp-validation-for="ModalSize" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
                 <label asp-for="UpdateDate" class="control-label"></label>
                 <input asp-for="UpdateDate" type="datetime-local" class="form-control" />
                 <div class="form-text">A date when this message has been updated enough to re-show it to the user.</div>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/Modals/WelcomeMessageModal.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/Modals/WelcomeMessageModal.cshtml
@@ -7,7 +7,7 @@
              id="welcome-modal"
              data-bs-backdrop="@(Model.DismissOnButtonOnly ?  "static" : "true")"
              data-bs-keyboard="@(Model.DismissOnButtonOnly ?  "false" : "true")">
-            <div class="modal-dialog modal-lg">
+            <div class="modal-dialog @Model.ModalSize">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title">@Model.Title</h5>

--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -604,6 +604,23 @@
     background-color: var(--primary-color) !important;
     border-color: var(--primary-color) !important;
 }
+
+/*Welcome modal on mobile devices 576px and under*/
+@media (max-width: 576px) {
+    #welcome-modal .modal-dialog {
+        width: 100%;
+        max-width: none;
+        height: 100%;
+        margin: 0;
+    }
+
+    #welcome-modal .modal-content {
+        border-radius: 0;
+        height: 100%;
+    }
+}
+
+
 /*Helpers*/
 .giframeworkMap .text-pre-line {
     white-space: pre-line;


### PR DESCRIPTION
Welcome messages can now be set to be either a pop-up window or full-screen sized in the admin console. The default is to be a pop-up window.

![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/4aa71106-2933-4f5f-87d4-71e77485b25a)

A pop-up sized welcome message:
![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/15f06fe3-64b7-4bfb-a535-712bb1dade47)

A full-screen welcome message:
![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/a82ec24d-356e-460a-9caa-3b942525331d)

On mobile phones (devices smaller than 576px), the welcome message will display full-screen regardless. This is because it looks neater on a smaller screen.

Before the changes, the welcome message modal on mobile phones was a pop-up:
![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/d04e98f2-d735-4e3a-824b-deb262411557)

Full-screen modal on a mobile phone:
![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/0e70bd5f-4ee6-46e7-8685-cc84a227e8b9)


Closes #79