### PR TITLE
Fix casing in webpack config

### DIFF
--- a/GIFrameworkMaps.Web/webpack.common.js
+++ b/GIFrameworkMaps.Web/webpack.common.js
@@ -23,7 +23,7 @@ const mapBundle = {
 
 const managementBundle =
 {
-    entry: ['./Scripts/management/management.ts'],
+    entry: ['./Scripts/Management/management.ts'],
     module: {
         rules: [
             {


### PR DESCRIPTION
Mismatched case causing failure for CodeQL as that runs on Linux. Would affect builds being done in Linux as well.