### PR TITLE
Make sidebar headers sticky

### DIFF
--- a/GIFrameworkMaps.Web/Views/Map/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Index.cshtml
@@ -74,8 +74,8 @@
 
         <div class="sidebar-panels sidebar-left" id="gifw-sidebar-left">
             <div class="card sidebar" id="gifw-search-results" style="display:none;">
-                <div class="card-body">
-                    <div class="card-title-closeable">
+                <div class="card-body pt-0">
+                    <div class="card-title-closeable py-3">
                         <h4 class="card-title">Search results</h4>
                         <button type="button" class="btn-close" data-gifw-dismiss-sidebar="search-results" aria-label="Close"></button>
                     </div>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/AnnotationStyling.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/AnnotationStyling.cshtml
@@ -1,6 +1,6 @@
-﻿<div class="card-body">
+﻿<div class="card-body pt-0">
 
-    <div class="card-title-closeable">
+    <div class="card-title-closeable py-3">
         <h5 class="card-title">Modify annotation style</h5>
         <button type="button" class="btn-close" data-gifw-dismiss-sidebar="annotation-style-panel" aria-label="Close"></button>
     </div>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/BasemapsPanel.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/BasemapsPanel.cshtml
@@ -1,7 +1,7 @@
 ﻿@model List<GIFrameworkMaps.Data.Models.ViewModels.BasemapViewModel>
 
-<div class="card-body">
-    <div class="card-title-closeable">
+<div class="card-body pt-0">
+    <div class="card-title-closeable py-3">
         <h5 class="card-title">Background Map</h5>
         <button type="button" class="btn-close" data-gifw-dismiss-sidebar="basemaps" aria-label="Close"></button>
     </div>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/LayersPanel.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/LayersPanel.cshtml
@@ -1,7 +1,7 @@
 ﻿@model List<GIFrameworkMaps.Data.Models.ViewModels.CategoryViewModel>
 
-<div class="card-body">
-    <div class="card-title-closeable">
+<div class="card-body pt-0">
+    <div class="card-title-closeable py-3">
         <h5 class="card-title">Layers</h5>
         <button type="button" class="btn-close" data-gifw-dismiss-sidebar="layers-control" aria-label="Close"></button>
     </div>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/LegendsPanel.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/LegendsPanel.cshtml
@@ -1,5 +1,5 @@
-﻿<div class="card-body">
-    <div class="card-title-closeable">
+﻿<div class="card-body pt-0">
+    <div class="card-title-closeable py-3">
         <h5 class="card-title">Legend</h5>
         <button type="button" class="btn-close" data-gifw-dismiss-sidebar="legends" aria-label="Close"></button>
     </div>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/PrintPanel.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/PrintPanel.cshtml
@@ -1,5 +1,5 @@
-﻿<div class="card-body">
-    <div class="card-title-closeable">
+﻿<div class="card-body pt-0">
+    <div class="card-title-closeable py-3">
         <h5 class="card-title">Export and Print</h5>
         <button type="button" class="btn-close" data-gifw-dismiss-sidebar="print-control" aria-label="Close"></button>
     </div>

--- a/GIFrameworkMaps.Web/Views/Map/Partials/SharePanel.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/SharePanel.cshtml
@@ -1,5 +1,5 @@
-﻿<div class="card-body">
-    <div class="card-title-closeable">
+﻿<div class="card-body pt-0">
+    <div class="card-title-closeable py-3">
         <h5 class="card-title">Share</h5>
         <button type="button" class="btn-close" data-gifw-dismiss-sidebar="legends" aria-label="Close"></button>
     </div>

--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -272,7 +272,8 @@
 }
 
 .giframeworkMap aside#sidebar-container .sidebar-panels.show {
-    display: block;
+    display: flex;
+    flex-direction:column;
 }
 
 .giframeworkMap aside#sidebar-container .sidebar-panels .card {
@@ -280,27 +281,30 @@
     overflow-y: auto;
 }
 
-/*taken from modal header to allow close button to appear alongside title*/
-    .giframeworkMap aside#sidebar-container .sidebar-panels .card .card-title-closeable {
-        display: flex;
-        flex-shrink: 0;
-        align-items: center;
-        justify-content: space-between;
-    }
+.giframeworkMap aside#sidebar-container .sidebar-panels .card .card-title-closeable {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: space-between;
+    position: sticky;
+    top: 0px;
+    background: linear-gradient(0deg, transparent 0%, white 15%);
+    z-index: 10;
+}
 /*BASEMAPS*/
-    .giframeworkMap aside#sidebar-container .sidebar-panels .card.basemaps-selector {
-        height: 4rem;
-        background-color: #e0e0e0;
-        background-repeat: no-repeat;
-        background-size: cover;
-        margin-top: .5rem;
-        border-color: #e0e0e0;
-    }
-        .giframeworkMap aside#sidebar-container .sidebar-panels .card.basemaps-selector:hover {
-            box-shadow: 2px 2px 5px #e0e0e0;
-            border-color: var(--primary-color-transparent-50);
-            transition: all 0.2s ease;
-        }
+.giframeworkMap aside#sidebar-container .sidebar-panels .card.basemaps-selector {
+    height: 4rem;
+    background-color: #e0e0e0;
+    background-repeat: no-repeat;
+    background-size: cover;
+    margin-top: .5rem;
+    border-color: #e0e0e0;
+}
+.giframeworkMap aside#sidebar-container .sidebar-panels .card.basemaps-selector:hover {
+    box-shadow: 2px 2px 5px #e0e0e0;
+    border-color: var(--primary-color-transparent-50);
+    transition: all 0.2s ease;
+}
 .giframeworkMap aside#sidebar-container .sidebar-panels .card.basemaps-selector.active:hover {
     box-shadow: none;
 }
@@ -347,7 +351,7 @@
 /*Medium devices (tablets, 768px and up)*/
 @media (min-width: 768px) {
     .giframeworkMap .search-control {
-        width: 50%;
+        width: 45%;
     }
 
 }
@@ -363,7 +367,7 @@
 }
 
 .giframeworkMap #gifw-search-results {
-    padding-top: 2rem;
+    margin-top: 2.5rem;
 }
 .giframeworkMap #gifw-search-results-list li{
     padding:.5rem 0 .5rem 0;


### PR DESCRIPTION
This PR makes sidebar titles sticky. When a sidebar is taller than the screen, the title will stick to the top, allowing users to still access the close button.

![Sticky title example](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/109682469/99073ebf-8ae6-4811-ab4b-5dfa8cbc3c6d)

Some other minor CSS tweaks were made on top of what was required for sticky positioning.

Closes #104 