### PR TITLE
Added last visited date to short links

### DIFF
--- a/GIFrameworkMap.Data/Data/Models/ShortLink.cs
+++ b/GIFrameworkMap.Data/Data/Models/ShortLink.cs
@@ -13,5 +13,6 @@ namespace GIFrameworkMaps.Data.Models
         public string FullUrl { get; set; }
         [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
         public DateTime Created { get; set; }
+        public DateTime? LastVisited { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230811105200_AddLastVisitedToShortLink.Designer.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230811105200_AddLastVisitedToShortLink.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GIFrameworkMaps.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230811105200_AddLastVisitedToShortLink")]
+    partial class AddLastVisitedToShortLink
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20230811105200_AddLastVisitedToShortLink.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20230811105200_AddLastVisitedToShortLink.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddLastVisitedToShortLink : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastVisited",
+                schema: "giframeworkmaps",
+                table: "ShortLink",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastVisited",
+                schema: "giframeworkmaps",
+                table: "ShortLink");
+        }
+    }
+}

--- a/GIFrameworkMaps.Web/Controllers/MapController.cs
+++ b/GIFrameworkMaps.Web/Controllers/MapController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Configuration;
 using GIFrameworkMaps.Data.Models;
 using GIFrameworkMaps.Data.Models.ViewModels.Management;
+using Microsoft.EntityFrameworkCore;
 
 namespace GIFrameworkMaps.Web.Controllers
 {
@@ -19,19 +20,22 @@ namespace GIFrameworkMaps.Web.Controllers
         private readonly ICommonRepository _repository;
         private readonly IManagementRepository _adminRepository;
         private readonly IConfiguration _configuration;
+        private readonly ApplicationDbContext _context;
 
         public MapController(
             ILogger<MapController> logger, 
             IAuthorizationService authorization,
             ICommonRepository repository,
             IManagementRepository adminRepository,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            ApplicationDbContext context)
         {
             _logger = logger;
             _authorization = authorization;
             _repository = repository;
             _adminRepository = adminRepository;
             _configuration = configuration;
+            _context = context;
         }
         /// <summary>
         /// This route forces calls to the general /Map endpoint to redirect to the default slug route. Not pretty but does the job
@@ -115,6 +119,10 @@ namespace GIFrameworkMaps.Web.Controllers
             {
                 return View("ShortLinkNotFound");
             }
+            var shortLink = await _context.ShortLink.FirstOrDefaultAsync(s => s.ShortId == id);
+            shortLink.LastVisited = DateTime.UtcNow;
+            _context.SaveChanges();
+
             return Redirect(redirectUrl);
         }
     }


### PR DESCRIPTION
A LastVisited column has been added to the ShortLink table. This will fill in with today's date every time a short link is used.

This will help us to manage short links in the future and make it easy to remove any old records that are no longer being used.

Closes #146