### PR TITLE
Debounced permalink URL updates

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -35,6 +35,7 @@ import { VersionViewModel } from "./Interfaces/VersionViewModel";
 import { WebLayerService } from "./WebLayerService";
 import { BookmarkMenu } from "./BookmarkMenu";
 import { LegendURLs } from "./Interfaces/LegendURLs";
+import { DebouncedFunc, debounce } from "lodash";
 
 export class GIFWMap {
     id: string;
@@ -44,10 +45,12 @@ export class GIFWMap {
     popupOverlay: GIFWPopupOverlay;
     olMap: olMap;
     customControls: any[] = [];
+    private delayPermalinkUpdate: DebouncedFunc<any>;
     constructor(id: string, config:VersionViewModel, sidebars: gifwSidebar.Sidebar[]) {
         this.id = id;
         this.config = config;
         this.sidebars = sidebars;
+        this.delayPermalinkUpdate = debounce(() => { document.getElementById(this.id).dispatchEvent(new CustomEvent('gifw-update-permalink')) },500);
     }
 
     /**
@@ -708,11 +711,11 @@ export class GIFWMap {
         if (l !== null) {
             l.setOpacity(olOpacity);
             if (!quiet) {
-                document.getElementById(this.id).dispatchEvent(new CustomEvent('gifw-update-permalink'));
+                this.delayPermalinkUpdate();
             }
         }
     }
-
+    
     /**
      * Sets the saturation of the currently active basemap
     * @param {number} saturation - The saturation level to set to (0-100)
@@ -744,12 +747,11 @@ export class GIFWMap {
                 container.style.filter = `grayscale(${olSaturation})`;
                 layer.set("saturation", saturation, quiet);
                 if (!quiet) {
-                    document.getElementById(this.id).dispatchEvent(new CustomEvent('gifw-update-permalink'));
+                    this.delayPermalinkUpdate();;
                 }
             }
         }
     }
-
 
     /**
     * Sets the opacity for an overlay
@@ -761,8 +763,7 @@ export class GIFWMap {
     */
     public setLayerOpacity(layer: olLayer.Layer<any, any>, opacity: number) {
         layer.setOpacity(opacity / 100);
-        document.getElementById(this.id).dispatchEvent(new CustomEvent('gifw-update-permalink'));
-
+        this.delayPermalinkUpdate();
     }
 
     /**

--- a/GIFrameworkMaps.Web/package-lock.json
+++ b/GIFrameworkMaps.Web/package-lock.json
@@ -22,6 +22,7 @@
         "fontoxpath": "3.30.2",
         "fuse.js": "6.6.2",
         "jspdf": "2.5.1",
+        "lodash": "4.17.21",
         "luxon": "3.4.3",
         "nunjucks": "3.2.4",
         "ol": "8.2.0",
@@ -34,6 +35,7 @@
       "devDependencies": {
         "@types/bootstrap": "5.2.8",
         "@types/dom-screen-wake-lock": "1.0.2",
+        "@types/lodash": "4.14.201",
         "@types/luxon": "3.3.2",
         "@types/nunjucks": "3.2.4",
         "@types/proj4": "2.5.3",
@@ -711,6 +713,12 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.201",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
+      "integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ==",
       "dev": true
     },
     "node_modules/@types/luxon": {
@@ -2274,6 +2282,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/GIFrameworkMaps.Web/package.json
+++ b/GIFrameworkMaps.Web/package.json
@@ -29,6 +29,7 @@
     "fontoxpath": "3.30.2",
     "fuse.js": "6.6.2",
     "jspdf": "2.5.1",
+    "lodash": "4.17.21",
     "luxon": "3.4.3",
     "nunjucks": "3.2.4",
     "ol": "8.2.0",
@@ -41,6 +42,7 @@
   "devDependencies": {
     "@types/bootstrap": "5.2.8",
     "@types/dom-screen-wake-lock": "1.0.2",
+    "@types/lodash": "4.14.201",
     "@types/luxon": "3.3.2",
     "@types/nunjucks": "3.2.4",
     "@types/proj4": "2.5.3",


### PR DESCRIPTION
This pull request fixes a bug where the permalink in the URL was being constantly updated (sometimes over 100 times a second) when the opacity or saturation controls were used on a basemap or layer.

Instead of being updated constantly, the permalink in the URL will now only update when you have either finished setting your opacity/saturation or when you pause moving the slider for 500ms or more. This drastically cuts down the number of times a function is called and should hopefully improve performance.

To do this, we have installed a new dependency called Lodash and have used the `debounce` function.

Closes #170 