### PR TITLE
Fix issue with user list being limited to 100

### DIFF
--- a/GIFrameworkMap.Data/CoordHelper.cs
+++ b/GIFrameworkMap.Data/CoordHelper.cs
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 [assembly: InternalsVisibleTo("GIFrameworkMaps.Tests")]
 namespace GIFrameworkMaps.Data
 {
-    public class CoordHelper
+    public partial class CoordHelper
     {
         /// <summary>
         /// Checks whether a BNG 12 figure grid ref pair is within the UK
@@ -16,7 +16,7 @@ namespace GIFrameworkMaps.Data
         /// <returns>True if valid. False otherwise.</returns>
         internal static bool ValidateBNG12Figure(decimal x, decimal y)
         {
-            if((x >= 0 && x <= 700000) && (y >= 0 && y<=1300000)) {
+            if(x >= 0 && x <= 700000 && y >= 0 && y<=1300000) {
                 return true;
             }
             return false;
@@ -30,7 +30,7 @@ namespace GIFrameworkMaps.Data
         /// <returns>True if valid. False otherwise.</returns>
         internal static bool ValidateLatLon(decimal latitude, decimal longitude)
         {
-            if((latitude >= -180 && latitude <= 180) && (longitude >= -180 && longitude <= 180))
+            if(latitude >= -180 && latitude <= 180 && longitude >= -180 && longitude <= 180)
             {
                 return true;
             }
@@ -40,7 +40,7 @@ namespace GIFrameworkMaps.Data
         internal static bool ValidateSphericalMercator(decimal x, decimal y)
         {
             
-            if((x >= -20026376.39M && x <= 20026376.39M) && (y >= -20048966.10M && y<= 20048966.10M))
+            if(x >= -20026376.39M && x <= 20026376.39M && y >= -20048966.10M && y<= 20048966.10M)
             {
                 return true;
             }
@@ -56,15 +56,15 @@ namespace GIFrameworkMaps.Data
         {
             string x, y;
             gridRef = gridRef.Replace(" ", "");
-            var alpha = gridRef.Substring(0, 2);
+            var alpha = gridRef[..2];
             var xy = TranslateOSGBAlphaCharactersToNumerics(alpha.ToUpper());
             if(xy != null)
             {
                 x = xy[0].ToString();
                 y = xy[1].ToString();
-                gridRef = gridRef.Substring(2);
-                x += gridRef.Substring(0, gridRef.Length / 2);
-                y += gridRef.Substring(gridRef.Length / 2);
+                gridRef = gridRef[2..];
+                x += gridRef[..(gridRef.Length / 2)];
+                y += gridRef[(gridRef.Length / 2)..];
                 for(int i = x.Length; i < 6; i++)
                 {
                     x += "0";
@@ -93,20 +93,19 @@ namespace GIFrameworkMaps.Data
             /*the third part will be the numbers until the last number in the string*/
             /*This could perhaps be better done with regular expressions*/
             var firstBreak = dmsCoord.IndexOfAny(new char[] { ' ', '°' });
-            var degrees = dmsCoord.Substring(0, firstBreak);
+            var degrees = dmsCoord[..firstBreak];
 
             var startPointOfSecondSection = dmsCoord.IndexOfAny("0123456789".ToCharArray(),firstBreak);
             var secondBreak = dmsCoord.IndexOfAny(new char[] { ' ', '\'', '′' },startPointOfSecondSection);
-            var minutes = dmsCoord.Substring(startPointOfSecondSection, (secondBreak - startPointOfSecondSection));
+            var minutes = dmsCoord[startPointOfSecondSection..secondBreak];
 
             var startPointOfThirdSection = dmsCoord.IndexOfAny("0123456789".ToCharArray(), secondBreak);
             var thirdBreak = dmsCoord.LastIndexOfAny("0123456789".ToCharArray())+1;
-            var seconds = dmsCoord.Substring(startPointOfThirdSection, (thirdBreak - startPointOfThirdSection));
+            var seconds = dmsCoord[startPointOfThirdSection..thirdBreak];
 
-            Regex pattern = new Regex("[NSEW]");
+            Regex pattern = NSEWRegex();
             var hemisphereIndicator = pattern.Match(dmsCoord.ToUpper());
-            decimal d, m, s;
-            if(decimal.TryParse(degrees,out d) && decimal.TryParse(minutes,out m) && decimal.TryParse(seconds, out s))
+            if (decimal.TryParse(degrees, out decimal d) && decimal.TryParse(minutes, out decimal m) && decimal.TryParse(seconds, out decimal s))
             {
                 return ConvertDegreeAngleToDecimal(d, m, s, hemisphereIndicator.Success ? hemisphereIndicator.Value : "");
             }
@@ -125,7 +124,7 @@ namespace GIFrameworkMaps.Data
         internal static decimal ConvertDegreeAngleToDecimal(decimal degrees, decimal minutes, decimal seconds, string hemisphere = "")
         {
 
-            var multiplier = (hemisphere.Contains('S') || hemisphere.Contains('W')) ? -1 : 1; //handle south and west
+            var multiplier = hemisphere.Contains('S') || hemisphere.Contains('W') ? -1 : 1; //handle south and west
 
             //Decimal degrees = 
             //   whole number of degrees, 
@@ -135,7 +134,7 @@ namespace GIFrameworkMaps.Data
             minutes /= 60;
             seconds /= 3600;
 
-            return Decimal.Round((degrees + minutes + seconds) * multiplier,5);
+            return decimal.Round((degrees + minutes + seconds) * multiplier,5);
         }
 
         /// <summary>
@@ -528,6 +527,7 @@ namespace GIFrameworkMaps.Data
             return return_array;
         }
 
-
+        [GeneratedRegex("[NSEW]")]
+        private static partial Regex NSEWRegex();
     }
 }

--- a/GIFrameworkMap.Data/Data/CommonRepository.cs
+++ b/GIFrameworkMap.Data/Data/CommonRepository.cs
@@ -71,7 +71,7 @@ namespace GIFrameworkMaps.Data
         /// <param name="slugParts">A list of the slug parts (which must contain at least one).</param>
         /// <returns></returns>
         /// <remarks>Have created this as a generic method so it could be reused.</remarks>
-        private string CreateSlug(params string[] slugParts)
+        private static string CreateSlug(params string[] slugParts)
         {
             return slugParts[0].ToLower() + 
                 //Append more slug parts if there are any left and the next is non-blank.

--- a/GIFrameworkMap.Data/Data/IManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/IManagementRepository.cs
@@ -43,7 +43,7 @@ namespace GIFrameworkMaps.Data
         Task<List<DatabaseSearchDefinition>> GetDatabaseSearchDefinitions();
         Task<LocalSearchDefinition?> GetLocalSearchDefinition(int id);
         Task<List<LocalSearchDefinition>> GetLocalSearchDefinitions();
-        Task<Microsoft.Graph.Beta.Models.UserCollectionResponse?> GetUsers();
+        Task<List<Microsoft.Graph.Beta.Models.User>> GetUsers();
         Task<Microsoft.Graph.Beta.Models.User?> GetUser(string id);
         AnalyticsViewModel GetAnalyticsModel();
     }

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/Management/AnalyticsModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/Management/AnalyticsModel.cs
@@ -20,9 +20,9 @@ namespace GIFrameworkMaps.Data.Models.ViewModels.Management
 
     public class AnalyticsEditModel
     {
-        public AnalyticsDefinition? analyticDefinition { get; set; }
-        public SelectList? availableProducts { get; set; }
-        public SelectList? availableCookieControl { get; set; }
+        public AnalyticsDefinition? AnalyticDefinition { get; set; }
+        public SelectList? AvailableProducts { get; set; }
+        public SelectList? AvailableCookieControl { get; set; }
 
         public List<int> SelectedVersions { get; set; } = new();
         public List<Version> AvailableVersions { get; set; } = new();

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/Management/VersionAddContactModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/Management/VersionAddContactModel.cs
@@ -10,6 +10,6 @@ namespace GIFrameworkMaps.Data.Models.ViewModels.Management
     public class VersionAddContactModel
     {
         public VersionContact? ContactEntry { get; set; }
-        public UserCollectionResponse? ListOfUsers { get; set; }
+        public List<User>? ListOfUsers { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/GIFrameworkMaps.Data.csproj
+++ b/GIFrameworkMap.Data/GIFrameworkMaps.Data.csproj
@@ -8,13 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.10.3" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.13">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Graph.Beta" Version="5.19.0-preview" />
+    <PackageReference Include="Microsoft.Graph.Beta" Version="5.58.0-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.11" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="7.0.11" />

--- a/GIFrameworkMap.Data/packages.lock.json
+++ b/GIFrameworkMap.Data/packages.lock.json
@@ -14,11 +14,11 @@
       },
       "Azure.Identity": {
         "type": "Direct",
-        "requested": "[1.10.3, )",
-        "resolved": "1.10.3",
-        "contentHash": "l1Xm2MWOF2Mzcwuarlw8kWQXLZk3UeB55aQXVyjj23aBfDwOZ3gu5GP2kJ6KlmZeZv2TCzw7x4L3V36iNr3gww==",
+        "requested": "[1.10.4, )",
+        "resolved": "1.10.4",
+        "contentHash": "hSvisZy9sld0Gik1X94od3+rRXCx+AKgi+iLH6fFdlnRZRePn7RtrqUGSsORiH2h8H2sc4NLTrnuUte1WL+QuQ==",
         "dependencies": {
-          "Azure.Core": "1.35.0",
+          "Azure.Core": "1.36.0",
           "Microsoft.Identity.Client": "4.56.0",
           "Microsoft.Identity.Client.Extensions.Msal": "4.56.0",
           "System.Memory": "4.5.4",
@@ -53,11 +53,11 @@
       },
       "Microsoft.Graph.Beta": {
         "type": "Direct",
-        "requested": "[5.19.0-preview, )",
-        "resolved": "5.19.0-preview",
-        "contentHash": "WlxQeRuAsbgyiZxV31IKWykCekkkq3SAFUVPOeNaQalto5WdPx5EkOfCdREFNDQ9ThvrP9+InXfcZZOiZDw/dA==",
+        "requested": "[5.58.0-preview, )",
+        "resolved": "5.58.0-preview",
+        "contentHash": "C5r8Nf/yyt+HBWUxVo3gJMsFX6sbF0uYrcd5aidQJyBFcivMMBH4RzEK6FRz6/7SVAg86tjZmzEwe75vixw2Dg==",
         "dependencies": {
-          "Microsoft.Graph.Core": "3.0.0-rc.6"
+          "Microsoft.Graph.Core": "3.1.2"
         }
       },
       "Newtonsoft.Json": {
@@ -131,8 +131,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.35.0",
-        "contentHash": "hENcx03Jyuqv05F4RBEPbxz29UrM3Nbhnr6Wl6NQpoU9BCIbL3XLentrxDCTrH54NLS11Exxi/o8MYgT/cnKFA==",
+        "resolved": "1.36.0",
+        "contentHash": "vwqFZdHS4dzPlI7FFRkPx9ctA+aGGeRev3gnzG8lntWvKMmBhAmulABi1O9CEvS3/jzYt7yA+0pqVdxkpAd7dQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.1.1",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
@@ -271,16 +271,17 @@
       },
       "Microsoft.Graph.Core": {
         "type": "Transitive",
-        "resolved": "3.0.0-rc.6",
-        "contentHash": "4bcZGi8Z6EoO09p30Q+lbTHumhGDh554lSF0dCMUcC0lzo6Gm67GanIpM+KQaOjv1XZ4TaCg+Jdl7eAt1f0eig==",
+        "resolved": "3.1.2",
+        "contentHash": "r+8fbhwGbfelqS3ZbFkESC+B6Lwn21gv88oXtUtRLkwFkJRmtFiCZVyuom7JaHn3cP7AUw5QNyWP6PaoqsoKEQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.26.1",
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.7",
-          "Microsoft.Kiota.Authentication.Azure": "1.0.0-rc.3",
-          "Microsoft.Kiota.Http.HttpClientLibrary": "1.0.0-rc.6",
-          "Microsoft.Kiota.Serialization.Form": "1.0.0-rc.4",
-          "Microsoft.Kiota.Serialization.Json": "1.0.0-rc.3",
-          "Microsoft.Kiota.Serialization.Text": "1.0.0-rc.3",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.0.3",
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "Microsoft.Kiota.Authentication.Azure": "1.1.2",
+          "Microsoft.Kiota.Http.HttpClientLibrary": "1.3.2",
+          "Microsoft.Kiota.Serialization.Form": "1.1.1",
+          "Microsoft.Kiota.Serialization.Json": "1.1.2",
+          "Microsoft.Kiota.Serialization.Multipart": "1.1.1",
+          "Microsoft.Kiota.Serialization.Text": "1.1.1",
           "NETStandard.Library": "2.0.3",
           "System.Security.Claims": "4.3.0"
         }
@@ -305,108 +306,111 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "YE6pc6/TG1axQU5U1zGmgpcV4vKhEl4t0MTjqxdnnrorrozeBPkTECyZk9djysKTLfd8moBe7VHVpuf+jvmlkA=="
+        "resolved": "7.0.3",
+        "contentHash": "cfPUWdjigLIRIJSKz3uaZxShgf86RVDXHC1VEEchj1gnY25akwPYpbrfSoIGDCqA9UmOMdlctq411+2pAViFow=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "3n+Pdetj8JukY3hSTLiLhZHpxq9m9dai0k3OK0UrNIhaAP+N8ea5gYoFSu2gdOJELbirc5OW4oyjaTvQaefF0w==",
+        "resolved": "7.0.3",
+        "contentHash": "vxjHVZbMKD3rVdbvKhzAW+7UiFrYToUVm3AGmYfKSOAwyhdLl/ELX1KZr+FaLyyS5VReIzWRWJfbOuHM9i6ywg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "6.26.1",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encodings.Web": "4.7.2",
-          "System.Text.Json": "4.7.2"
+          "Microsoft.IdentityModel.Tokens": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "ujS5+a2L3uquqeWa3i9uNjXAfEFuDzIfKlDqZ09aKTR2M6eLqQcc0BBhh0FtJkTmsfa8GJjKDEYVcbgVzNARfQ==",
+        "resolved": "7.0.3",
+        "contentHash": "b6GbGO+2LOTBEccHhqoJsOsmemG4A/MY+8H0wK/ewRhiG+DCYwEnucog1cSArPIY55zcn+XdZl0YEiUHkpDISQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "6.26.1"
+          "Microsoft.IdentityModel.Abstractions": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Protocols": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "icZMVqD1xX9+LzrxZZoSXbmwBC5/5ckU9pYEbJjBzNFWUMBL74G0YrajM+FKcE6Q2G0730P5WbTQcKju/SrF6w==",
+        "resolved": "7.0.3",
+        "contentHash": "BtwR+tctBYhPNygyZmt1Rnw74GFrJteW+1zcdIgyvBCjkek6cNwPPqRfdhzCv61i+lwyNomRi8+iI4QKd4YCKA==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "6.26.1",
-          "Microsoft.IdentityModel.Tokens": "6.26.1"
+          "Microsoft.IdentityModel.Logging": "7.0.3",
+          "Microsoft.IdentityModel.Tokens": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "JeZSQUtjWT/+wZIMtdrdBWPSOphXE70bPxPBehYzXyRXu796DPXqT/4K6i0Z9nVqTU9anzvM8hAiypEWZDcZ+w==",
+        "resolved": "7.0.3",
+        "contentHash": "W97TraHApDNArLwpPcXfD+FZH7njJsfEwZE9y9BoofeXMS8H0LBBobz0VOmYmMK4mLdOKxzN7SFT3Ekg0FWI3Q==",
         "dependencies": {
-          "Microsoft.IdentityModel.Protocols": "6.26.1",
-          "System.IdentityModel.Tokens.Jwt": "6.26.1"
+          "Microsoft.IdentityModel.Protocols": "7.0.3",
+          "System.IdentityModel.Tokens.Jwt": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "dhUE+4uhO/JhGYYRWZynO42tZ5H2p2GeVFjCwa7gLzCWBeKowO2OEtFHG3Mq/DhBR+mp6+LzUdRkKR2kI3I+TQ==",
+        "resolved": "7.0.3",
+        "contentHash": "wB+LlbDjhnJ98DULjmFepqf9eEMh/sDs6S6hFh68iNRHmwollwhxk+nbSSfpA5+j+FbRyNskoaY4JsY1iCOKCg==",
         "dependencies": {
-          "Microsoft.CSharp": "4.5.0",
-          "Microsoft.IdentityModel.Logging": "6.26.1",
-          "System.Security.Cryptography.Cng": "4.5.0"
+          "Microsoft.IdentityModel.Logging": "7.0.3"
         }
       },
       "Microsoft.Kiota.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.7",
-        "contentHash": "RccZfwTjk/MCLtaV3N3C1u1Eh6NO0RZJ64zpJ2YkfJfr6pjrOJfhx8QVL8jGN8MToQ7gjZe8AjTvOnON5f+g7g==",
+        "resolved": "1.7.2",
+        "contentHash": "7ZxIrX23NZXqmYZyUCmjtDYnY6Wc9pkKWsItIxxSQ5Obea4xqX0AGRInxP8tsV5Z5t67RkVcM1O2zATRDJh1fA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "7.0.0",
-          "Tavis.UriTemplates": "2.0.0"
+          "Std.UriTemplate": "0.0.46",
+          "System.Diagnostics.DiagnosticSource": "[6.0.0, 9.0.0)"
         }
       },
       "Microsoft.Kiota.Authentication.Azure": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.3",
-        "contentHash": "43IxtHWTQ4jzNxMsL4NX4JQZJvxtjGYxcIB/0TolH8ZizlyxgXdBPomf5z1I/S1XXZkAp3t5HN7TkrNbhK/zow==",
+        "resolved": "1.1.2",
+        "contentHash": "Dzc6h9pSHKCJPjJ4RnEs2liL4vVO/O7Oh8XolMHB7c+4/bkdvOdWS9UYz5uMtP4Q+zgnUF3KO/0WvJSA4nbiNw==",
         "dependencies": {
-          "Azure.Core": "1.27.0",
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.4",
-          "System.Diagnostics.DiagnosticSource": "7.0.0"
+          "Azure.Core": "1.36.0",
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "System.Diagnostics.DiagnosticSource": "[6.0.1, 9.0.0)"
         }
       },
       "Microsoft.Kiota.Http.HttpClientLibrary": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.6",
-        "contentHash": "VWK7d+WTwZ6r9FUaaoazim5Dmz0fPqe4nGoDh5iI8QCweok3wT7BE0h8UX2tVwg9HNE/Yz37XIkNtXPkf1d6iA==",
+        "resolved": "1.3.2",
+        "contentHash": "ifCWjA6gFp7/77jqN38ZhyPTKNuh7kOsoS1+EjttTOsTufz54L42bJ7GK+jd0Gk4zuYjDncVBXtNSZWGbwtzgQ==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.7",
-          "System.Diagnostics.DiagnosticSource": "7.0.0",
-          "System.Text.Json": "7.0.1"
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "System.Diagnostics.DiagnosticSource": "[6.0.0, 9.0.0)",
+          "System.Text.Json": "[6.0.0, 9.0.0)"
         }
       },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.4",
-        "contentHash": "6mtoFqxn4Jt6wgNlkJVipm1QyPERO+as9dLKAX1Qc/9wNkBXPb+NfPxgsdcxuEfZcCirlYOFj3lTL3fx8pno4A==",
+        "resolved": "1.1.1",
+        "contentHash": "/j0B30rmLUoan6ckekHmPe6H0xJ3nCkn5RfgFfJkDnJiLO15N57+NTDgjGPbdwqRafQGyvJUmuON2APVZIdQhA==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.6"
+          "Microsoft.Kiota.Abstractions": "1.7.2"
         }
       },
       "Microsoft.Kiota.Serialization.Json": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.3",
-        "contentHash": "53/vdQCvCCk/1/KXQQ6495NQY5+PPs+J803npjXtZbh36R81p152aN749v7i198GlV6TUJDk7j8sCZg1opWT7w==",
+        "resolved": "1.1.2",
+        "contentHash": "n421mk9agwBeHhAkeQIwRc3bjRE4oEPM1/CTxuiUZkd8ni4PN0Tabp3PPCjsuNmqcZXLleUh2nG/JBCoRizdzA==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.6",
-          "System.Text.Json": "7.0.1"
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "System.Text.Json": "[6.0.0, 9.0.0)"
+        }
+      },
+      "Microsoft.Kiota.Serialization.Multipart": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "+31xiVWveV9/8qGlm+STiwVVN74tpwJvXq2Q2MZGDQCWZ1j+aDr4y5auOw0l1yr2nD+1jjyjU239101Pu6ECgw==",
+        "dependencies": {
+          "Microsoft.Kiota.Abstractions": "1.7.2"
         }
       },
       "Microsoft.Kiota.Serialization.Text": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.3",
