### PR TITLE
Logs using user-input values sanitised

### DIFF
--- a/GIFrameworkMap.Data/Data/CommonRepository.cs
+++ b/GIFrameworkMap.Data/Data/CommonRepository.cs
@@ -280,7 +280,9 @@ namespace GIFrameworkMaps.Data
             else
             {
                 //we couldn't get a unique short id in 100 tries
-                _logger.LogError("Could not generate a unique short id for url {url} after {maxIterations} tries", url, maxIterations);
+                _logger.LogError("Could not generate a unique short id for url {url} after {maxIterations} tries",
+                    //Sanitise user input to prevent log forging
+                    url.Replace(Environment.NewLine, ""), maxIterations);
                 return null;
             }
         }

--- a/GIFrameworkMaps.Web/Controllers/MapController.cs
+++ b/GIFrameworkMaps.Web/Controllers/MapController.cs
@@ -44,7 +44,11 @@ namespace GIFrameworkMaps.Web.Controllers
 
         public async Task<IActionResult> IndexAsync(string slug1, string slug2, string slug3)
         {
-            _logger.LogInformation("User requested version {slug1}/{slug2}/{slug3}",slug1,slug2,slug3);
+            _logger.LogInformation("User requested version {slug1}/{slug2}/{slug3}",
+                //Sanitise user input to prevent log forging
+                slug1.Replace(Environment.NewLine, ""),
+                slug2 != null ? slug2.Replace(Environment.NewLine, "") : null,
+                slug3 != null ? slug3.Replace(Environment.NewLine, "") : null);
             var version = _repository.GetVersionBySlug(slug1,slug2,slug3);
             if (version != null)
             {

--- a/GIFrameworkMaps.Web/Controllers/SearchController.cs
+++ b/GIFrameworkMaps.Web/Controllers/SearchController.cs
@@ -22,9 +22,13 @@ namespace GIFrameworkMaps.Web.Controllers
 
         public JsonResult Index([FromBody]SearchQuery searchQuery)
         {
-            _logger.LogInformation("User searched for {searchQuery}",searchQuery.Query);
+            _logger.LogInformation("User searched for {searchQuery}",
+                //Sanitise user input to prevent log forging
+                searchQuery.Query.Replace(Environment.NewLine, ""));
             var results = _repository.Search(searchQuery.Query, searchQuery.Searches);
-            _logger.LogInformation("{TotalResults} results returned for query {searchQuery}", results.TotalResults,searchQuery.Query);
+            _logger.LogInformation("{TotalResults} results returned for query {searchQuery}", results.TotalResults,
+                //Sanitise user input to prevent log forging
+                searchQuery.Query.Replace(Environment.NewLine, ""));
             return Json(results);
         }
 


### PR DESCRIPTION
Various log inputs using user-input values now sanitised to help prevent log forging.

This has been done by replacing any new lines or carriage returns with an empty space.
[More info on log forging here](https://codeql.github.com/codeql-query-help/csharp/cs-log-forging/)