### PR TITLE
Move toasts to top middle and remove app-height variable

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -302,10 +302,8 @@ export class GIFWMap {
         //add attribution size checker and app height variable
         window.addEventListener('resize', () => {
             this.checkAttributionSize(map, attribution);
-            this.setAppHeightVariable();
         });
         this.checkAttributionSize(map, attribution);
-        this.setAppHeightVariable();
 
         //add drag and drop
         this.addDragAndDropInteraction();
@@ -653,16 +651,6 @@ export class GIFWMap {
         let small = map.getSize()[0] < 600;
         attribution.setCollapsible(small);
         attribution.setCollapsed(small);
-    }
-
-    /**
-     * Sets the --app-height css variable to the current innerHeight of the Window
-     * @author Andreas Herd/StackOverflow https://stackoverflow.com/a/50683190/863487
-     * */
-    public setAppHeightVariable(): void {
-        const doc = document.documentElement
-        doc.style.setProperty('--app-height', `${window.innerHeight}px`);
-        this.olMap.updateSize();
     }
 
     /**

--- a/GIFrameworkMaps.Web/Views/Map/Partials/ErrorNotifications.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/ErrorNotifications.cshtml
@@ -28,7 +28,7 @@
     </div>
 </div>
 
-<div class="toast-container position-absolute p-3 bottom-0 start-0">
+<div class="toast-container position-absolute p-3 top-0 start-50 translate-middle-x mt-5">
     <div class="toast hide" role="alert" aria-live="assertive" aria-atomic="true" data-bs-autohide="false" id="gifw-error-toast">
         <div class="toast-header">
             <strong class="me-auto"><span>There was an problem</span></strong>
@@ -40,7 +40,7 @@
     </div>
 </div>
 
-<div class="toast-container position-absolute p-3 bottom-0 start-0">
+<div class="toast-container position-absolute p-3 top-0 start-50 translate-middle-x mt-5">
     <div class="toast hide" role="alert" aria-live="assertive" aria-atomic="true" data-bs-autohide="true" data-bs-delay="4000" id="gifw-timed-toast">
         <div class="d-flex">
             <div class="toast-body">

--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -1,9 +1,6 @@
-﻿:root{
-    --app-height: 100%;
-}
-.giframeworkMap {
+﻿.giframeworkMap {
     z-index: 1;
-    height: var(--app-height);
+    height: 100dvh;
     width: 100%;
     position: absolute;
     top: 0;
@@ -249,7 +246,7 @@
     right: 0;
     z-index: 100;
     top: 46px;
-    height: calc(var(--app-height) - 46px);
+    height: calc(100dvh - 46px);
 }
 
 /*Medium devices (tablets, 768px and up)*/
@@ -429,6 +426,7 @@
 /*NOTIFICATIONS*/
 .giframeworkMapContainer .toast-container {
     z-index: 1000;
+    max-width:75vw;
 }
 .giframeworkMapContainer .toast-container .toast-body {
     backdrop-filter: grayscale(1) blur(4px);


### PR DESCRIPTION
This PR moves the default position of toasts (for warnings and notifications) to the top middle, instead of the bottom right. 

The reason for this change is described in #38. These toasts would appear off screen on most mobile devices, due to difficulties in using absolutely positioned elements with the mobile UI. Multiple methods were attempted, including using [css env](https://developer.mozilla.org/en-US/docs/Web/CSS/env), which is supposed to provide information about space needed to get around browser UI, but this did not work. So the workaround is simply to put the toasts top middle (with some max size css to prevent them being too wide on mobile). 

Also took the opportunity to replace use of the `--app-height` variable (used to get round original issues with mobile browser UI) with css `dvh` (dynamic viewport height) units, which seem to work nicely. 