### PR TITLE
Make Civic cookie control (if used) more prominent

### DIFF
--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementAnalyticsController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementAnalyticsController.cs
@@ -180,7 +180,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
         {
             var versions = _context.Versions.OrderBy(b => b.Name).ToList();
             string[] supportedProducts = { "Cloudflare", "Google Analytics (GA4)", "Microsoft Application Insights", "Microsoft Clarity" };
-            string[] supportedCookieControls = { "Civica Cookie Control" };
+            string[] supportedCookieControls = { "Civic Cookie Control" };
 
             model.availableProducts = new SelectList(supportedProducts);
             model.availableCookieControl = new SelectList(supportedCookieControls);

--- a/GIFrameworkMaps.Web/Scripts/CookieControls.ts
+++ b/GIFrameworkMaps.Web/Scripts/CookieControls.ts
@@ -3,7 +3,7 @@ declare var configure_cookie_control: string;
 
 function loadCookieControl() {
     //This allows the use of a cookie control
-    if (configure_cookie_control == "Civica Cookie Control" && typeof CookieControl != "undefined") {
+    if (configure_cookie_control == "Civic Cookie Control" && typeof CookieControl != "undefined") {
         document.getElementById("CookieControlLink").addEventListener("click", CookieControl.open);
     }
 }

--- a/GIFrameworkMaps.Web/Scripts/app.ts
+++ b/GIFrameworkMaps.Web/Scripts/app.ts
@@ -36,7 +36,7 @@ if (gifw_appinsights_key != "") {
 document.addEventListener('DOMContentLoaded', function () {
 
     //This allows the use of a cookie control
-    if (configure_cookie_control == "Civica Cookie Control" && typeof CookieControl != "undefined") {
+    if (configure_cookie_control == "Civic Cookie Control" && typeof CookieControl != "undefined") {
         document.getElementById("CookieControlLink").addEventListener("click", CookieControl.open);
     }
 

--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -635,6 +635,10 @@
     z-index: 10000;
 }
 
+/*Civic Cookie Control overrides*/
+.giframeworkMap #ccc-overlay {
+    backdrop-filter: blur(2px) brightness(0.5);
+}
 
 /*Shepherd overrides (welcome tour)*/
 


### PR DESCRIPTION
This PR makes the Civic cookie control more prominent with a simple CSS override on the overlay, which adds a slight blur and darkens it a bit more.

Also rename incorrectly named Civica -> Civic

Closes #127 