### PR TITLE
Help guidance linked to management area

### DIFF
--- a/GIFrameworkMaps.Web/Views/Management/BroadcastMessage.cshtml
+++ b/GIFrameworkMaps.Web/Views/Management/BroadcastMessage.cshtml
@@ -7,6 +7,12 @@
 
 <h1>@ViewData["Title"]</h1>
 <p class="lead">Broadcast a message to all current users. Use sparingly!</p>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/broadcast/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="container">
     <div class="row">
         <div class="col-sm-6">

--- a/GIFrameworkMaps.Web/Views/ManagementAnalytics/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementAnalytics/Create.cshtml
@@ -4,6 +4,12 @@
 }
 
 <h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/system/#site-analytics-and-cookie-control" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 @using (Html.BeginForm("Create", "ManagementAnalytics",null, FormMethod.Post, true, null))
 {
     <div class="row mt-4">

--- a/GIFrameworkMaps.Web/Views/ManagementAnalytics/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementAnalytics/Edit.cshtml
@@ -5,6 +5,11 @@
 
 <h1>@ViewData["Title"]</h1>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/system/#site-analytics-and-cookie-control" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 @using (Html.BeginForm("Edit", "ManagementAnalytics", null, FormMethod.Post, true, null))
 {
     <div class="row mt-4">

--- a/GIFrameworkMaps.Web/Views/ManagementAttribution/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementAttribution/Create.cshtml
@@ -5,6 +5,11 @@
 
 <h1>@ViewData["Title"]</h1>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/attributions/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2">
     <div class="col-md-8">
         <form asp-action="Create">

--- a/GIFrameworkMaps.Web/Views/ManagementAttribution/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementAttribution/Edit.cshtml
@@ -4,6 +4,12 @@
 }
 
 <h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/attributions/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2 mb-2">
     <div class="col-md-8">
         <form asp-action="Edit">

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Create.cshtml
@@ -5,6 +5,11 @@
 
 <h1>@ViewData["Title"]</h1>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/bounds/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2">
     <div class="col-md-8">
         <form asp-action="Create">

--- a/GIFrameworkMaps.Web/Views/ManagementBound/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementBound/Edit.cshtml
@@ -4,6 +4,12 @@
 }
 
 <h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/bounds/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2 mb-2">
     <div class="col-md-8">
         <form asp-action="Edit">

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
@@ -7,6 +7,12 @@
 }
 
 <h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/layers/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <form asp-action="CreateFromSource">
     <div class="row mt-2">
     

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
@@ -7,6 +7,12 @@
 }
 
 <h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/layers/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <form asp-action="Edit">
     <div class="row mt-2 mb-2">
         <div class="col-md-8 col-lg-6">

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/Create.cshtml
@@ -7,6 +7,11 @@
 
 <div class="alert alert-warning">This is the manual way of creating layer sources. For a simpler experience, try the @Html.ActionLink("Layer Wizard","Index","ManagementLayerWizard")</div>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/layers/#add-a-new-layer-manually" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2 mb-2">
     <div class="col-md-8 col-lg-6">
         <form asp-action="Create">

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/CreateOption.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/CreateOption.cshtml
@@ -5,6 +5,11 @@
 
 <h1>@ViewData["Title"]</h1>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/layers/#add-a-new-layer-manually" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2 mb-2">
     <div class="col-md-8 col-lg-6">
         <form asp-action="CreateOption">

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/Edit.cshtml
@@ -5,6 +5,12 @@
 }
 
 <h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/layers/#add-a-new-layer-manually" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2 mb-2">
     <div class="col-md-8 col-lg-6">
         <form asp-action="Edit">

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/EditOption.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/EditOption.cshtml
@@ -5,6 +5,11 @@
 
 <h1>@ViewData["Title"]</h1>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/layers/#add-a-new-layer-manually" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2 mb-2">
     <div class="col-md-8 col-lg-6">
         <form asp-action="EditOption">

--- a/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
@@ -10,6 +10,11 @@
 <h1>@ViewData["Title"]</h1>
 <p class="lead">Create a layer from a web service or an XYZ URL template</p>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/layers/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <ul class="nav nav-underline" role="tablist">
     <li class="nav-item" role="presentation">
         <button class="nav-link active" id="wms-tab" data-bs-toggle="tab" data-bs-target="#wms-tab-pane" type="button" role="tab" aria-controls="wms-tab-pane" aria-selected="true">WMS</button>

--- a/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/CreateAPISearchDefinition.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/CreateAPISearchDefinition.cshtml
@@ -5,6 +5,11 @@
 
 <h1>@ViewData["Title"]</h1>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/search-definitions/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2">
     <div class="col-md-8">
         <form asp-action="CreateAPISearchDefinition">

--- a/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/CreateDatabaseSearchDefinition.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/CreateDatabaseSearchDefinition.cshtml
@@ -5,6 +5,11 @@
 
 <h1>@ViewData["Title"]</h1>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/search-definitions/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2">
     <div class="col-md-8">
         <form asp-action="CreateDatabaseSearchDefinition">