-        "contentHash": "QQAR/dpb/Rg8xYkuVoUnx4HYyoMukQe+OaeWZ06NjuGXKgNyKtFziqpngIOv/RYNpmf1aeRSo5gW7M34AJ54oQ==",
+        "resolved": "1.1.1",
+        "contentHash": "6iA04gp7BhbgkLjKJ9wq+/87zI5DROSkakQ5cenlUKMUySTHkleLI7f0r57BNHi+sCtQu5Am3+h40G85yJwhug==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.6"
+          "Microsoft.Kiota.Abstractions": "1.7.2"
         }
       },
       "Microsoft.NETCore.Platforms": {
@@ -442,15 +446,6 @@
         "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
-        }
-      },
-      "Newtonsoft.Json.Bson": {
-        "type": "Transitive",
-        "resolved": "1.0.1",
-        "contentHash": "5PYT/IqQ+UK31AmZiSS102R6EsTo+LGTSI8bp7WAUqDKaF4wHXD8U9u4WxTI1vc64tYi++8p3dk3WWNqPFgldw==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1",
-          "Newtonsoft.Json": "10.0.1"
         }
       },
       "NodaTime": {
@@ -494,6 +489,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "Std.UriTemplate": {
+        "type": "Transitive",
+        "resolved": "0.0.46",
+        "contentHash": "/cCCMsB3i+MVt5LTbl236dnFd/BE4dKzzzC1teGTpAHzwPTiLIuD5hioGgtPuli/enAj8Dhmt/e9JlVUIITIgQ=="
+      },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -511,8 +511,11 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "9W0ewWDuAyDqS2PigdTxk6jDKonfgscY/hP8hm7VpxYhNHZHKvZTdRckberlFk3VnCmr3xBUyMBut12Q+T2aOw=="
+        "resolved": "6.0.1",
+        "contentHash": "KiLYDu2k2J82Q9BJpWiuQqCkFjRBWVq4jDzKKWawVi9KWzyD0XG3cmfX0vqTQlL14Wi9EufJrbL0+KCLTbqWiQ==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "System.Globalization": {
         "type": "Transitive",
@@ -526,11 +529,11 @@
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "SWdMY1W8z/7XmYXrAGSH8yZKGWIpPZ1yICdfkbKh+mctb2flxzZzaSheD8XzRQhu2dtdYcKL5mnJIvZIaYBYUQ==",
+        "resolved": "7.0.3",
+        "contentHash": "caEe+OpQNYNiyZb+DJpUVROXoVySWBahko2ooNfUcllxa9ZQUM8CgM/mDjP6AoFn6cQU9xMmG+jivXWub8cbGg==",
         "dependencies": {
-          "Microsoft.IdentityModel.JsonWebTokens": "6.26.1",
-          "Microsoft.IdentityModel.Tokens": "6.26.1"
+          "Microsoft.IdentityModel.JsonWebTokens": "7.0.3",
+          "Microsoft.IdentityModel.Tokens": "7.0.3"
         }
       },
       "System.IO": {
@@ -618,8 +621,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "zOHkQmzPCn5zm/BH+cxC1XbUS3P4Yoi3xzW7eRgVpDR2tPGSzyMZ17Ig1iRkfJuY0nhxkQQde8pgePNiA7z7TQ=="
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
       "System.Runtime.Extensions": {
         "type": "Transitive",
@@ -653,11 +656,6 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Security.Principal": "4.3.0"
         }
-      },
-      "System.Security.Cryptography.Cng": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "WG3r7EyjUe9CMPFSs6bty5doUqT+q9pbI80hlNzo2SkPkZ4VTuZkGWjpp77JB8+uaL4DFPRdBsAY+DX3dBK92A=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
@@ -694,8 +692,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "OtDEmCCiNl8JAduFKZ/r0Sw6XZNHwIicUYy/mXgMDGeOsZLshH37qi3oPRzFYiryVktiMoQLByMGPtRCEMYbeQ==",
+        "resolved": "7.0.0",
+        "contentHash": "DaGSsVqKsn/ia6RG8frjwmJonfos0srquhw09TlT8KRw5I43E+4gs+/bZj4K0vShJ5H9imCuXupb4RmS+dBy3w==",
         "dependencies": {
           "System.Text.Encodings.Web": "7.0.0"
         }
@@ -714,11 +712,6 @@
         "type": "Transitive",
         "resolved": "4.5.4",
         "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
-      },
-      "Tavis.UriTemplates": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GbetWNcPIaXvWtanHlBqlEp2KflFrsJf8RBNXmI8Yyeft9CSGxNrcsoKWEiEzyrn7gGVQ25ZC6ep9UfWPR0Otw=="
       }
     }
   }

