### PR TITLE
Allow login button to retain map parameters by utilising short links

### DIFF
--- a/GIFrameworkMaps.Web/Controllers/AccountController.cs
+++ b/GIFrameworkMaps.Web/Controllers/AccountController.cs
@@ -1,15 +1,71 @@
 ﻿using GIFrameworkMaps.Data;
+using GIFrameworkMaps.Data.Models;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NuGet.Protocol.Core.Types;
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using System.Web;
 
 namespace GIFrameworkMaps.Web.Controllers
 {
     [Authorize]
     public class AccountController : Controller
     {
+        private readonly ICommonRepository _repository;
+        private readonly ApplicationDbContext _context;
+
+
+        public AccountController(ICommonRepository repository, ApplicationDbContext context)
+        {
+            _repository = repository;
+            _context = context;
+        }
+
         public IActionResult Index()
         {
             return View();
+        }
+
+        [AllowAnonymous]
+        public async Task<IActionResult> SignInWithRedirect(string redirectUri)
+        {
+            StringWriter decodedStringWriter = new StringWriter();
+            string decodedString;
+            // Decode the encoded string.
+            HttpUtility.HtmlDecode(redirectUri, decodedStringWriter);
+            decodedString = decodedStringWriter.ToString();
+            //generate short link for redirectUri
+            if (Uri.IsWellFormedUriString(decodedString, UriKind.Absolute) && _repository.IsURLCurrentApplication(decodedString))
+            {
+                string shortId = await _repository.GenerateShortId(decodedString);
+                if (shortId == null)
+                {
+                    return RedirectToAction("SignIn", "Account", new { area = "MicrosoftIdentity", redirectUri = decodedString });
+                }
+
+                await _context.ShortLink.AddAsync(new ShortLink
+                {
+                    ShortId = shortId,
+                    FullUrl = decodedString
+                });
+                await _context.SaveChangesAsync();                
+                
+                return RedirectToAction("SignIn", "Account", new { area = "MicrosoftIdentity", redirectUri = $"/u/{shortId}" });
+            }
+            else
+            {
+                return RedirectToAction("SignIn", "Account", new { area = "MicrosoftIdentity" });
+
+            }
+
+
         }
     }
 }

--- a/GIFrameworkMaps.Web/Controllers/AccountController.cs
+++ b/GIFrameworkMaps.Web/Controllers/AccountController.cs
@@ -55,9 +55,14 @@ namespace GIFrameworkMaps.Web.Controllers
                     ShortId = shortId,
                     FullUrl = decodedString
                 });
-                await _context.SaveChangesAsync();                
-                
-                return RedirectToAction("SignIn", "Account", new { area = "MicrosoftIdentity", redirectUri = $"/u/{shortId}" });
+                await _context.SaveChangesAsync();
+
+                Uri shortLink = new Uri(Url.RouteUrl("UserShortLink", new { id = shortId }, Request.Scheme));
+
+                string relativeShortLink = shortLink.IsAbsoluteUri ? shortLink.PathAndQuery : shortLink.OriginalString;
+
+
+                return RedirectToAction("SignIn", "Account", new { area = "MicrosoftIdentity", redirectUri = relativeShortLink });
             }
             else
             {

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -349,6 +349,7 @@ export class GIFWMap {
 
         document.getElementById(this.id).addEventListener('gifw-update-permalink', () => {
             this.updatePermalinkInURL();
+            this.updatePermalinkInLinks();
         });
 
 
@@ -364,6 +365,16 @@ export class GIFWMap {
 
         window.history.replaceState(hashParams, '', permalink);
 
+    }
+
+    private updatePermalinkInLinks() {
+        let permalink = Util.Mapping.generatePermalinkForMap(this);
+        document.querySelectorAll('a[data-gifw-permalink-update-uri-param]').forEach(link => {
+            let paramToUpdate = (link as HTMLAnchorElement).dataset.gifwPermalinkUpdateUriParam;
+            const existingLink = new URL((link as HTMLAnchorElement).href);
+            existingLink.searchParams.set(paramToUpdate, permalink);
+            (link as HTMLAnchorElement).href = existingLink.toString();
+        })
     }
 
     /**

--- a/GIFrameworkMaps.Web/Views/Shared/_LoginPartial.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/_LoginPartial.cshtml
@@ -24,7 +24,8 @@
         {
             string redirectUri = $"{Context.Request.PathBase}{Context.Request.Path}";
             <li class="nav-item">
-            <a class="nav-link" id="login" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignIn" asp-route-redirectUri="@redirectUri" data-gifw-permalink-update-uri-param="redirectUri">Login/Register</a>
+            <a class="nav-link" id="login"  asp-controller="Account" asp-action="SignInWithRedirect" asp-route-redirectUri="@redirectUri" data-gifw-permalink-update-uri-param="redirectUri">Login/Register</a>
+            @*<a class="nav-link" id="login" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignIn" asp-route-redirectUri="/u/-olVNCuQ">Login/Register</a>*@
             </li>
         }
 }

--- a/GIFrameworkMaps.Web/Views/Shared/_LoginPartial.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/_LoginPartial.cshtml
@@ -22,9 +22,9 @@
         }
         else
         {
-            string redirectUrl = $"{Context.Request.PathBase}{Context.Request.Path}";
+            string redirectUri = $"{Context.Request.PathBase}{Context.Request.Path}";
             <li class="nav-item">
-                <a class="nav-link" id="login" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignIn" asp-route-redirectUri="@redirectUrl">Login/Register</a>
+            <a class="nav-link" id="login" asp-area="MicrosoftIdentity" asp-controller="Account" asp-action="SignIn" asp-route-redirectUri="@redirectUri" data-gifw-permalink-update-uri-param="redirectUri">Login/Register</a>
             </li>
         }
 }


### PR DESCRIPTION
This PR allows the login button to remember the permalink parameters, allowing users to login and have their map view be the same once they've authenticated.

## How it works

A new endpoint has been created on the `AccountController` called `SignInWithRedirect`, which takes a `redirectUri` parameter. The login link points at this endpoint. The `redirectUri` parameter in the link is constantly updated the same way the URL in the address bar is constantly updated as the map is moved and reconfigured. Other links can be added in the future which update the same way, by making use of the `data-gifw-permalink-update-uri-param` attribute on any anchor.

When a user clicks the link, the `SignInWithRedirect` action generates a short link, then redirects to the standard login URL with that short link as the `redirectUri`. 

## Alternatives that were not used
- Just adding the hash parameters to the `redirectUri` does not work as these cannot be used server side so are not carried through the authentication
- Switching to query string parameters instead of hash parameters would be too much work and would fundamentally change how the system works
- Making use of `state` is an option, but not used as this was simpler

## Limitations
This only works for the login button link. If you passed a link to someone that required authentication, the link would not be carried through as it takes a different route. This could be resolved using a page that jumps in the middle of the request and processes the hash parameters, or switching to using query string params. For this reason, the issue linked with this PR will be left open for future enhancements.

Partially resolves #144 