### PR TITLE
Add last visited date to shortlinks

### DIFF
--- a/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
@@ -1,4 +1,6 @@
-﻿using GIFrameworkMaps.Data.Models;
+﻿using System;
+using System.Linq;
+using GIFrameworkMaps.Data.Models;
 using GIFrameworkMaps.Data.Models.Authorization;
 using GIFrameworkMaps.Data.Models.Tour;
 using Microsoft.EntityFrameworkCore;

--- a/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using GIFrameworkMaps.Data.Models;
+﻿using GIFrameworkMaps.Data.Models;
 using GIFrameworkMaps.Data.Models.Authorization;
 using GIFrameworkMaps.Data.Models.Tour;
 using Microsoft.EntityFrameworkCore;

--- a/GIFrameworkMap.Data/Data/CommonRepository.cs
+++ b/GIFrameworkMap.Data/Data/CommonRepository.cs
@@ -11,10 +11,6 @@ using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using shortid;
-using Microsoft.AspNetCore.Mvc;
-using System.Reflection.Emit;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace GIFrameworkMaps.Data
 {

--- a/GIFrameworkMap.Data/Data/CommonRepository.cs
+++ b/GIFrameworkMap.Data/Data/CommonRepository.cs
@@ -11,6 +11,10 @@ using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using shortid;
+using Microsoft.AspNetCore.Mvc;
+using System.Reflection.Emit;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace GIFrameworkMaps.Data
 {
@@ -290,7 +294,7 @@ namespace GIFrameworkMaps.Data
         public async Task<string> GetFullUrlFromShortId(string shortId)
         {
             var shortLink = await _context.ShortLink.AsNoTracking().FirstOrDefaultAsync(s => s.ShortId == shortId);
-            if(shortLink == null)
+            if (shortLink == null)
             {
                 return null;
             }

--- a/GIFrameworkMap.Data/Data/Models/ShortLink.cs
+++ b/GIFrameworkMap.Data/Data/Models/ShortLink.cs
@@ -10,8 +10,12 @@ namespace GIFrameworkMaps.Data.Models
     public class ShortLink
     {
         public string ShortId { get; set; }
+
         public string FullUrl { get; set; }
+
         [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
         public DateTime Created { get; set; }
+
+        public DateTime? LastVisited { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230810103058_AddLastVisitedToShortLink.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230810103058_AddLastVisitedToShortLink.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddLastVisitedToShortLink : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastVisited",
+                schema: "giframeworkmaps",
+                table: "ShortLink",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastVisited",
+                schema: "giframeworkmaps",
+                table: "ShortLink");
+        }
+    }
+}

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/ApplicationDbContextModelSnapshot.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/ApplicationDbContextModelSnapshot.cs
@@ -151,7 +151,7 @@ namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasMaxLength(100)
+                        .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 
                     b.Property<string>("UserId")
@@ -510,6 +510,10 @@ namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 
                     b.Property<string>("FullUrl")
                         .HasColumnType("text");
+
+                    b.Property<DateTime?>("LastVisited")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("ShortId");
 

--- a/GIFrameworkMaps.Web/Controllers/MapController.cs
+++ b/GIFrameworkMaps.Web/Controllers/MapController.cs
@@ -8,6 +8,12 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Configuration;
 using GIFrameworkMaps.Data.Models;
 using GIFrameworkMaps.Data.Models.ViewModels.Management;
+using Microsoft.EntityFrameworkCore;
+using GIFrameworkMaps.Data.Migrations.ApplicationDb;
+using Microsoft.Graph.Beta.Models.TermStore;
+using System.Reflection.Emit;
+using System.Linq;
+using shortid;
 
 namespace GIFrameworkMaps.Web.Controllers
 {
@@ -19,19 +25,22 @@ namespace GIFrameworkMaps.Web.Controllers
         private readonly ICommonRepository _repository;
         private readonly IManagementRepository _adminRepository;
         private readonly IConfiguration _configuration;
+        private readonly ApplicationDbContext _context;
 
         public MapController(
             ILogger<MapController> logger, 
             IAuthorizationService authorization,
             ICommonRepository repository,
             IManagementRepository adminRepository,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            ApplicationDbContext context)
         {
             _logger = logger;
             _authorization = authorization;
             _repository = repository;
             _adminRepository = adminRepository;
             _configuration = configuration;
+            _context = context;
         }
         /// <summary>
         /// This route forces calls to the general /Map endpoint to redirect to the default slug route. Not pretty but does the job
@@ -115,6 +124,11 @@ namespace GIFrameworkMaps.Web.Controllers
             {
                 return View("ShortLinkNotFound");
             }
+
+            var shortLink = await _context.ShortLink.FirstOrDefaultAsync(s => s.ShortId == id);
+            shortLink.LastVisited = DateTime.UtcNow;
+            _context.SaveChanges();
+
             return Redirect(redirectUrl);
         }
     }

--- a/GIFrameworkMaps.Web/Controllers/MapController.cs
+++ b/GIFrameworkMaps.Web/Controllers/MapController.cs
@@ -6,14 +6,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Configuration;
-using GIFrameworkMaps.Data.Models;
-using GIFrameworkMaps.Data.Models.ViewModels.Management;
 using Microsoft.EntityFrameworkCore;
-using GIFrameworkMaps.Data.Migrations.ApplicationDb;
-using Microsoft.Graph.Beta.Models.TermStore;
-using System.Reflection.Emit;
-using System.Linq;
-using shortid;
 
 namespace GIFrameworkMaps.Web.Controllers
 {


### PR DESCRIPTION
A LastVisited column has been added to the ShortLink table. This will fill in with today's date every time a short link is used.

This will help us to manage short links in the future and make it easy to remove any old records that are no longer being used.

Closes #146