--- a/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/CreateLocalSearchDefinition.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/CreateLocalSearchDefinition.cshtml
@@ -9,6 +9,11 @@
     Local search definitions are hard-coded into the application. Only enter a local search definition if you know what you are doing!
 </div>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/search-definitions/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2">
     <div class="col-md-8">
         <form asp-action="CreateLocalSearchDefinition">

--- a/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/EditAPISearchDefinition.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/EditAPISearchDefinition.cshtml
@@ -4,6 +4,12 @@
 }
 
 <h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/search-definitions/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2 mb-2">
     <div class="col-md-8">
         <form asp-action="EditAPISearchDefinition">

--- a/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/EditDatabaseSearchDefinition.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/EditDatabaseSearchDefinition.cshtml
@@ -4,6 +4,12 @@
 }
 
 <h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/search-definitions/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2 mb-2">
     <div class="col-md-8">
         <form asp-action="EditDatabaseSearchDefinition">

--- a/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/EditLocalSearchDefinition.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementSearchDefinition/EditLocalSearchDefinition.cshtml
@@ -10,6 +10,10 @@
         <div class="alert alert-warning" role="alert">
             Local search definitions are hard-coded into the application. Only edit a local search definition if you know what you are doing!
         </div>
+        <div>
+            <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/search-definitions/" class="btn btn-outline-primary" target="_blank"
+               role="button">Stuck? Read the help documentation</a>
+        </div>
         <form asp-action="EditLocalSearchDefinition">
             <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
             <input type="hidden" asp-for="Id" />

--- a/GIFrameworkMaps.Web/Views/ManagementTheme/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementTheme/Create.cshtml
@@ -5,6 +5,11 @@
 
 <h1>@ViewData["Title"]</h1>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/themes/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2">
     <div class="col-md-8">
         <form asp-action="Create">

--- a/GIFrameworkMaps.Web/Views/ManagementTheme/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementTheme/Edit.cshtml
@@ -4,6 +4,12 @@
 }
 
 <h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/themes/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2 mb-2">
     <div class="col-md-8">
         <form asp-action="Edit">

--- a/GIFrameworkMaps.Web/Views/ManagementTour/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementTour/Create.cshtml
@@ -7,6 +7,11 @@
 
 <a asp-action="Index">Cancel</a>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/tours/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <form asp-action="Create">
     <div class="row mt-4">
         <div class="col-md-6">

--- a/GIFrameworkMaps.Web/Views/ManagementTour/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementTour/Edit.cshtml
@@ -7,6 +7,11 @@
 
 <a asp-action="Index">Cancel</a>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/tours/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <form asp-action="Edit">
     <div class="row mt-4">
         <div class="col-md-6">

--- a/GIFrameworkMaps.Web/Views/ManagementUser/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementUser/Edit.cshtml
@@ -7,6 +7,11 @@
 
 <a asp-action="Index">Cancel</a>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/users/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <form asp-action="Edit">
     <div class="row mt-4 mb-2">
         <div class="col-md-6">

--- a/GIFrameworkMaps.Web/Views/ManagementVersion/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementVersion/Create.cshtml
@@ -7,6 +7,11 @@
 
 <a asp-action="Index">Cancel</a>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/versions/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <form asp-action="Create">
     <div class="row mt-4">
         <div class="col-md-6">

--- a/GIFrameworkMaps.Web/Views/ManagementVersion/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementVersion/Edit.cshtml
@@ -6,6 +6,12 @@
 <h1>@ViewData["Title"]</h1>
 
 <a asp-action="Index">Cancel</a>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/versions/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <a asp-action="ContactAlert" asp-route-id="@Model.Version.Id" class="float-end">Version Contacts</a>
 
 <form asp-action="Edit">

--- a/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Create.cshtml
@@ -5,6 +5,11 @@
 
 <h1>@ViewData["Title"]</h1>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/system/#web-layer-service-definitions" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2">
     <div class="col-md-8">
         <form asp-action="Create">

--- a/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Edit.cshtml
@@ -4,6 +4,12 @@
 }
 
 <h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/system/#web-layer-service-definitions" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2 mb-2">
     <div class="col-md-8">
         <form asp-action="Edit">

--- a/GIFrameworkMaps.Web/Views/ManagementWelcomeMessage/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWelcomeMessage/Create.cshtml
@@ -5,6 +5,11 @@
 
 <h1>@ViewData["Title"]</h1>
 
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/welcome-messages/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2">
     <div class="col-md-8">
         <form asp-action="Create">

--- a/GIFrameworkMaps.Web/Views/ManagementWelcomeMessage/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWelcomeMessage/Edit.cshtml
@@ -4,6 +4,12 @@
 }
 
 <h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/welcome-messages/" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
 <div class="row mt-2 mb-2">
     <div class="col-md-8">
         <form asp-action="Edit">


### PR DESCRIPTION
The management area now has links to the relevant pages in the help documentation. The links are at the top of the pages  whenever an admin creates or edits something. 

Closes #94