--- a/GIFrameworkMaps.Tests/CommonRepositoryTests.cs
+++ b/GIFrameworkMaps.Tests/CommonRepositoryTests.cs
@@ -35,35 +35,35 @@ namespace GIFrameworkMaps.Tests
 
             var versions = new List<Version>
             {
-                new Version { Name = "General version",Slug= "general",Id=1 },
-                new Version { Name = "Valid Version Test",Slug= "valid/version",Id=2 },
-                new Version { Name = "Valid Version Test 2",Slug= "valid/version/two",Id=3 },
-                new Version { Name = "Requires Login",Slug= "requires/login",Id=4 ,RequireLogin=true},
-                new Version { Name = "Requires Login 2",Slug= "requires/login/two",Id=5, RequireLogin=true }
+                new() { Name = "General version",Slug= "general",Id=1 },
+                new() { Name = "Valid Version Test",Slug= "valid/version",Id=2 },
+                new() { Name = "Valid Version Test 2",Slug= "valid/version/two",Id=3 },
+                new() { Name = "Requires Login",Slug= "requires/login",Id=4 ,RequireLogin=true},
+                new() { Name = "Requires Login 2",Slug= "requires/login/two",Id=5, RequireLogin=true }
             };
 
             var roles = new List<ApplicationRole>
             {
-                new ApplicationRole{Id=1,RoleName="GIFWAdmin"}
+                new() {Id=1,RoleName="GIFWAdmin"}
             };
 
             var userRoles = new List<ApplicationUserRole>
             {
-                new ApplicationUserRole{UserId = "36850518-dd0a-48e0-9004-cdaf30d82746",Role=roles.First()}
+                new() {UserId = "36850518-dd0a-48e0-9004-cdaf30d82746",Role=roles.First()}
             };
 
             var users = new List<VersionUser>
             {
-                new VersionUser{UserId="36850518-dd0a-48e0-9004-cdaf30d82746",VersionId=4 }
+                new() {UserId="36850518-dd0a-48e0-9004-cdaf30d82746",VersionId=4 }
             };
 
             var bookmarks = new List<Bookmark>
             {
-                new Bookmark{UserId="36850518-dd0a-48e0-9004-cdaf30d82746",Name="Test Bookmark",X=(decimal)-283267.6475493251, Y=(decimal)6570725.6916950345, Zoom = 18, Id = 1 },
-                new Bookmark{UserId="36850518-dd0a-48e0-9004-cdaf30d82746",Name="Test Bookmark 2",X=(decimal)-283945.864, Y=(decimal)61023565.9784, Zoom = 8, Id = 2 },
-                new Bookmark{UserId="36850518-dd0a-48e0-9004-cdaf30d82746",Name="Test Bookmark 3",X=(decimal)1005456.2345, Y=(decimal)0.456, Zoom = 10, Id = 3 },
-                new Bookmark{UserId="17819f99-b8d5-4495-8c48-964f5692afdc",Name="Test Bookmark 4",X=(decimal)-283267.6475493251, Y=(decimal)6570725.6916950345, Zoom = 10, Id = 4 },
-                new Bookmark{UserId="17819f99-b8d5-4495-8c48-964f5692afdc",Name="Test Bookmark 5",X=(decimal)-3894566.44, Y=(decimal)55427657.45, Zoom = 7, Id = 5 },
+                new() {UserId="36850518-dd0a-48e0-9004-cdaf30d82746",Name="Test Bookmark",X=(decimal)-283267.6475493251, Y=(decimal)6570725.6916950345, Zoom = 18, Id = 1 },
+                new() {UserId="36850518-dd0a-48e0-9004-cdaf30d82746",Name="Test Bookmark 2",X=(decimal)-283945.864, Y=(decimal)61023565.9784, Zoom = 8, Id = 2 },
+                new() {UserId="36850518-dd0a-48e0-9004-cdaf30d82746",Name="Test Bookmark 3",X=(decimal)1005456.2345, Y=(decimal)0.456, Zoom = 10, Id = 3 },
+                new() {UserId="17819f99-b8d5-4495-8c48-964f5692afdc",Name="Test Bookmark 4",X=(decimal)-283267.6475493251, Y=(decimal)6570725.6916950345, Zoom = 10, Id = 4 },
+                new() {UserId="17819f99-b8d5-4495-8c48-964f5692afdc",Name="Test Bookmark 5",X=(decimal)-3894566.44, Y=(decimal)55427657.45, Zoom = 7, Id = 5 },
             };
 
             var versionsMockSet = versions.AsQueryable().BuildMockDbSet();

--- a/GIFrameworkMaps.Tests/packages.lock.json
+++ b/GIFrameworkMaps.Tests/packages.lock.json
@@ -84,8 +84,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.35.0",
-        "contentHash": "hENcx03Jyuqv05F4RBEPbxz29UrM3Nbhnr6Wl6NQpoU9BCIbL3XLentrxDCTrH54NLS11Exxi/o8MYgT/cnKFA==",
+        "resolved": "1.36.0",
+        "contentHash": "vwqFZdHS4dzPlI7FFRkPx9ctA+aGGeRev3gnzG8lntWvKMmBhAmulABi1O9CEvS3/jzYt7yA+0pqVdxkpAd7dQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.1.1",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
@@ -98,10 +98,10 @@
       },
       "Azure.Identity": {
         "type": "Transitive",
-        "resolved": "1.10.3",
-        "contentHash": "l1Xm2MWOF2Mzcwuarlw8kWQXLZk3UeB55aQXVyjj23aBfDwOZ3gu5GP2kJ6KlmZeZv2TCzw7x4L3V36iNr3gww==",
+        "resolved": "1.10.4",
+        "contentHash": "hSvisZy9sld0Gik1X94od3+rRXCx+AKgi+iLH6fFdlnRZRePn7RtrqUGSsORiH2h8H2sc4NLTrnuUte1WL+QuQ==",
         "dependencies": {
-          "Azure.Core": "1.35.0",
+          "Azure.Core": "1.36.0",
           "Microsoft.Identity.Client": "4.56.0",
           "Microsoft.Identity.Client.Extensions.Msal": "4.56.0",
           "System.Memory": "4.5.4",
@@ -236,24 +236,25 @@
       },
       "Microsoft.Graph.Beta": {
         "type": "Transitive",
-        "resolved": "5.19.0-preview",
-        "contentHash": "WlxQeRuAsbgyiZxV31IKWykCekkkq3SAFUVPOeNaQalto5WdPx5EkOfCdREFNDQ9ThvrP9+InXfcZZOiZDw/dA==",
+        "resolved": "5.58.0-preview",
+        "contentHash": "C5r8Nf/yyt+HBWUxVo3gJMsFX6sbF0uYrcd5aidQJyBFcivMMBH4RzEK6FRz6/7SVAg86tjZmzEwe75vixw2Dg==",
         "dependencies": {
-          "Microsoft.Graph.Core": "3.0.0-rc.6"
+          "Microsoft.Graph.Core": "3.1.2"
         }
       },
       "Microsoft.Graph.Core": {
         "type": "Transitive",
-        "resolved": "3.0.0-rc.6",
-        "contentHash": "4bcZGi8Z6EoO09p30Q+lbTHumhGDh554lSF0dCMUcC0lzo6Gm67GanIpM+KQaOjv1XZ4TaCg+Jdl7eAt1f0eig==",
+        "resolved": "3.1.2",
+        "contentHash": "r+8fbhwGbfelqS3ZbFkESC+B6Lwn21gv88oXtUtRLkwFkJRmtFiCZVyuom7JaHn3cP7AUw5QNyWP6PaoqsoKEQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.26.1",
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.7",
-          "Microsoft.Kiota.Authentication.Azure": "1.0.0-rc.3",
-          "Microsoft.Kiota.Http.HttpClientLibrary": "1.0.0-rc.6",
-          "Microsoft.Kiota.Serialization.Form": "1.0.0-rc.4",
-          "Microsoft.Kiota.Serialization.Json": "1.0.0-rc.3",
-          "Microsoft.Kiota.Serialization.Text": "1.0.0-rc.3",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.0.3",
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "Microsoft.Kiota.Authentication.Azure": "1.1.2",
+          "Microsoft.Kiota.Http.HttpClientLibrary": "1.3.2",
+          "Microsoft.Kiota.Serialization.Form": "1.1.1",
+          "Microsoft.Kiota.Serialization.Json": "1.1.2",
+          "Microsoft.Kiota.Serialization.Multipart": "1.1.1",
+          "Microsoft.Kiota.Serialization.Text": "1.1.1",
           "NETStandard.Library": "2.0.3",
           "System.Security.Claims": "4.3.0"
         }
@@ -278,108 +279,111 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "YE6pc6/TG1axQU5U1zGmgpcV4vKhEl4t0MTjqxdnnrorrozeBPkTECyZk9djysKTLfd8moBe7VHVpuf+jvmlkA=="
+        "resolved": "7.0.3",
+        "contentHash": "cfPUWdjigLIRIJSKz3uaZxShgf86RVDXHC1VEEchj1gnY25akwPYpbrfSoIGDCqA9UmOMdlctq411+2pAViFow=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "3n+Pdetj8JukY3hSTLiLhZHpxq9m9dai0k3OK0UrNIhaAP+N8ea5gYoFSu2gdOJELbirc5OW4oyjaTvQaefF0w==",
+        "resolved": "7.0.3",
+        "contentHash": "vxjHVZbMKD3rVdbvKhzAW+7UiFrYToUVm3AGmYfKSOAwyhdLl/ELX1KZr+FaLyyS5VReIzWRWJfbOuHM9i6ywg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "6.26.1",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encodings.Web": "4.7.2",
-          "System.Text.Json": "4.7.2"
+          "Microsoft.IdentityModel.Tokens": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "ujS5+a2L3uquqeWa3i9uNjXAfEFuDzIfKlDqZ09aKTR2M6eLqQcc0BBhh0FtJkTmsfa8GJjKDEYVcbgVzNARfQ==",
+        "resolved": "7.0.3",
+        "contentHash": "b6GbGO+2LOTBEccHhqoJsOsmemG4A/MY+8H0wK/ewRhiG+DCYwEnucog1cSArPIY55zcn+XdZl0YEiUHkpDISQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "6.26.1"
+          "Microsoft.IdentityModel.Abstractions": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Protocols": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "icZMVqD1xX9+LzrxZZoSXbmwBC5/5ckU9pYEbJjBzNFWUMBL74G0YrajM+FKcE6Q2G0730P5WbTQcKju/SrF6w==",
+        "resolved": "7.0.3",
+        "contentHash": "BtwR+tctBYhPNygyZmt1Rnw74GFrJteW+1zcdIgyvBCjkek6cNwPPqRfdhzCv61i+lwyNomRi8+iI4QKd4YCKA==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "6.26.1",
-          "Microsoft.IdentityModel.Tokens": "6.26.1"
+          "Microsoft.IdentityModel.Logging": "7.0.3",
+          "Microsoft.IdentityModel.Tokens": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "JeZSQUtjWT/+wZIMtdrdBWPSOphXE70bPxPBehYzXyRXu796DPXqT/4K6i0Z9nVqTU9anzvM8hAiypEWZDcZ+w==",
+        "resolved": "7.0.3",
+        "contentHash": "W97TraHApDNArLwpPcXfD+FZH7njJsfEwZE9y9BoofeXMS8H0LBBobz0VOmYmMK4mLdOKxzN7SFT3Ekg0FWI3Q==",
         "dependencies": {
-          "Microsoft.IdentityModel.Protocols": "6.26.1",
-          "System.IdentityModel.Tokens.Jwt": "6.26.1"
+          "Microsoft.IdentityModel.Protocols": "7.0.3",
+          "System.IdentityModel.Tokens.Jwt": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "dhUE+4uhO/JhGYYRWZynO42tZ5H2p2GeVFjCwa7gLzCWBeKowO2OEtFHG3Mq/DhBR+mp6+LzUdRkKR2kI3I+TQ==",
+        "resolved": "7.0.3",
+        "contentHash": "wB+LlbDjhnJ98DULjmFepqf9eEMh/sDs6S6hFh68iNRHmwollwhxk+nbSSfpA5+j+FbRyNskoaY4JsY1iCOKCg==",
         "dependencies": {
-          "Microsoft.CSharp": "4.5.0",
-          "Microsoft.IdentityModel.Logging": "6.26.1",
-          "System.Security.Cryptography.Cng": "4.5.0"
+          "Microsoft.IdentityModel.Logging": "7.0.3"
         }
       },
       "Microsoft.Kiota.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.7",
-        "contentHash": "RccZfwTjk/MCLtaV3N3C1u1Eh6NO0RZJ64zpJ2YkfJfr6pjrOJfhx8QVL8jGN8MToQ7gjZe8AjTvOnON5f+g7g==",
+        "resolved": "1.7.2",
+        "contentHash": "7ZxIrX23NZXqmYZyUCmjtDYnY6Wc9pkKWsItIxxSQ5Obea4xqX0AGRInxP8tsV5Z5t67RkVcM1O2zATRDJh1fA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "7.0.0",
-          "Tavis.UriTemplates": "2.0.0"
+          "Std.UriTemplate": "0.0.46",
+          "System.Diagnostics.DiagnosticSource": "[6.0.0, 9.0.0)"
         }
       },
       "Microsoft.Kiota.Authentication.Azure": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.3",
-        "contentHash": "43IxtHWTQ4jzNxMsL4NX4JQZJvxtjGYxcIB/0TolH8ZizlyxgXdBPomf5z1I/S1XXZkAp3t5HN7TkrNbhK/zow==",
+        "resolved": "1.1.2",
+        "contentHash": "Dzc6h9pSHKCJPjJ4RnEs2liL4vVO/O7Oh8XolMHB7c+4/bkdvOdWS9UYz5uMtP4Q+zgnUF3KO/0WvJSA4nbiNw==",
         "dependencies": {
-          "Azure.Core": "1.27.0",
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.4",
-          "System.Diagnostics.DiagnosticSource": "7.0.0"
+          "Azure.Core": "1.36.0",
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "System.Diagnostics.DiagnosticSource": "[6.0.1, 9.0.0)"
         }
       },
       "Microsoft.Kiota.Http.HttpClientLibrary": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.6",
-        "contentHash": "VWK7d+WTwZ6r9FUaaoazim5Dmz0fPqe4nGoDh5iI8QCweok3wT7BE0h8UX2tVwg9HNE/Yz37XIkNtXPkf1d6iA==",
+        "resolved": "1.3.2",
+        "contentHash": "ifCWjA6gFp7/77jqN38ZhyPTKNuh7kOsoS1+EjttTOsTufz54L42bJ7GK+jd0Gk4zuYjDncVBXtNSZWGbwtzgQ==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.7",
-          "System.Diagnostics.DiagnosticSource": "7.0.0",
-          "System.Text.Json": "7.0.1"
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "System.Diagnostics.DiagnosticSource": "[6.0.0, 9.0.0)",
+          "System.Text.Json": "[6.0.0, 9.0.0)"
         }
       },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.4",
