### PR TITLE
Bug - geometry searches not zooming to extents properly

### DIFF
--- a/GIFrameworkMap.Data/Data/Models/Search/SearchResult.cs
+++ b/GIFrameworkMap.Data/Data/Models/Search/SearchResult.cs
@@ -7,8 +7,8 @@ namespace GIFrameworkMaps.Data.Models.Search
     public class SearchResult
     {
         public string DisplayText { get; set; }
-        public decimal? X { get; set; }
-        public decimal? Y { get; set; }
+        public decimal X { get; set; }
+        public decimal Y { get; set; }
         public int? Zoom { get; set; }
         public decimal[] Bbox { get; set; }
         public decimal Ordering { get; set; }

--- a/GIFrameworkMap.Data/Data/Models/Search/SearchResult.cs
+++ b/GIFrameworkMap.Data/Data/Models/Search/SearchResult.cs
@@ -7,9 +7,9 @@ namespace GIFrameworkMaps.Data.Models.Search
     public class SearchResult
     {
         public string DisplayText { get; set; }
-        public decimal X { get; set; }
-        public decimal Y { get; set; }
-        public int Zoom { get; set; }
+        public decimal? X { get; set; }
+        public decimal? Y { get; set; }
+        public int? Zoom { get; set; }
         public decimal[] Bbox { get; set; }
         public decimal Ordering { get; set; }
         public int EPSG { get; set; }

--- a/GIFrameworkMap.Data/Data/SearchRepository.cs
+++ b/GIFrameworkMap.Data/Data/SearchRepository.cs
@@ -336,7 +336,7 @@ namespace GIFrameworkMaps.Data
                     DisplayText = title.ToString(),
                     EPSG = searchDefinition.EPSG,
                     Ordering = i,
-                    Zoom = searchDefinition.ZoomLevel.GetValueOrDefault()
+                    Zoom = searchDefinition.ZoomLevel
                 };
                 //check whether we've received an X/Y
                 if (JTokensExist(xCoords, yCoords))

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -854,6 +854,9 @@ export class GIFWMap {
 
     public fitMapToExtent(extent: Extent, maxZoom: number = 50, animationDuration: number = 1000): void {
         let curExtent = this.olMap.getView().calculateExtent();
+        if (maxZoom === null) {
+            maxZoom = 50;
+        }
         if (!Util.Browser.PrefersReducedMotion() && containsExtent(curExtent, extent)) {
             this.olMap.getView().fit(extent, { padding: this.getPaddingForMapCenter(), maxZoom: maxZoom, duration: animationDuration });
         } else {
@@ -890,8 +893,7 @@ export class GIFWMap {
         if (rightPanelPercentWidth > 50) {
             rightPadding = defaultPadding;
         }
-
-        return [defaultPadding, rightPadding, defaultPadding, leftPadding];
+        return [defaultPadding, rightPadding + defaultPadding, defaultPadding, leftPadding + defaultPadding];
     }
 
     /**


### PR DESCRIPTION
Fixes a bug where if using a geometry object to control where a search zooms to, the system will not zoom to it correctly if a zoom level is not defined.

Bonus bugfix to add in extra padding to the left and right of search objects, so that they don't extend right to the edges of the page.

Closes #142 