-        "contentHash": "6mtoFqxn4Jt6wgNlkJVipm1QyPERO+as9dLKAX1Qc/9wNkBXPb+NfPxgsdcxuEfZcCirlYOFj3lTL3fx8pno4A==",
+        "resolved": "1.1.1",
+        "contentHash": "/j0B30rmLUoan6ckekHmPe6H0xJ3nCkn5RfgFfJkDnJiLO15N57+NTDgjGPbdwqRafQGyvJUmuON2APVZIdQhA==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.6"
+          "Microsoft.Kiota.Abstractions": "1.7.2"
         }
       },
       "Microsoft.Kiota.Serialization.Json": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.3",
-        "contentHash": "53/vdQCvCCk/1/KXQQ6495NQY5+PPs+J803npjXtZbh36R81p152aN749v7i198GlV6TUJDk7j8sCZg1opWT7w==",
+        "resolved": "1.1.2",
+        "contentHash": "n421mk9agwBeHhAkeQIwRc3bjRE4oEPM1/CTxuiUZkd8ni4PN0Tabp3PPCjsuNmqcZXLleUh2nG/JBCoRizdzA==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.6",
-          "System.Text.Json": "7.0.1"
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "System.Text.Json": "[6.0.0, 9.0.0)"
+        }
+      },
+      "Microsoft.Kiota.Serialization.Multipart": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "+31xiVWveV9/8qGlm+STiwVVN74tpwJvXq2Q2MZGDQCWZ1j+aDr4y5auOw0l1yr2nD+1jjyjU239101Pu6ECgw==",
+        "dependencies": {
+          "Microsoft.Kiota.Abstractions": "1.7.2"
         }
       },
       "Microsoft.Kiota.Serialization.Text": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.3",
-        "contentHash": "QQAR/dpb/Rg8xYkuVoUnx4HYyoMukQe+OaeWZ06NjuGXKgNyKtFziqpngIOv/RYNpmf1aeRSo5gW7M34AJ54oQ==",
+        "resolved": "1.1.1",
+        "contentHash": "6iA04gp7BhbgkLjKJ9wq+/87zI5DROSkakQ5cenlUKMUySTHkleLI7f0r57BNHi+sCtQu5Am3+h40G85yJwhug==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.6"
+          "Microsoft.Kiota.Abstractions": "1.7.2"
         }
       },
       "Microsoft.NETCore.Platforms": {
@@ -445,15 +449,6 @@
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
-      "Newtonsoft.Json.Bson": {
-        "type": "Transitive",
-        "resolved": "1.0.1",
-        "contentHash": "5PYT/IqQ+UK31AmZiSS102R6EsTo+LGTSI8bp7WAUqDKaF4wHXD8U9u4WxTI1vc64tYi++8p3dk3WWNqPFgldw==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1",
-          "Newtonsoft.Json": "10.0.1"
-        }
       },
       "NodaTime": {
         "type": "Transitive",
@@ -540,6 +535,11 @@
         "resolved": "4.0.0",
         "contentHash": "iiOsFHiZLfmUxViNKWAmLYi6xCJanKBYlxe163pkK4C+k9vnkWdCNCPouNWukn/F147k3bLq0tEFEQhlGMLqjA=="
       },
+      "Std.UriTemplate": {
+        "type": "Transitive",
+        "resolved": "0.0.46",
+        "contentHash": "/cCCMsB3i+MVt5LTbl236dnFd/BE4dKzzzC1teGTpAHzwPTiLIuD5hioGgtPuli/enAj8Dhmt/e9JlVUIITIgQ=="
+      },
       "System.Collections": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -562,8 +562,11 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "9W0ewWDuAyDqS2PigdTxk6jDKonfgscY/hP8hm7VpxYhNHZHKvZTdRckberlFk3VnCmr3xBUyMBut12Q+T2aOw=="
+        "resolved": "6.0.1",
+        "contentHash": "KiLYDu2k2J82Q9BJpWiuQqCkFjRBWVq4jDzKKWawVi9KWzyD0XG3cmfX0vqTQlL14Wi9EufJrbL0+KCLTbqWiQ==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -582,11 +585,11 @@
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
-        "resolved": "6.26.1",
-        "contentHash": "SWdMY1W8z/7XmYXrAGSH8yZKGWIpPZ1yICdfkbKh+mctb2flxzZzaSheD8XzRQhu2dtdYcKL5mnJIvZIaYBYUQ==",
+        "resolved": "7.0.3",
+        "contentHash": "caEe+OpQNYNiyZb+DJpUVROXoVySWBahko2ooNfUcllxa9ZQUM8CgM/mDjP6AoFn6cQU9xMmG+jivXWub8cbGg==",
         "dependencies": {
-          "Microsoft.IdentityModel.JsonWebTokens": "6.26.1",
-          "Microsoft.IdentityModel.Tokens": "6.26.1"
+          "Microsoft.IdentityModel.JsonWebTokens": "7.0.3",
+          "Microsoft.IdentityModel.Tokens": "7.0.3"
         }
       },
       "System.IO": {
@@ -679,8 +682,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.7.1",
-        "contentHash": "zOHkQmzPCn5zm/BH+cxC1XbUS3P4Yoi3xzW7eRgVpDR2tPGSzyMZ17Ig1iRkfJuY0nhxkQQde8pgePNiA7z7TQ=="
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
       "System.Runtime.Extensions": {
         "type": "Transitive",
@@ -715,11 +718,6 @@
           "System.Security.Principal": "4.3.0"
         }
       },
-      "System.Security.Cryptography.Cng": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "WG3r7EyjUe9CMPFSs6bty5doUqT+q9pbI80hlNzo2SkPkZ4VTuZkGWjpp77JB8+uaL4DFPRdBsAY+DX3dBK92A=="
-      },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
         "resolved": "4.7.0",
@@ -750,15 +748,19 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "OP6umVGxc0Z0MvZQBVigj4/U31Pw72ITihDWP9WiWDm+q5aoe0GaJivsfYGq53o6dxH7DcXWiCTl7+0o2CGdmg=="
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "OtDEmCCiNl8JAduFKZ/r0Sw6XZNHwIicUYy/mXgMDGeOsZLshH37qi3oPRzFYiryVktiMoQLByMGPtRCEMYbeQ==",
+        "resolved": "6.0.0",
+        "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
         "dependencies": {
-          "System.Text.Encodings.Web": "7.0.0"
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "6.0.0"
         }
       },
       "System.Threading.Tasks": {
@@ -776,18 +778,13 @@
         "resolved": "4.5.4",
         "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
-      "Tavis.UriTemplates": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GbetWNcPIaXvWtanHlBqlEp2KflFrsJf8RBNXmI8Yyeft9CSGxNrcsoKWEiEzyrn7gGVQ25ZC6ep9UfWPR0Otw=="
-      },
       "giframeworkmaps.data": {
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "[12.0.1, )",
-          "Azure.Identity": "[1.10.3, )",
+          "Azure.Identity": "[1.10.4, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Graph.Beta": "[5.19.0-preview, )",
+          "Microsoft.Graph.Beta": "[5.58.0-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[7.0.11, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime": "[7.0.11, )",

--- a/GIFrameworkMaps.Web/Authorization/ClaimsTransformer.cs
+++ b/GIFrameworkMaps.Web/Authorization/ClaimsTransformer.cs
@@ -9,12 +9,10 @@ namespace GIFrameworkMaps.Web.Authorization
 {
     public class ClaimsTransformer : IClaimsTransformation
     {
-        private readonly IConfiguration _configuration;
         private readonly ICommonRepository _commonRepository;
 
-        public ClaimsTransformer(IConfiguration configuration, ICommonRepository commonRepository)
+        public ClaimsTransformer(ICommonRepository commonRepository)
         {
-            _configuration = configuration;
             _commonRepository = commonRepository;
         }
         public Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
@@ -28,7 +26,7 @@ namespace GIFrameworkMaps.Web.Authorization
             
             foreach(var role in roles)
             {
-                Claim customRoleClaim = new Claim(claimsIdentity.RoleClaimType, role.Role.RoleName);
+                Claim customRoleClaim = new(claimsIdentity.RoleClaimType, role.Role.RoleName);
                 claimsIdentity.AddClaim(customRoleClaim);
             }
             //fetch roles from extension_roles claim

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementAnalyticsController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementAnalyticsController.cs
@@ -44,7 +44,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
         public IActionResult Create()
         {
             AnalyticsEditModel viewModel = new AnalyticsEditModel();
-            viewModel.analyticDefinition =  new AnalyticsDefinition();
+            viewModel.AnalyticDefinition =  new AnalyticsDefinition();
             RebuildEditModel(ref viewModel);
             return View(viewModel);
         }
@@ -58,17 +58,17 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 try
                 {
                     editModel.SelectedVersions = selectedVersions.ToList();
-                    editModel.analyticDefinition.DateModified = SystemClock.Instance.GetCurrentInstant();
+                    editModel.AnalyticDefinition.DateModified = SystemClock.Instance.GetCurrentInstant();
                     //Update the versions this analytic will apply to
                     foreach (int version in editModel.SelectedVersions)
                     {
-                        editModel.analyticDefinition.VersionAnalytics.Add(new VersionAnalytic
+                        editModel.AnalyticDefinition.VersionAnalytics.Add(new VersionAnalytic
                         {
                             VersionId = version,
-                            AnalyticsDefinitionId = editModel.analyticDefinition.Id
+                            AnalyticsDefinitionId = editModel.AnalyticDefinition.Id
                         });
                     }
-                    _context.Add(editModel.analyticDefinition);
+                    _context.Add(editModel.AnalyticDefinition);
                     await _context.SaveChangesAsync();
                     return RedirectToAction(nameof(Index));
                 }
@@ -82,7 +82,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             } 
             
             AnalyticsEditModel viewModel = new AnalyticsEditModel();
-            viewModel.analyticDefinition = editModel.analyticDefinition;
+            viewModel.AnalyticDefinition = editModel.AnalyticDefinition;
             RebuildEditModel(ref viewModel);
             return View(viewModel);
         }
@@ -92,7 +92,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             if (analyticRecord != null)
             {
                 AnalyticsEditModel viewModel = new AnalyticsEditModel();
-                viewModel.analyticDefinition = analyticRecord;
+                viewModel.AnalyticDefinition = analyticRecord;
                 RebuildEditModel(ref viewModel);
                 return View(viewModel);
             }
@@ -112,14 +112,14 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             try
             {
                 editModel.SelectedVersions = selectedVersions.ToList();
-                var analyticRecord = _context.AnalyticsDefinitions.Where(a => a.Id == editModel.analyticDefinition.Id).FirstOrDefault();
+                var analyticRecord = _context.AnalyticsDefinitions.Where(a => a.Id == editModel.AnalyticDefinition.Id).FirstOrDefault();
                 if (analyticRecord != null)
                 {
                     analyticRecord.DateModified = SystemClock.Instance.GetCurrentInstant();
-                    analyticRecord.ProductKey = editModel.analyticDefinition.ProductKey;
-                    analyticRecord.ProductName = editModel.analyticDefinition.ProductName;
-                    analyticRecord.CookieControl = editModel.analyticDefinition.CookieControl;
-                    analyticRecord.Enabled = editModel.analyticDefinition.Enabled;
+                    analyticRecord.ProductKey = editModel.AnalyticDefinition.ProductKey;
+                    analyticRecord.ProductName = editModel.AnalyticDefinition.ProductName;
+                    analyticRecord.CookieControl = editModel.AnalyticDefinition.CookieControl;
+                    analyticRecord.Enabled = editModel.AnalyticDefinition.Enabled;
                     UpdateVersionAnalytics(editModel, analyticRecord);
                     await _context.SaveChangesAsync();
                     return RedirectToAction(nameof(Index));
@@ -140,7 +140,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                     "contact your system administrator.");
             }
             AnalyticsEditModel viewModel = new AnalyticsEditModel();
-            viewModel.analyticDefinition = editModel.analyticDefinition;
+            viewModel.AnalyticDefinition = editModel.AnalyticDefinition;
             RebuildEditModel(ref viewModel);
             return View(viewModel);
         }
@@ -182,12 +182,12 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             string[] supportedProducts = { "Cloudflare", "Google Analytics (GA4)", "Microsoft Application Insights", "Microsoft Clarity" };
             string[] supportedCookieControls = { "Civic Cookie Control" };
 
-            model.availableProducts = new SelectList(supportedProducts);
-            model.availableCookieControl = new SelectList(supportedCookieControls);
+            model.AvailableProducts = new SelectList(supportedProducts);
+            model.AvailableCookieControl = new SelectList(supportedCookieControls);
             model.AvailableVersions = versions;
-            if (model.analyticDefinition.VersionAnalytics.Any())
+            if (model.AnalyticDefinition.VersionAnalytics.Any())
             {
-                model.SelectedVersions = model.analyticDefinition.VersionAnalytics.Select(c => c.VersionId).ToList();
+                model.SelectedVersions = model.AnalyticDefinition.VersionAnalytics.Select(c => c.VersionId).ToList();
             }
             ViewData["AllVersions"] = model.AvailableVersions;
             ViewData["SelectedVersions"] = model.SelectedVersions;
@@ -204,7 +204,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             var selectedVersionsHS = new HashSet<int>(editModel.SelectedVersions);
             //Create a HashSet of the existing list from the database
             var analyticVersions = new HashSet<int>();
-            var currentDefinition = _context.AnalyticsDefinitions.Include(ad => ad.VersionAnalytics).FirstOrDefault(a => a.Id == editModel.analyticDefinition.Id);
+            var currentDefinition = _context.AnalyticsDefinitions.Include(ad => ad.VersionAnalytics).FirstOrDefault(a => a.Id == editModel.AnalyticDefinition.Id);
             if (currentDefinition.VersionAnalytics.Any())
             {
                 analyticVersions = new HashSet<int>(currentDefinition.VersionAnalytics.Select(c => c.VersionId));
@@ -224,7 +224,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                             _contextRecord.VersionAnalytics.Add(new VersionAnalytic
                             {
                                 VersionId = id,
-                                AnalyticsDefinitionId = editModel.analyticDefinition.Id
+                                AnalyticsDefinitionId = editModel.AnalyticDefinition.Id
                             });
                         }
                     }
@@ -233,7 +233,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                         //If it is not selected but is in the database we remove it
                         if (analyticVersions.Contains(id))
                         {
-                            VersionAnalytic versionAnalyticToRemove = currentDefinition.VersionAnalytics.FirstOrDefault(i => i.VersionId == id && i.AnalyticsDefinitionId == editModel.analyticDefinition.Id);
+                            VersionAnalytic versionAnalyticToRemove = currentDefinition.VersionAnalytics.FirstOrDefault(i => i.VersionId == id && i.AnalyticsDefinitionId == editModel.AnalyticDefinition.Id);
                             _context.Remove(versionAnalyticToRemove);
                         }
                     }

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerSourceController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerSourceController.cs
@@ -93,8 +93,8 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 return NotFound();
             }
 
-            LayerSourceOption opt = new LayerSourceOption { LayerSourceId = layerSource.Id};
-            var editModel = new LayerSourceOptionEditModel { LayerSourceOption=opt, LayerSource = layerSource };
+            LayerSourceOption opt = new() { LayerSourceId = layerSource.Id};
+            LayerSourceOptionEditModel editModel = new()  { LayerSourceOption=opt, LayerSource = layerSource };
             return View(editModel);
         }
 

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementUserController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementUserController.cs
@@ -115,7 +115,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 {
                     if (!existingRolesHS.Contains(role.Id))
                     {
-                        ApplicationUserRole roleToAdd = new ApplicationUserRole() { ApplicationRoleId = role.Id, UserId = userToUpdate.Id };
+                        ApplicationUserRole roleToAdd = new() { ApplicationRoleId = role.Id, UserId = userToUpdate.Id };
                         _context.Add(roleToAdd);
                     }
                 }
@@ -153,7 +153,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 {
                     if (!existingVersionsHS.Contains(version.Id))
                     {
-                        VersionUser versionToAdd = new VersionUser() { VersionId = version.Id, UserId = userToUpdate.Id };
+                        VersionUser versionToAdd = new() { VersionId = version.Id, UserId = userToUpdate.Id };
                         _context.Add(versionToAdd);
                     }
                 }

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementVersionController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementVersionController.cs
@@ -206,9 +206,11 @@ namespace GIFrameworkMaps.Web.Controllers.Management
         // GET: Version/AddContact/1
         public async Task<IActionResult> AddContact(int id)
         {
-            VersionAddContactModel ViewModel = new VersionAddContactModel();
-            ViewModel.ContactEntry = new VersionContact { VersionId = id, VersionContactId = -1 };
-            ViewModel.ListOfUsers = await _repository.GetUsers();
+            VersionAddContactModel ViewModel = new()
+            {
+                ContactEntry = new VersionContact { VersionId = id, VersionContactId = -1 },
+                ListOfUsers = await _repository.GetUsers()
+            };
             return View(ViewModel);
         }
 
@@ -266,9 +268,11 @@ namespace GIFrameworkMaps.Web.Controllers.Management
         // GET: Version/EditContact/1?VersionContactId=1
         public async Task<IActionResult> EditContact(int id, int VersionContactId)
         {
-            VersionAddContactModel ViewModel = new VersionAddContactModel();
-            ViewModel.ContactEntry = _context.VersionContact.FirstOrDefault(u => u.VersionId == id && u.VersionContactId == VersionContactId);
-            ViewModel.ListOfUsers = await _repository.GetUsers();
+            VersionAddContactModel ViewModel = new()
+            {
+                ContactEntry = _context.VersionContact.FirstOrDefault(u => u.VersionId == id && u.VersionContactId == VersionContactId),
+                ListOfUsers = await _repository.GetUsers()
+            };
             return View("AddContact", ViewModel);
         }
 

--- a/GIFrameworkMaps.Web/GIFrameworkMaps.Web.csproj
+++ b/GIFrameworkMaps.Web/GIFrameworkMaps.Web.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.13" />
@@ -43,20 +43,20 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Graph" Version="4.54.0" />
-    <PackageReference Include="Microsoft.Graph.Beta" Version="5.19.0-preview" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="2.15.3" />
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.2.2">
+    <PackageReference Include="Microsoft.Graph" Version="5.36.0" />
+    <PackageReference Include="Microsoft.Graph.Beta" Version="5.58.0-preview" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="2.16.0" />
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.11" />
     <PackageReference Include="Npgsql" Version="7.0.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.11" />
-    <PackageReference Include="Svg" Version="3.4.5" />
+    <PackageReference Include="Svg" Version="3.4.6" />
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.1.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="7.0.11" />
-    <PackageReference Include="Yarp.ReverseProxy" Version="2.0.1" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GIFrameworkMaps.Web/Views/ManagementAnalytics/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementAnalytics/Create.cshtml
@@ -16,28 +16,28 @@
         <div class="col-md-6">
             <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
             <div class="mb-3">
-                <label asp-for="analyticDefinition.ProductName" class="control-label"></label>
-                <select asp-for="analyticDefinition.ProductName" asp-items="Model.availableProducts" class="form-select">
+                <label asp-for="AnalyticDefinition.ProductName" class="control-label"></label>
+                <select asp-for="AnalyticDefinition.ProductName" asp-items="Model.AvailableProducts" class="form-select">
                     <option value="">Please select</option>
                 </select>
-                <span asp-validation-for="analyticDefinition.ProductName" class="text-danger"></span>
+                <span asp-validation-for="AnalyticDefinition.ProductName" class="text-danger"></span>
             </div>
             <div class="mb-3">
-                <label asp-for="analyticDefinition.ProductKey" class="control-label"></label>
-                <input asp-for="analyticDefinition.ProductKey" class="form-control" />
-                <span asp-validation-for="analyticDefinition.ProductKey" class="text-danger"></span>
+                <label asp-for="AnalyticDefinition.ProductKey" class="control-label"></label>
+                <input asp-for="AnalyticDefinition.ProductKey" class="form-control" />
+                <span asp-validation-for="AnalyticDefinition.ProductKey" class="text-danger"></span>
             </div>
             <div class="mb-3">
-                <label asp-for="analyticDefinition.CookieControl" class="control-label"></label>
-                <select asp-for="analyticDefinition.CookieControl" asp-items="Model.availableCookieControl" class="form-select">
+                <label asp-for="AnalyticDefinition.CookieControl" class="control-label"></label>
+                <select asp-for="AnalyticDefinition.CookieControl" asp-items="Model.AvailableCookieControl" class="form-select">
                     <option value="">None</option>
                 </select>
-                <span asp-validation-for="analyticDefinition.CookieControl" class="text-danger"></span>
+                <span asp-validation-for="AnalyticDefinition.CookieControl" class="text-danger"></span>
             </div>
             <div class="mb-3">
-                <label asp-for="analyticDefinition.Enabled" class="control-label"></label>
-                <input asp-for="analyticDefinition.Enabled" class="form-check-input" type="checkbox" />
-                <span asp-validation-for="analyticDefinition.Enabled" class="text-danger"></span>
+                <label asp-for="AnalyticDefinition.Enabled" class="control-label"></label>
+                <input asp-for="AnalyticDefinition.Enabled" class="form-check-input" type="checkbox" />
+                <span asp-validation-for="AnalyticDefinition.Enabled" class="text-danger"></span>
             </div>
         </div>
         <div class="col-md-6">
@@ -58,8 +58,8 @@
     <div class="row mt-4">
         <div class="col-md-6">
             <div class="mb-3">
-                <input type="hidden" asp-for="analyticDefinition.Id" />
-                <input type="hidden" asp-for="analyticDefinition.DateModified" />
+                <input type="hidden" asp-for="AnalyticDefinition.Id" />
+                <input type="hidden" asp-for="AnalyticDefinition.DateModified" />
                 <div class="mb-3">
                     <input type="submit" value="Create Record" class="btn btn-primary" />
                 </div>

--- a/GIFrameworkMaps.Web/Views/ManagementAnalytics/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementAnalytics/Edit.cshtml
@@ -16,28 +16,28 @@
         <div class="col-md-6">
             <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
             <div class="mb-3">
-                <label asp-for="analyticDefinition.ProductName" class="control-label"></label>
-                <select asp-for="analyticDefinition.ProductName" asp-items="Model.availableProducts" class="form-select">
+                <label asp-for="AnalyticDefinition.ProductName" class="control-label"></label>
+                <select asp-for="AnalyticDefinition.ProductName" asp-items="Model.AvailableProducts" class="form-select">
                     <option value="">Please select</option>
                 </select>
-                <span asp-validation-for="analyticDefinition.ProductName" class="text-danger"></span>
+                <span asp-validation-for="AnalyticDefinition.ProductName" class="text-danger"></span>
             </div>
             <div class="mb-3">
-                <label asp-for="analyticDefinition.ProductKey" class="control-label"></label>
-                <input asp-for="analyticDefinition.ProductKey" class="form-control" />
-                <span asp-validation-for="analyticDefinition.ProductKey" class="text-danger"></span>
+                <label asp-for="AnalyticDefinition.ProductKey" class="control-label"></label>
+                <input asp-for="AnalyticDefinition.ProductKey" class="form-control" />
+                <span asp-validation-for="AnalyticDefinition.ProductKey" class="text-danger"></span>
             </div>
             <div class="mb-3">
-                <label asp-for="analyticDefinition.CookieControl" class="control-label"></label>
-                <select asp-for="analyticDefinition.CookieControl" asp-items="Model.availableCookieControl" class="form-select">
+                <label asp-for="AnalyticDefinition.CookieControl" class="control-label"></label>
+                <select asp-for="AnalyticDefinition.CookieControl" asp-items="Model.AvailableCookieControl" class="form-select">
                     <option value="">None</option>
                 </select>
-                <span asp-validation-for="analyticDefinition.CookieControl" class="text-danger"></span>
+                <span asp-validation-for="AnalyticDefinition.CookieControl" class="text-danger"></span>
             </div>
             <div class="mb-3">
-                <label asp-for="analyticDefinition.Enabled" class="control-label"></label>
-                <input asp-for="analyticDefinition.Enabled" class="form-check-input" type="checkbox" />
-                <span asp-validation-for="analyticDefinition.Enabled" class="text-danger"></span>
+                <label asp-for="AnalyticDefinition.Enabled" class="control-label"></label>
+                <input asp-for="AnalyticDefinition.Enabled" class="form-check-input" type="checkbox" />
+                <span asp-validation-for="AnalyticDefinition.Enabled" class="text-danger"></span>
             </div>
         </div>
         <div class="col-md-6">
@@ -58,8 +58,8 @@
     <div class="row mt-4">
         <div class="col-md-6">
             <div class="mb-3">
-                <input type="hidden" asp-for="analyticDefinition.Id" />
-                <input type="hidden" asp-for="analyticDefinition.DateModified" />
+                <input type="hidden" asp-for="AnalyticDefinition.Id" />
+                <input type="hidden" asp-for="AnalyticDefinition.DateModified" />
                 <div class="mb-3">
                     <input type="submit" value="Save Record" class="btn btn-primary" />
                 </div>

--- a/GIFrameworkMaps.Web/Views/ManagementUser/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementUser/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@model Microsoft.Graph.Beta.Models.UserCollectionResponse
+﻿@model List<Microsoft.Graph.Beta.Models.User>
 @{
     ViewData["Title"] = "Users";
 }
@@ -9,7 +9,7 @@
 <p class="lead">Manage user permissions</p>
 
 
-@if (Model != null)
+@if (Model != null && Model.Count != 0)
 {
     <table id="userTable" class="table table-bordered table-striped mt-2">
         <thead>
@@ -20,7 +20,7 @@
             </tr>
         </thead>
         <tbody>
-            @foreach (var user in Model.Value.OrderBy(u => u.DisplayName))
+            @foreach (var user in Model.OrderBy(u => u.DisplayName))
             {
                 <tr>
                     <td>@user.Id</td>

--- a/GIFrameworkMaps.Web/Views/ManagementVersion/AddContact.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementVersion/AddContact.cshtml
@@ -18,7 +18,7 @@
                     {
                     <option value="" data-abbreviations=""></option>
                     }
-                    @foreach (User user in Model.ListOfUsers.Value.OrderBy(u => u.DisplayName))
+                    @foreach (User user in Model.ListOfUsers.OrderBy(u => u.DisplayName))
                     {
                         
                         if (user.Id == Model.ContactEntry.UserId)

--- a/GIFrameworkMaps.Web/Views/ManagementVersion/ContactAlert.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementVersion/ContactAlert.cshtml
@@ -29,10 +29,10 @@
 <p>
     You can add a list of contacts for this version below and specify whether or not they should recieve messages relating to this version.
  </p>
-
+<a href="@Url.Action("AddContact", "ManagementVersion",new {Id = Model.Version.Id})" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Add a contact entry</a>
 @if (Model.Version.VersionContacts.Any())
 {
-    <a href="@Url.Action("AddContact", "ManagementVersion",new {Id = Model.Version.Id})" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Add a contact entry</a>
+
     <a href="mailto:@(mailingList)?subject=Re:%20DorsetExplorer%20version%20=%20@(Model.Version.Name)" class="btn btn-primary float-end"><i class="bi bi-envelope-at"></i> Draft an email</a>
     @if (Model.Version.VersionContacts.Count > 0){
     <table id="userTable" class="table table-bordered table-striped mt-2">
@@ -53,7 +53,7 @@
                 {
                     <tr>
                         <td>@Html.ActionLink("Edit entry", "EditContact",new {Id = Model.Version.Id, VersionContactId = user.VersionContactId})</td>
-                        <td>@Html.ActionLink(user.DisplayName, "Edit", "ManagementUser", new { id = currentUser.Id })</td>
+                        <td>@Html.ActionLink((!string.IsNullOrEmpty(user.DisplayName) ? user.DisplayName : currentUser.DisplayName), "Edit", "ManagementUser", new { id = currentUser.Id })</td>
                         <td>
                             @foreach (var mail in currentUser.OtherMails)
                             {
@@ -84,7 +84,7 @@
 }
 else
 {
-    <div class="alert alert-warning mt-1">We were unable to work out which users are associated with this version</div>
+    <div class="alert alert-info mt-1">There are no users are associated with this version yet</div>
 }
 
 

--- a/GIFrameworkMaps.Web/packages.lock.json
+++ b/GIFrameworkMaps.Web/packages.lock.json
@@ -23,11 +23,11 @@
       },
       "Azure.Extensions.AspNetCore.Configuration.Secrets": {
         "type": "Direct",
-        "requested": "[1.2.2, )",
-        "resolved": "1.2.2",
-        "contentHash": "veuqVD+Xr9/EOj9vTXBKvoh2GqObb6r+oK99L6rasJDOAJCTwwf6JqcOqXeNGnIDP0k0CcjfQSN4tY4nC7EHkg==",
+        "requested": "[1.3.0, )",
+        "resolved": "1.3.0",
+        "contentHash": "1ugCXAzxwfx/8DbOMlPbVr80++1O6xXUXtXWo7fNRmFnQC4mclDaml2H26kvhaWbof7XHnwt7/9g5dDIoU3FIw==",
         "dependencies": {
-          "Azure.Core": "1.24.0",
+          "Azure.Core": "1.35.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Microsoft.Extensions.Configuration": "2.1.0"
         }
@@ -114,36 +114,36 @@
       },
       "Microsoft.Graph": {
         "type": "Direct",
-        "requested": "[4.54.0, )",
-        "resolved": "4.54.0",
-        "contentHash": "i0YbssvaLF19OvX5wyZbrfQT9tDkMx0a7bjh7Si4KWh8gYDiJUcNO7rVxu4or89KcKpFUGEk7PjXD1Z+9ErCaw==",
+        "requested": "[5.36.0, )",
+        "resolved": "5.36.0",
+        "contentHash": "EN05EORfdRdvgC3Kyk+2fya438HypWeAP4JZi1JXr9qto0sp1ejoXA597plF3wUzaRDHlT8fW6s87oZTfdfyDw==",
         "dependencies": {
-          "Microsoft.Graph.Core": "2.0.15"
+          "Microsoft.Graph.Core": "3.1.2"
         }
       },
       "Microsoft.Graph.Beta": {
         "type": "Direct",
-        "requested": "[5.19.0-preview, )",
-        "resolved": "5.19.0-preview",
-        "contentHash": "WlxQeRuAsbgyiZxV31IKWykCekkkq3SAFUVPOeNaQalto5WdPx5EkOfCdREFNDQ9ThvrP9+InXfcZZOiZDw/dA==",
+        "requested": "[5.58.0-preview, )",
+        "resolved": "5.58.0-preview",
+        "contentHash": "C5r8Nf/yyt+HBWUxVo3gJMsFX6sbF0uYrcd5aidQJyBFcivMMBH4RzEK6FRz6/7SVAg86tjZmzEwe75vixw2Dg==",
         "dependencies": {
-          "Microsoft.Graph.Core": "3.0.0-rc.6"
+          "Microsoft.Graph.Core": "3.1.2"
         }
       },
       "Microsoft.Identity.Web.UI": {
         "type": "Direct",
-        "requested": "[2.15.3, )",
-        "resolved": "2.15.3",
-        "contentHash": "1RoJiDysqPVW0ap3TmN1X48jE2v/2+qiS7PejxPiQ5ORCta+NqRV9sdZG5BDiCKDdLnC3vY4DEfwRGYLZ3i2ww==",
+        "requested": "[2.16.0, )",
+        "resolved": "2.16.0",
+        "contentHash": "+pCvlkBZjNraSf7JY4wFCXlPnKXsqel/CqRY4sGnwOA54zGbFV+QaKsQOXeEuVYlNRoQpIpA203/m6IIPueYDw==",
         "dependencies": {
-          "Microsoft.Identity.Web": "2.15.3"
+          "Microsoft.Identity.Web": "2.16.0"
         }
       },
       "Microsoft.TypeScript.MSBuild": {
         "type": "Direct",
-        "requested": "[5.2.2, )",
-        "resolved": "5.2.2",
-        "contentHash": "anuU+9I9xKlho/N71AUEt5vU0CNNVPkQr8ISkOYnrW0gqZbeJmkfjahV71ykipngsWrIe0QxXNNJvurpEiuM7Q=="
+        "requested": "[5.3.2, )",
+        "resolved": "5.3.2",
+        "contentHash": "YZCpi5h1RKzykPr4ObCKiHwoaqapwYZa+8yMpujdCFUgc3LScujVoTHFPfYu3Z5/iIRPBi9E54cWWvuPDnBpCA=="
       },
       "Microsoft.VisualStudio.Web.CodeGeneration.Design": {
         "type": "Direct",
@@ -198,9 +198,9 @@
       },
       "Svg": {
         "type": "Direct",
-        "requested": "[3.4.5, )",
-        "resolved": "3.4.5",
-        "contentHash": "PJ5WBUhzLnrZQNuZs9CN2wEo470Htv8zs/li5jEyQyQTtSOgwgrCpvN2JAs8Gff8NgtSLeiN8jaudL0Q66/dQw==",
+        "requested": "[3.4.6, )",
+        "resolved": "3.4.6",
+        "contentHash": "Ko+N0trUmAy8Hu7vlWnh6FJ5ysyFD/5S1ymLKAZMqB+pmrC//0A8vbzWdbQl5kJbGLl5GLidREnl4QY0NFM/rA==",
         "dependencies": {
           "ExCSS": "4.2.3",
           "System.Drawing.Common": "5.0.3",
@@ -209,17 +209,19 @@
       },
       "Yarp.ReverseProxy": {
         "type": "Direct",
-        "requested": "[2.0.1, )",
-        "resolved": "2.0.1",
-        "contentHash": "op7vBwONPFeR1PYxeLw+RLqSodODDX8RWd0OinLGMVIq6yi1q9mv1j56ImuyZgiAToksiC0Dc7jbRUZ9I+jvFA==",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "VgRuCBxmh5ND4VuFhvIN3AAeoxFhYkS2hNINk6AVCrOVTlpk7OwdrTXi8NHACfqfhDL+/oYCZrF9RxN+yiYnEg==",
         "dependencies": {
+          "Microsoft.Bcl.TimeProvider": "8.0.0",
+          "System.Collections.Immutable": "8.0.0",
           "System.IO.Hashing": "7.0.0"
         }
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.35.0",
-        "contentHash": "hENcx03Jyuqv05F4RBEPbxz29UrM3Nbhnr6Wl6NQpoU9BCIbL3XLentrxDCTrH54NLS11Exxi/o8MYgT/cnKFA==",
+        "resolved": "1.36.0",
+        "contentHash": "vwqFZdHS4dzPlI7FFRkPx9ctA+aGGeRev3gnzG8lntWvKMmBhAmulABi1O9CEvS3/jzYt7yA+0pqVdxkpAd7dQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.1.1",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
@@ -232,10 +234,10 @@
       },
       "Azure.Identity": {
         "type": "Transitive",
-        "resolved": "1.10.3",
-        "contentHash": "l1Xm2MWOF2Mzcwuarlw8kWQXLZk3UeB55aQXVyjj23aBfDwOZ3gu5GP2kJ6KlmZeZv2TCzw7x4L3V36iNr3gww==",
+        "resolved": "1.10.4",
+        "contentHash": "hSvisZy9sld0Gik1X94od3+rRXCx+AKgi+iLH6fFdlnRZRePn7RtrqUGSsORiH2h8H2sc4NLTrnuUte1WL+QuQ==",
         "dependencies": {
-          "Azure.Core": "1.35.0",
+          "Azure.Core": "1.36.0",
           "Microsoft.Identity.Client": "4.56.0",
           "Microsoft.Identity.Client.Extensions.Msal": "4.56.0",
           "System.Memory": "4.5.4",
@@ -246,24 +248,24 @@
       },
       "Azure.Security.KeyVault.Certificates": {
         "type": "Transitive",
-        "resolved": "4.1.0",
-        "contentHash": "I+irkjO1JBzJWYBLhW835/b7GllxkjMbQwrirhxUJsf6FQnH+eIGin4T/jBLgyuu1zPsn2AxiUFju6Shb/uiNA==",
+        "resolved": "4.5.1",
+        "contentHash": "fUUUhs77HPVJZ1ZqKIpCo6qrYDAeol2EzpwIK1j/14HD1DKB2EIWu0FsmtNLivpc6mPI4OA+YPfJpDzu47Azuw==",
         "dependencies": {
-          "Azure.Core": "1.0.2",
-          "System.Memory": "4.5.3",
-          "System.Text.Json": "4.6.0",
-          "System.Threading.Tasks.Extensions": "4.5.2"
+          "Azure.Core": "1.30.0",
+          "System.Memory": "4.5.4",
+          "System.Text.Json": "4.7.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Azure.Security.KeyVault.Secrets": {
         "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "ujVMKVzEtVNQom5A0iEXSDovNGoSidV0RO5QlOBFfcIZlXwFnBmO5OhOfS4D/F1gbMNCCFS3re39qd/Bgh6+QQ==",
+        "resolved": "4.5.0",
+        "contentHash": "ztr26Ai4K7AZGuw68/ffLDn+2G3WL0myjC7nY1RYkxPMnsplTPEH+Ke4RGxvSkg4kC7bJ9NwdlqpEwfDX0qhdw==",
         "dependencies": {
-          "Azure.Core": "1.15.0",
+          "Azure.Core": "1.30.0",
           "System.Memory": "4.5.4",
-          "System.Text.Json": "4.6.0",
-          "System.Threading.Tasks.Extensions": "4.5.2"
+          "System.Text.Json": "4.7.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "ExCSS": {
@@ -789,27 +791,27 @@
       },
       "Microsoft.AspNetCore.Cryptography.Internal": {
         "type": "Transitive",
-        "resolved": "7.0.12",
-        "contentHash": "Dkoz1TOzucnarpOWLFiHwtASWnYT0r6FDMH9BoN9UXJD06yl1jvBk8loI92XUShoHcNJR8a+/VknqYv6yz5ssQ=="
+        "resolved": "7.0.0",
+        "contentHash": "hFF+HOqtiNrGtO5ZxLVAFo1ksDLQWf8IHEmGRmcF9azlUWvDLZp8+W8gDyLBcGcY5m3ugEvKy/ncElxO4d0NtQ=="
       },
       "Microsoft.AspNetCore.DataProtection": {
         "type": "Transitive",
-        "resolved": "7.0.12",
-        "contentHash": "hoK/oemmEyZaS5nWzY6JKKWdLJNE0t7hz1K5yA+S5k4VmQJaVdcL6w9EbYN4rdVqFqAU83J/PrO/mW6VbreyCw==",
+        "resolved": "7.0.0",
+        "contentHash": "z5ZTRZ19bOSpYWQHEE8nYD6Dg5GD70XvAfyaLM1JEkOtEvD1ePAGO+szVAvKPWELHYANMXOI96M3k4kjZ+kJoQ==",
         "dependencies": {
-          "Microsoft.AspNetCore.Cryptography.Internal": "7.0.12",
-          "Microsoft.AspNetCore.DataProtection.Abstractions": "7.0.12",
+          "Microsoft.AspNetCore.Cryptography.Internal": "7.0.0",
+          "Microsoft.AspNetCore.DataProtection.Abstractions": "7.0.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "7.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "7.0.1",
-          "Microsoft.Extensions.Options": "7.0.1",
-          "System.Security.Cryptography.Xml": "7.0.1"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
+          "System.Security.Cryptography.Xml": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.DataProtection.Abstractions": {
         "type": "Transitive",
-        "resolved": "7.0.12",
-        "contentHash": "O+tOtrqZfq8VsuPD3ArNdOO0zH8UXKxflv6ActUvvws+ZK2YTLP6XW+GllDBVPft8YE1mBAduLdt3W+6Ha82hw=="
+        "resolved": "7.0.0",
+        "contentHash": "R0QfULGA/EXvcGRclxyDi7mDvighV3SK0G2oVjw/2sN1+DfHWsgsO/F8KpfZmQRFY2y9Be8OA567Z6auak7Ikw=="
       },
       "Microsoft.AspNetCore.Hosting": {
         "type": "Transitive",
@@ -917,6 +919,14 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "f5Kr5JepAbiGo7uDmhgvMqhntwxqXNn6/IpTBSSI4cuHhgnJGrLxFRhMjVpRkLPp6zJXO0/G0l3j9p9zSJxa+w==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
       },
       "Microsoft.Build": {
         "type": "Transitive",
@@ -1269,8 +1279,8 @@
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "pkeBFx0vqMW/A3aUVHh7MPu3WkBhaVlezhSZeb1c9XD0vUReYH1TLFSy5MxJgZfmz5LZzYoErMorlYZiwpOoNA=="
+        "resolved": "7.0.0",
+        "contentHash": "kmn78+LPVMOWeITUjIlfxUPDsI0R6G0RkeAMBmQxAJ7vBJn4q2dTva7pWi65ceN5vPGjJ9q/Uae2WKgvfktJAw=="
       },
       "Microsoft.Extensions.Logging.ApplicationInsights": {
         "type": "Transitive",
@@ -1288,8 +1298,8 @@
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "pZRDYdN1FpepOIfHU62QoBQ6zdAoTvnjxFfqAzEd9Jhb2dfhA5i6jeTdgGgcgTWFRC7oT0+3XrbQu4LjvgX1Nw==",
+        "resolved": "7.0.0",
+        "contentHash": "lP1yBnTTU42cKpMozuafbvNtQ7QcBjr/CcK3bYOGEMH55Fjt+iecXjT6chR7vbgCMqy3PG3aNQSZgo/EuY/9qQ==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "7.0.0",
           "Microsoft.Extensions.Primitives": "7.0.0"
@@ -1314,16 +1324,17 @@
       },
       "Microsoft.Graph.Core": {
         "type": "Transitive",
-        "resolved": "3.0.0-rc.6",
-        "contentHash": "4bcZGi8Z6EoO09p30Q+lbTHumhGDh554lSF0dCMUcC0lzo6Gm67GanIpM+KQaOjv1XZ4TaCg+Jdl7eAt1f0eig==",
+        "resolved": "3.1.2",
+        "contentHash": "r+8fbhwGbfelqS3ZbFkESC+B6Lwn21gv88oXtUtRLkwFkJRmtFiCZVyuom7JaHn3cP7AUw5QNyWP6PaoqsoKEQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.26.1",
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.7",
-          "Microsoft.Kiota.Authentication.Azure": "1.0.0-rc.3",
-          "Microsoft.Kiota.Http.HttpClientLibrary": "1.0.0-rc.6",
-          "Microsoft.Kiota.Serialization.Form": "1.0.0-rc.4",
-          "Microsoft.Kiota.Serialization.Json": "1.0.0-rc.3",
-          "Microsoft.Kiota.Serialization.Text": "1.0.0-rc.3",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.0.3",
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "Microsoft.Kiota.Authentication.Azure": "1.1.2",
+          "Microsoft.Kiota.Http.HttpClientLibrary": "1.3.2",
+          "Microsoft.Kiota.Serialization.Form": "1.1.1",
+          "Microsoft.Kiota.Serialization.Json": "1.1.2",
+          "Microsoft.Kiota.Serialization.Multipart": "1.1.1",
+          "Microsoft.Kiota.Serialization.Text": "1.1.1",
           "NETStandard.Library": "2.0.3",
           "System.Security.Claims": "4.3.0"
         }
@@ -1353,41 +1364,38 @@
       },
       "Microsoft.Identity.Web": {
         "type": "Transitive",
-        "resolved": "2.15.3",
-        "contentHash": "VvQdUQYG0ZZtyEzRyjZxszIcc3oEUHpRT13UQiWrjcGlpp1M6vYOQOToslWt3ozK10rozvdlkLvnyY4MDP/Czw==",
+        "resolved": "2.16.0",
+        "contentHash": "+zzojhVbE3/4REXD8VORa4Y6D6PB7qfMPRyX9eDav+cMxpj5rMYxT4m0yIwVxbn6Ka0OYz/TlAoyte3HMRMp4w==",
         "dependencies": {
           "Microsoft.Extensions.Http": "3.1.3",
-          "Microsoft.Identity.Web.Certificate": "2.15.3",
-          "Microsoft.Identity.Web.Certificateless": "2.15.3",
-          "Microsoft.Identity.Web.TokenAcquisition": "2.15.3",
-          "Microsoft.Identity.Web.TokenCache": "2.15.3",
-          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.33.0",
-          "Microsoft.IdentityModel.Validators": "6.33.0",
-          "System.Drawing.Common": "4.7.2",
-          "System.IdentityModel.Tokens.Jwt": "6.33.0",
-          "System.Text.Encodings.Web": "7.0.0"
+          "Microsoft.Identity.Web.Certificate": "2.16.0",
+          "Microsoft.Identity.Web.Certificateless": "2.16.0",
+          "Microsoft.Identity.Web.TokenAcquisition": "2.16.0",
+          "Microsoft.Identity.Web.TokenCache": "2.16.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.0.3",
+          "Microsoft.IdentityModel.Validators": "7.0.3",
+          "System.IdentityModel.Tokens.Jwt": "7.0.3"
         }
       },
       "Microsoft.Identity.Web.Certificate": {
         "type": "Transitive",
-        "resolved": "2.15.3",
-        "contentHash": "0gXvLRbHb79eprdShFTMWHNBOzIQJlMziJzMbFLMvTr390RAkmY8ltE1UpxDtsN3udHyXSLyIDggOfaASAad1w==",
+        "resolved": "2.16.0",
+        "contentHash": "U04iTkH2PytI0K0PqHfXHBEMTdgQFX7z63bK5uTNZBw9YXNEtGaoay1rdtgApcJYHhosUi53dWKrtz7vuO3ghA==",
         "dependencies": {
-          "Azure.Identity": "1.10.2",
-          "Azure.Security.KeyVault.Certificates": "4.1.0",
-          "Azure.Security.KeyVault.Secrets": "4.1.0",
+          "Azure.Identity": "1.10.4",
+          "Azure.Security.KeyVault.Certificates": "4.5.1",
+          "Azure.Security.KeyVault.Secrets": "4.5.0",
           "Microsoft.Identity.Abstractions": "5.0.0",
-          "Microsoft.Identity.Web.Certificateless": "2.15.3",
-          "Microsoft.Identity.Web.Diagnostics": "2.15.3",
-          "System.Text.Encodings.Web": "7.0.0"
+          "Microsoft.Identity.Web.Certificateless": "2.16.0",
+          "Microsoft.Identity.Web.Diagnostics": "2.16.0"
         }
       },
       "Microsoft.Identity.Web.Certificateless": {
         "type": "Transitive",
-        "resolved": "2.15.3",
-        "contentHash": "IqifMnVdnAQviHC+NRzXBtwoT/KiGKkYJiWA36NIz9tQ2F4wVQzb/IIV3vJ4uASZfenJrxUkXvCLaIrVe5gZJg==",
+        "resolved": "2.16.0",
+        "contentHash": "F926iZV4L11bu9QVwDEX0ix2cI9xleE3nJo2PKgcajAlgOBYEz9paNG/G7hxMZTQWPjA7pWYzoQ5F7EZGDmCDQ==",
         "dependencies": {
-          "Azure.Identity": "1.10.2",
+          "Azure.Identity": "1.10.4",
           "Microsoft.Extensions.Logging.Abstractions": "2.1.0",
           "Microsoft.IdentityModel.JsonWebTokens": "6.33.0",
           "System.Text.Encodings.Web": "4.7.2"
@@ -1395,169 +1403,169 @@
       },
       "Microsoft.Identity.Web.Diagnostics": {
         "type": "Transitive",
-        "resolved": "2.15.3",
-        "contentHash": "lCmmeg52XquoF71ajR18DtaUFL2IjbZOyShQNGeroAfDrOBAYfawEpTmd42aCoEDVWfyBIx8Bb6xKBjA4xAiSw=="
+        "resolved": "2.16.0",
+        "contentHash": "WMk9vrNum06tZdZkxGuLwykdujDDWcex+TQyidXActxjx6ho+e/wxfRVZr1IVeW69xQT+/GF4V9+ibgWMur6Vg=="
       },
       "Microsoft.Identity.Web.TokenAcquisition": {
         "type": "Transitive",
-        "resolved": "2.15.3",
-        "contentHash": "UyNWxZSJJdaPpilhc6iF9QPlXVudLXbelmm/hyYv+XYbyPCVDIOJy2/vWPg8Uk4eR4L6vvVZhfFkaXfU98aSSw==",
+        "resolved": "2.16.0",
+        "contentHash": "lxWwYIIg1wl6v63BvEgfYfgyxW7a+XjXtL/nt6QbplA3iJm6CV3Qa7n8zPwaBbhot0jbkWeg5d9fkkEgzU0cAQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Authentication.JwtBearer": "7.0.1",
           "Microsoft.AspNetCore.Authentication.OpenIdConnect": "7.0.1",
           "Microsoft.Extensions.Http": "3.1.3",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "7.0.0",
           "Microsoft.Identity.Abstractions": "5.0.0",
-          "Microsoft.Identity.Web.Certificate": "2.15.3",
-          "Microsoft.Identity.Web.Certificateless": "2.15.3",
-          "Microsoft.Identity.Web.TokenCache": "2.15.3",
-          "Microsoft.IdentityModel.Logging": "6.33.0",
-          "Microsoft.IdentityModel.LoggingExtensions": "6.33.0",
-          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.33.0",
-          "System.IdentityModel.Tokens.Jwt": "6.33.0",
-          "System.Text.Encodings.Web": "7.0.0"
+          "Microsoft.Identity.Web.Certificate": "2.16.0",
+          "Microsoft.Identity.Web.Certificateless": "2.16.0",
+          "Microsoft.Identity.Web.TokenCache": "2.16.0",
+          "Microsoft.IdentityModel.Logging": "7.0.3",
+          "Microsoft.IdentityModel.LoggingExtensions": "7.0.3",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.0.3",
+          "System.IdentityModel.Tokens.Jwt": "7.0.3"
         }
       },
       "Microsoft.Identity.Web.TokenCache": {
         "type": "Transitive",
-        "resolved": "2.15.3",
-        "contentHash": "o69mBCsyr/lRQlb0Oc0/yqFnr8drmmVXD+ofpc6AQ9I13SBpFjB5xit+w/NXpi9wnVa9TqbX60M4RYS41hcwFQ==",
+        "resolved": "2.16.0",
+        "contentHash": "FsANa568bCqugV69Hx96jO5bQkSwiOewdLYCvQjPkzkj/252b+q3EBOiA0epxAo5JpwtO5digjF8jX/PXo5B3A==",
         "dependencies": {
-          "Microsoft.AspNetCore.DataProtection": "7.0.12",
+          "Microsoft.AspNetCore.DataProtection": "7.0.0",
           "Microsoft.Extensions.Caching.Memory": "7.0.0",
           "Microsoft.Extensions.Logging": "7.0.0",
           "Microsoft.Identity.Client": "4.57.0",
-          "Microsoft.Identity.Web.Diagnostics": "2.15.3",
-          "System.Drawing.Common": "4.7.2",
-          "System.Security.Cryptography.Pkcs": "7.0.2",
-          "System.Security.Cryptography.Xml": "7.0.1",
-          "System.Text.Encodings.Web": "7.0.0"
+          "Microsoft.Identity.Web.Diagnostics": "2.16.0",
+          "System.Security.Cryptography.Pkcs": "7.0.3",
+          "System.Security.Cryptography.Xml": "7.0.1"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "6.33.0",
-        "contentHash": "ZcR07HQRqpHkQRu5r4Lrt+BEY5PXJX3JFgVN0FyUI2PREAdi8KGiNrrH/xD4VsKNCjgldpKrJqBQ+ZmKVc0kxg=="
+        "resolved": "7.0.3",
+        "contentHash": "cfPUWdjigLIRIJSKz3uaZxShgf86RVDXHC1VEEchj1gnY25akwPYpbrfSoIGDCqA9UmOMdlctq411+2pAViFow=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "6.33.0",
-        "contentHash": "Qe4/vtpp2ws17TiI0U1NIFeDjoj+1mvXa47arHeXc+YEQ5dizggotILTeOhXuEerl7ELhc35OEPaUEPABudACA==",
+        "resolved": "7.0.3",
+        "contentHash": "vxjHVZbMKD3rVdbvKhzAW+7UiFrYToUVm3AGmYfKSOAwyhdLl/ELX1KZr+FaLyyS5VReIzWRWJfbOuHM9i6ywg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "6.33.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encodings.Web": "4.7.2",
-          "System.Text.Json": "4.7.2"
+          "Microsoft.IdentityModel.Tokens": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "6.33.0",
-        "contentHash": "Yio46NE5HL6JxjSVvUXx83Q3aXNaEmhGA/3l7xOL1SnB4dAHNo8evRJh9rUzxtSxSwll8r6RG9sbcOcUaPXI8Q==",
+        "resolved": "7.0.3",
+        "contentHash": "b6GbGO+2LOTBEccHhqoJsOsmemG4A/MY+8H0wK/ewRhiG+DCYwEnucog1cSArPIY55zcn+XdZl0YEiUHkpDISQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "6.33.0"
+          "Microsoft.IdentityModel.Abstractions": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.LoggingExtensions": {
         "type": "Transitive",
-        "resolved": "6.33.0",
-        "contentHash": "PajDo1Y+7g8RNKsuHObcqb940ASX522UpqLCnbx4mjPUIKZCPfGi0l7dKywtDkN4WFGkaOv9tdGidgurNn1oRA==",
+        "resolved": "7.0.3",
+        "contentHash": "pHE4qi0bQ2qF6iLETujdynoH8tx5poNnhprsRmGLPZGNqCxlW1E1EoGDCWQadOEy7RdI9+N4785WKxEElKHzcA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1",
-          "Microsoft.IdentityModel.Abstractions": "6.33.0"
+          "Microsoft.IdentityModel.Abstractions": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Protocols": {
         "type": "Transitive",
-        "resolved": "6.33.0",
-        "contentHash": "G63Gwg3FNQHdEtntnEquQeg3X7rz4K4sL2Y5S7W0HskOXBItYvybynjSx5L8XYTiLopmzyoZSs53rb+0GMT5Xg==",
+        "resolved": "7.0.3",
+        "contentHash": "BtwR+tctBYhPNygyZmt1Rnw74GFrJteW+1zcdIgyvBCjkek6cNwPPqRfdhzCv61i+lwyNomRi8+iI4QKd4YCKA==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "6.33.0",
-          "Microsoft.IdentityModel.Tokens": "6.33.0"
+          "Microsoft.IdentityModel.Logging": "7.0.3",
+          "Microsoft.IdentityModel.Tokens": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
         "type": "Transitive",
-        "resolved": "6.33.0",
-        "contentHash": "iNaOLnuYm8NzhXQ29zqWIaR866unnffF3EumLelcXWwvYcT8lHnxhqO4NrA0MQ40gYFFPFE8Umppaf9cXFdBHg==",
+        "resolved": "7.0.3",
+        "contentHash": "W97TraHApDNArLwpPcXfD+FZH7njJsfEwZE9y9BoofeXMS8H0LBBobz0VOmYmMK4mLdOKxzN7SFT3Ekg0FWI3Q==",
         "dependencies": {
-          "Microsoft.IdentityModel.Protocols": "6.33.0",
-          "System.IdentityModel.Tokens.Jwt": "6.33.0"
+          "Microsoft.IdentityModel.Protocols": "7.0.3",
+          "System.IdentityModel.Tokens.Jwt": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "6.33.0",
-        "contentHash": "hOcOovM/A4Q6izXVKX/iqdOPC1AtQB9b+TmQfEM1TfTgCOD4OO99LPGe9rQsEY8JupTM7vzzYrNdXuXYhtQmVA==",
+        "resolved": "7.0.3",
+        "contentHash": "wB+LlbDjhnJ98DULjmFepqf9eEMh/sDs6S6hFh68iNRHmwollwhxk+nbSSfpA5+j+FbRyNskoaY4JsY1iCOKCg==",
         "dependencies": {
-          "Microsoft.CSharp": "4.5.0",
-          "Microsoft.IdentityModel.Logging": "6.33.0",
-          "System.Security.Cryptography.Cng": "4.5.0"
+          "Microsoft.IdentityModel.Logging": "7.0.3"
         }
       },
       "Microsoft.IdentityModel.Validators": {
         "type": "Transitive",
-        "resolved": "6.33.0",
-        "contentHash": "d2OcFOuJabQm1TjHldQi+vo2Tvfqfy/ql7JOjEG67bW5b5hrsHUKpLzQKRqzMhv4kclaNhX3MPTr7e2S5M7HPg==",
+        "resolved": "7.0.3",
+        "contentHash": "+nvtDjBpvuXr2NsgsRk6B64rsbNpPMKuKhEXrPF2F/YSw5fWUjnzWf1B3hr+ia+CdcLRQYesVlDZbXF7Q0JdRA==",
         "dependencies": {
-          "Microsoft.IdentityModel.Protocols": "6.33.0",
-          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.33.0",
-          "Microsoft.IdentityModel.Tokens": "6.33.0",
-          "System.IdentityModel.Tokens.Jwt": "6.33.0"
+          "Microsoft.IdentityModel.Protocols": "7.0.3",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.0.3",
+          "Microsoft.IdentityModel.Tokens": "7.0.3",
+          "System.IdentityModel.Tokens.Jwt": "7.0.3"
         }
       },
       "Microsoft.Kiota.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.7",
-        "contentHash": "RccZfwTjk/MCLtaV3N3C1u1Eh6NO0RZJ64zpJ2YkfJfr6pjrOJfhx8QVL8jGN8MToQ7gjZe8AjTvOnON5f+g7g==",
+        "resolved": "1.7.2",
+        "contentHash": "7ZxIrX23NZXqmYZyUCmjtDYnY6Wc9pkKWsItIxxSQ5Obea4xqX0AGRInxP8tsV5Z5t67RkVcM1O2zATRDJh1fA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "7.0.0",
-          "Tavis.UriTemplates": "2.0.0"
+          "Std.UriTemplate": "0.0.46",
+          "System.Diagnostics.DiagnosticSource": "[6.0.0, 9.0.0)"
         }
       },
       "Microsoft.Kiota.Authentication.Azure": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.3",
-        "contentHash": "43IxtHWTQ4jzNxMsL4NX4JQZJvxtjGYxcIB/0TolH8ZizlyxgXdBPomf5z1I/S1XXZkAp3t5HN7TkrNbhK/zow==",
+        "resolved": "1.1.2",
+        "contentHash": "Dzc6h9pSHKCJPjJ4RnEs2liL4vVO/O7Oh8XolMHB7c+4/bkdvOdWS9UYz5uMtP4Q+zgnUF3KO/0WvJSA4nbiNw==",
         "dependencies": {
-          "Azure.Core": "1.27.0",
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.4",
-          "System.Diagnostics.DiagnosticSource": "7.0.0"
+          "Azure.Core": "1.36.0",
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "System.Diagnostics.DiagnosticSource": "[6.0.1, 9.0.0)"
         }
       },
       "Microsoft.Kiota.Http.HttpClientLibrary": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.6",
-        "contentHash": "VWK7d+WTwZ6r9FUaaoazim5Dmz0fPqe4nGoDh5iI8QCweok3wT7BE0h8UX2tVwg9HNE/Yz37XIkNtXPkf1d6iA==",
+        "resolved": "1.3.2",
+        "contentHash": "ifCWjA6gFp7/77jqN38ZhyPTKNuh7kOsoS1+EjttTOsTufz54L42bJ7GK+jd0Gk4zuYjDncVBXtNSZWGbwtzgQ==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.7",
-          "System.Diagnostics.DiagnosticSource": "7.0.0",
-          "System.Text.Json": "7.0.1"
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "System.Diagnostics.DiagnosticSource": "[6.0.0, 9.0.0)",
+          "System.Text.Json": "[6.0.0, 9.0.0)"
         }
       },
       "Microsoft.Kiota.Serialization.Form": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.4",
-        "contentHash": "6mtoFqxn4Jt6wgNlkJVipm1QyPERO+as9dLKAX1Qc/9wNkBXPb+NfPxgsdcxuEfZcCirlYOFj3lTL3fx8pno4A==",
+        "resolved": "1.1.1",
+        "contentHash": "/j0B30rmLUoan6ckekHmPe6H0xJ3nCkn5RfgFfJkDnJiLO15N57+NTDgjGPbdwqRafQGyvJUmuON2APVZIdQhA==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.6"
+          "Microsoft.Kiota.Abstractions": "1.7.2"
         }
       },
       "Microsoft.Kiota.Serialization.Json": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.3",
-        "contentHash": "53/vdQCvCCk/1/KXQQ6495NQY5+PPs+J803npjXtZbh36R81p152aN749v7i198GlV6TUJDk7j8sCZg1opWT7w==",
+        "resolved": "1.1.2",
+        "contentHash": "n421mk9agwBeHhAkeQIwRc3bjRE4oEPM1/CTxuiUZkd8ni4PN0Tabp3PPCjsuNmqcZXLleUh2nG/JBCoRizdzA==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.6",
-          "System.Text.Json": "7.0.1"
+          "Microsoft.Kiota.Abstractions": "1.7.2",
+          "System.Text.Json": "[6.0.0, 9.0.0)"
+        }
+      },
+      "Microsoft.Kiota.Serialization.Multipart": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "+31xiVWveV9/8qGlm+STiwVVN74tpwJvXq2Q2MZGDQCWZ1j+aDr4y5auOw0l1yr2nD+1jjyjU239101Pu6ECgw==",
+        "dependencies": {
+          "Microsoft.Kiota.Abstractions": "1.7.2"
         }
       },
       "Microsoft.Kiota.Serialization.Text": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc.3",
-        "contentHash": "QQAR/dpb/Rg8xYkuVoUnx4HYyoMukQe+OaeWZ06NjuGXKgNyKtFziqpngIOv/RYNpmf1aeRSo5gW7M34AJ54oQ==",
+        "resolved": "1.1.1",
+        "contentHash": "6iA04gp7BhbgkLjKJ9wq+/87zI5DROSkakQ5cenlUKMUySTHkleLI7f0r57BNHi+sCtQu5Am3+h40G85yJwhug==",
         "dependencies": {
-          "Microsoft.Kiota.Abstractions": "1.0.0-rc.6"
+          "Microsoft.Kiota.Abstractions": "1.7.2"
         }
       },
       "Microsoft.Net.Http.Headers": {
@@ -1818,6 +1826,11 @@
         "resolved": "4.0.0",
         "contentHash": "iiOsFHiZLfmUxViNKWAmLYi6xCJanKBYlxe163pkK4C+k9vnkWdCNCPouNWukn/F147k3bLq0tEFEQhlGMLqjA=="
       },
+      "Std.UriTemplate": {
+        "type": "Transitive",
+        "resolved": "0.0.46",
+        "contentHash": "/cCCMsB3i+MVt5LTbl236dnFd/BE4dKzzzC1teGTpAHzwPTiLIuD5hioGgtPuli/enAj8Dhmt/e9JlVUIITIgQ=="
+      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.0",
@@ -1840,11 +1853,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Composition": {
         "type": "Transitive",
@@ -1920,8 +1930,11 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "9W0ewWDuAyDqS2PigdTxk6jDKonfgscY/hP8hm7VpxYhNHZHKvZTdRckberlFk3VnCmr3xBUyMBut12Q+T2aOw=="
+        "resolved": "6.0.1",
+        "contentHash": "KiLYDu2k2J82Q9BJpWiuQqCkFjRBWVq4jDzKKWawVi9KWzyD0XG3cmfX0vqTQlL14Wi9EufJrbL0+KCLTbqWiQ==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "System.Diagnostics.PerformanceCounter": {
         "type": "Transitive",
@@ -1959,11 +1972,11 @@
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
-        "resolved": "6.33.0",
-        "contentHash": "wzGyqWYmD+ze1DWXeksDLcQdYyDGvEf0eJGKTrNVJLi0eZS971I+y9GxfjXHDCnBBf99rETrfVhGtqqT2HLy9A==",
+        "resolved": "7.0.3",
+        "contentHash": "caEe+OpQNYNiyZb+DJpUVROXoVySWBahko2ooNfUcllxa9ZQUM8CgM/mDjP6AoFn6cQU9xMmG+jivXWub8cbGg==",
         "dependencies": {
-          "Microsoft.IdentityModel.JsonWebTokens": "6.33.0",
-          "Microsoft.IdentityModel.Tokens": "6.33.0"
+          "Microsoft.IdentityModel.JsonWebTokens": "7.0.3",
+          "Microsoft.IdentityModel.Tokens": "7.0.3"
         }
       },
       "System.IO": {
@@ -2128,8 +2141,8 @@
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
-        "resolved": "7.0.2",
-        "contentHash": "xhFNJOcQSWhpiVGLLBQYoxAltQSQVycMkwaX1z7I7oEdT9Wr0HzSM1yeAbfoHaERIYd5s6EpLSOLs2qMchSKlA==",
+        "resolved": "7.0.3",
+        "contentHash": "yhwEHH5Gzl/VoADrXtt5XC95OFoSjNSWLHNutE7GwdOgefZVRvEXRSooSpL8HHm3qmdd9epqzsWg28UJemt22w==",
         "dependencies": {
           "System.Formats.Asn1": "7.0.0"
         }
@@ -2194,8 +2207,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "OtDEmCCiNl8JAduFKZ/r0Sw6XZNHwIicUYy/mXgMDGeOsZLshH37qi3oPRzFYiryVktiMoQLByMGPtRCEMYbeQ==",
+        "resolved": "7.0.0",
+        "contentHash": "DaGSsVqKsn/ia6RG8frjwmJonfos0srquhw09TlT8KRw5I43E+4gs+/bZj4K0vShJ5H9imCuXupb4RmS+dBy3w==",
         "dependencies": {
           "System.Text.Encodings.Web": "7.0.0"
         }
@@ -2228,18 +2241,13 @@
           "System.Drawing.Common": "6.0.0"
         }
       },
-      "Tavis.UriTemplates": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GbetWNcPIaXvWtanHlBqlEp2KflFrsJf8RBNXmI8Yyeft9CSGxNrcsoKWEiEzyrn7gGVQ25ZC6ep9UfWPR0Otw=="
-      },
       "giframeworkmaps.data": {
         "type": "Project",
         "dependencies": {
           "AutoMapper.Extensions.Microsoft.DependencyInjection": "[12.0.1, )",
-          "Azure.Identity": "[1.10.3, )",
+          "Azure.Identity": "[1.10.4, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Graph.Beta": "[5.19.0-preview, )",
+          "Microsoft.Graph.Beta": "[5.58.0-preview, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[7.0.11, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime": "[7.0.11, )",


### PR DESCRIPTION
This PR fixes the issue where the user list returned from the Graph API would only return 100 users. The `GetUsers` function in `ManagementRepository.cs` now pages through the full list of users to make sure it returns everything. It also will cache these results for 5 minutes to prevent saturating the Graph API with unnecessary requests. See commit 8337e89efbee211db5481a0aa17cbad680757e9a to see these changes in isolation.

Also in this request, code clarity and simplification suggestions from Visual Studio have been applied, and NuGet packages have been updated.

Closes #177 