### PR TITLE
Added a buffer tool

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Annotate/Annotate.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/Annotate.ts
@@ -12,6 +12,7 @@ import AnnotationStyleEvent from "./AnnotationStyleEvent";
 import {
   AnnotationTool,
   CircleTool,
+  BufferTool,
   LineTool,
   PointTool,
   PolygonTool,
@@ -79,6 +80,7 @@ export default class Annotate extends olControl {
       LineTool,
       PointTool,
       CircleTool,
+      BufferTool,
       TextTool,
     ];
 

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationDraw.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationDraw.ts
@@ -20,7 +20,10 @@ export default class AnnotationDraw extends Draw {
     annotationLayer: AnnotationLayer,
     annotationStyle: AnnotationStyle,
   ) {
-    const tip = "Click to start drawing";
+      const tip = (annotationStyle.activeTool.name === "Buffer" 
+          ? "Click to draw a buffer"
+          : "Click to start drawing"
+      );
     super({
       source: annotationLayer.getSource(),
       type: type,
@@ -127,7 +130,11 @@ export default class AnnotationDraw extends Draw {
         annotationLayer,
         popupText,
       );
-      this.tip = "Click to start drawing";
+        if (annotationStyle.activeTool.name === "Buffer") {
+            this.tip = "Click to draw a buffer";
+        } else {
+            this.tip = "Click to start drawing";
+        }
       if (
         annotationStyle.activeTool.name == "Text" &&
         annotationStyle.labelText.trim().length == 0

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationDraw.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationDraw.ts
@@ -20,10 +20,10 @@ export default class AnnotationDraw extends Draw {
     annotationLayer: AnnotationLayer,
     annotationStyle: AnnotationStyle,
   ) {
-      const tip = (annotationStyle.activeTool.name === "Buffer" 
-          ? "Click to draw a buffer"
-          : "Click to start drawing"
-      );
+    const tip = (annotationStyle.activeTool.name === "Buffer" 
+        ? "Click to draw a buffer"
+        : "Click to start drawing"
+    );
     super({
       source: annotationLayer.getSource(),
       type: type,

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationDraw.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationDraw.ts
@@ -84,10 +84,13 @@ export default class AnnotationDraw extends Draw {
       if (!annotationLayer.getVisible()) {
         annotationLayer.setVisible(true);
       }
-      let feature = e.feature;
-      if (annotationStyle.activeTool.name === 'Buffer') {
+        let feature = e.feature;
+
+    const bufferDistance = annotationStyle.radiusNumber;
+    const bufferUnit = annotationStyle.radiusUnit;
+      if (annotationStyle.activeTool.name === "Buffer") {
         //create the buffer feature
-        
+
         const formatter = new GeoJSON({
           dataProjection: "EPSG:4326",
         });
@@ -98,7 +101,7 @@ export default class AnnotationDraw extends Draw {
         );
 
         const point = turfPoint((featureGeom as Point).getCoordinates());
-        const buffer = Buffer(point, 100, { units: "meters" });
+        const buffer = Buffer(point, bufferDistance, { units: bufferUnit });
 
         const bufferedFeature = formatter.readFeature(
           buffer,
@@ -111,14 +114,18 @@ export default class AnnotationDraw extends Draw {
         feature = new Feature(bufferedGeometry);
         annotationLayer.getSource().addFeature(feature);
       }
+
       feature.setStyle(annotationStyle);
       const timestamp = new Date().toLocaleString("en-GB", { timeZone: "UTC" });
       feature.set("gifw-popup-title", `${type} added at ${timestamp}`);
-      feature.set("gifw-geometry-type", type);
+        feature.set("gifw-geometry-type", type);
+        const popupText = (annotationStyle.activeTool.name === "Buffer"
+            ? `<h1>Annotation</h1><p>Buffer of ${bufferDistance} ${bufferUnit} added at ${timestamp}</p>`
+            : `<h1>Annotation</h1><p>${type} added at ${timestamp}</p>`);
       this.addPopupOptionsToFeature(
         feature,
         annotationLayer,
-        `<h1>Annotation</h1><p>${type} added at ${timestamp}</p>`,
+        popupText,
       );
       this.tip = "Click to start drawing";
       if (

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationDraw.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationDraw.ts
@@ -1,4 +1,6 @@
-﻿import * as Condition from "ol/events/condition";
+﻿import Buffer from "@turf/buffer";
+import { point as turfPoint } from "@turf/helpers";
+import * as Condition from "ol/events/condition";
 import Feature from "ol/Feature";
 import { Draw } from "ol/interaction";
 import { Fill, Style, Text } from "ol/style";
@@ -7,6 +9,8 @@ import { GIFWPopupOptions } from "../Popups/PopupOptions";
 import Geometry, { Type as olGeomType } from "ol/geom/Geometry";
 import AnnotationLayer from "./AnnotationLayer";
 import AnnotationStyle from "./AnnotationStyle";
+import { Point, Polygon } from "ol/geom";
+import { GeoJSON } from "ol/format";
 
 export default class AnnotationDraw extends Draw {
   tip: string;
@@ -80,12 +84,39 @@ export default class AnnotationDraw extends Draw {
       if (!annotationLayer.getVisible()) {
         annotationLayer.setVisible(true);
       }
-      e.feature.setStyle(annotationStyle);
+      let feature = e.feature;
+      if (annotationStyle.activeTool.name === 'Buffer') {
+        //create the buffer feature
+        
+        const formatter = new GeoJSON({
+          dataProjection: "EPSG:4326",
+        });
+        const featureGeom = e.feature.getGeometry();
+        featureGeom.transform(
+          this.getMap().getView().getProjection(),
+          "EPSG:4326",
+        );
+
+        const point = turfPoint((featureGeom as Point).getCoordinates());
+        const buffer = Buffer(point, 100, { units: "meters" });
+
+        const bufferedFeature = formatter.readFeature(
+          buffer,
+        ) as Feature<Polygon>;
+        const bufferedGeometry = bufferedFeature.getGeometry();
+        bufferedGeometry.transform(
+          "EPSG:4326",
+          this.getMap().getView().getProjection(),
+        );
+        feature = new Feature(bufferedGeometry);
+        annotationLayer.getSource().addFeature(feature);
+      }
+      feature.setStyle(annotationStyle);
       const timestamp = new Date().toLocaleString("en-GB", { timeZone: "UTC" });
-      e.feature.set("gifw-popup-title", `${type} added at ${timestamp}`);
-      e.feature.set("gifw-geometry-type", type);
+      feature.set("gifw-popup-title", `${type} added at ${timestamp}`);
+      feature.set("gifw-geometry-type", type);
       this.addPopupOptionsToFeature(
-        e.feature,
+        feature,
         annotationLayer,
         `<h1>Annotation</h1><p>${type} added at ${timestamp}</p>`,
       );
@@ -96,7 +127,7 @@ export default class AnnotationDraw extends Draw {
       ) {
         // Do not draw a feature if the 'Add text' tool is active but no text has been specified
         setTimeout(() => {
-          annotationLayer.getSource().removeFeature(e.feature); // Unfortunately, abortDrawing() does not work properly when called by listeners of the drawstart event and a timeout is needed here to allow other events to complete, otherwise removal of the feature errors!
+          annotationLayer.getSource().removeFeature(feature); // Unfortunately, abortDrawing() does not work properly when called by listeners of the drawstart event and a timeout is needed here to allow other events to complete, otherwise removal of the feature errors!
         }, 500);
       }
     });

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationSelect.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationSelect.ts
@@ -189,11 +189,12 @@ export default class AnnotationSelect extends Select {
       this.selectedFeatures.forEach((feature) => {
         this.updateSelectionBackdrop(feature);
         if (feature.getStyle() instanceof AnnotationStyle) {
+          const style = feature.getStyle();
+          (style as AnnotationStyle).editMode = "edit";
           document.getElementById(this.gifwMapInstance.id).dispatchEvent(
             new CustomEvent("gifw-annotate-update-panel", {
               detail: {
-                    style: feature.getStyle(),
-                editMode: "edit",
+                    style: style,
               },
             }) as AnnotationStyleEvent,
           );

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationSelect.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationSelect.ts
@@ -192,7 +192,8 @@ export default class AnnotationSelect extends Select {
           document.getElementById(this.gifwMapInstance.id).dispatchEvent(
             new CustomEvent("gifw-annotate-update-panel", {
               detail: {
-                style: feature.getStyle(),
+                    style: feature.getStyle(),
+                editMode: "edit",
               },
             }) as AnnotationStyleEvent,
           );

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
@@ -17,7 +17,7 @@ export default class AnnotationStyle extends Style {
   pointType: string;
   size: number;
   radiusNumber: number;
-  radiusUnit: string;
+  radiusUnit: "meters" | "kilometers" | "miles" | "yards" | "feet";
   strokeColour: string;
   strokeColourHex: string;
   strokeStyle: "solid" | "dashed" | "dotted";
@@ -47,7 +47,7 @@ export default class AnnotationStyle extends Style {
     this.pointType = "pin";
     this.size = 24;
     this.radiusNumber = 100;
-    this.radiusUnit = "Metres";
+    this.radiusUnit = "meters";
     this.strokeStyle = "solid";
     this.strokeWidth = 2;
     this.fontFamily = "Arial";
@@ -162,7 +162,10 @@ export default class AnnotationStyle extends Style {
   public rebuildForTool(tool: AnnotationTool) {
     this.clear();
     this.activeTool = tool;
-    if (tool.name === "Buffer" || (tool.olDrawType != "Point" && tool.name != "Text")) {
+    if (
+      tool.name === "Buffer" ||
+      (tool.olDrawType != "Point" && tool.name != "Text")
+    ) {
       let lineDash: number[] | null;
       let lineCap: CanvasLineCap;
       switch (this.strokeStyle) {
@@ -176,7 +179,7 @@ export default class AnnotationStyle extends Style {
           lineDash = [1, 10];
           lineCap = "round";
           break;
-        }
+      }
       this.setFill(
         new Fill({
           color: this.fillColour,
@@ -323,5 +326,5 @@ export default class AnnotationStyle extends Style {
       e.detail.style.borderColourHex || this.borderColourHex;
     this.borderWidth = e.detail.style.borderWidth || this.borderWidth;
     this.rebuildForTool(this.activeTool);
-    }
+  }
 }

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
@@ -16,6 +16,8 @@ export default class AnnotationStyle extends Style {
   opacity: number;
   pointType: string;
   size: number;
+  radiusNumber: number;
+  radiusUnit: string;
   strokeColour: string;
   strokeColourHex: string;
   strokeStyle: "solid" | "dashed" | "dotted";
@@ -44,6 +46,8 @@ export default class AnnotationStyle extends Style {
     this.labelText = "";
     this.pointType = "pin";
     this.size = 24;
+    this.radiusNumber = 100;
+    this.radiusUnit = "Metres";
     this.strokeStyle = "solid";
     this.strokeWidth = 2;
     this.fontFamily = "Arial";
@@ -139,6 +143,8 @@ export default class AnnotationStyle extends Style {
     clone.opacity = this.opacity;
     clone.pointType = this.pointType;
     clone.size = this.size;
+    clone.radiusNumber = this.radiusNumber;
+    clone.radiusUnit = this.radiusUnit;
     clone.strokeColour = this.strokeColour;
     clone.strokeColourHex = this.strokeColourHex;
     clone.strokeStyle = this.strokeStyle;
@@ -170,7 +176,7 @@ export default class AnnotationStyle extends Style {
           lineDash = [1, 10];
           lineCap = "round";
           break;
-      }
+        }
       this.setFill(
         new Fill({
           color: this.fillColour,
@@ -293,6 +299,8 @@ export default class AnnotationStyle extends Style {
     }
     this.pointType = e.detail.style.pointType || this.pointType;
     this.size = e.detail.style.size || this.size;
+    this.radiusNumber = e.detail.style.radiusNumber || this.radiusNumber;
+    this.radiusUnit = e.detail.style.radiusUnit || this.radiusUnit;
     this.strokeColourHex =
       e.detail.style.strokeColourHex || this.strokeColourHex;
     this.strokeStyle = e.detail.style.strokeStyle || this.strokeStyle;
@@ -315,5 +323,5 @@ export default class AnnotationStyle extends Style {
       e.detail.style.borderColourHex || this.borderColourHex;
     this.borderWidth = e.detail.style.borderWidth || this.borderWidth;
     this.rebuildForTool(this.activeTool);
-  }
+    }
 }

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
@@ -26,7 +26,7 @@ export default class AnnotationStyle extends Style {
   borderColourHex: string;
   pointHasBorder: boolean;
   borderWidth: number;
-
+  editMode: "edit" | "create";
   constructor(gifwMap: GIFWMap) {
     super();
     this.gifwMapInstance = gifwMap;
@@ -55,6 +55,7 @@ export default class AnnotationStyle extends Style {
     this.borderColour = "rgb(0, 0, 0)";
     this.borderColourHex = "000000";
     this.borderWidth = 0.5;
+    this.editMode = "create";
     this.setFill(
       new Fill({
         color: this.fillColour,

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
@@ -162,7 +162,7 @@ export default class AnnotationStyle extends Style {
   public rebuildForTool(tool: AnnotationTool) {
     this.clear();
     this.activeTool = tool;
-    if (tool.olDrawType != "Point" && tool.name != "Text") {
+    if (tool.name === "Buffer" || (tool.olDrawType != "Point" && tool.name != "Text")) {
       let lineDash: number[] | null;
       let lineCap: CanvasLineCap;
       switch (this.strokeStyle) {

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyleEvent.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyleEvent.ts
@@ -3,6 +3,5 @@
 export default interface AnnotationStyleEvent extends CustomEvent {
   detail: {
       style: AnnotationStyle;
-      editMode?: "create" | "edit";
   };
 }

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyleEvent.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyleEvent.ts
@@ -2,6 +2,7 @@
 
 export default interface AnnotationStyleEvent extends CustomEvent {
   detail: {
-    style: AnnotationStyle;
+      style: AnnotationStyle;
+      editMode?: "create" | "edit";
   };
 }

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
@@ -268,7 +268,7 @@ BufferTool.optionsHTML = `
         <label class="form-label">Radius</label>
         <div class="col-sm-10 col-md-8">
             <div class="input-group mb-3">
-                <input type="text" class="form-control" id="radiusNumber" data-style-property="radiusNumber">
+                <input type="number" class="form-control" id="radiusNumber" data-style-property="radiusNumber">
                     <select class="form-select" id="radiusUnit" data-style-property="radiusUnit">
                         <option selected value="meters">Metres</option>
                         <option value="kilometers">Kilometres</option>

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
@@ -256,6 +256,71 @@ CircleTool.optionsHTML = `
     </div>
 `;
 
+export const BufferTool = new AnnotationTool(
+    "Buffer",
+    "Draw a buffer",
+    "gifw-buffer-control",
+    '<i class="bi bi-record-circle"></i>',
+    "Circle",
+);
+BufferTool.optionsHTML = `
+    <div class="form-group row mb-1">
+        <label class="form-label">Radius</label>
+        <div class="input-group mb-3">
+            <input type="text" class="form-control" id="radiusNumber">
+                <select class="form-select" id="radiusUnit">
+                    <option selected value="Metres">Metres</option>
+                    <option value="Kilometres">Kilometres</option>
+                    <option value="Miles">Miles</option>
+                    <option value="Yards">Yards</option>
+                    <option value="Feet">Feet</option>
+                </select>
+        </div>
+    </div>
+    <div class="form-group row mb-1">
+        <label class="form-label">Line colour</label>
+        <div>
+            <input type="color" class="form-range" data-style-property="strokeColour" list="annotationColors" id="colors" />
+                <datalist id="annotationColors">
+                    <option value="#648fff"></option>
+                    <option value="#785EF0"></option>
+                    <option value="#DC267F"></option>
+                    <option value="#FE6100"></option>
+                    <option value="#FFB000"></option>
+                    <option value="#000000"></option>
+                </datalist>
+        </div>
+    </div>
+    <div class="form-group row mb-1">
+        <label class="form-label">Fill colour</label>
+        <div>
+            <input type="color" class="form-range" data-style-property="fillColour" list="annotationColors" id="colors" />
+        </div>
+    </div>
+    <div class="form-group row mb-1">
+        <label class="form-label">Fill opacity</label>
+        <div>
+            <input type="range" class="form-range" data-style-property="opacity" min="0" max="1" value="0.2" step="0.1">
+        </div>
+    </div>
+    <div class="form-group row mb-1">
+        <label class="form-label">Line width</label>
+        <div>
+            <input type="range" class="form-range" data-style-property="strokeWidth" min="1" max="5" value="2">
+        </div>
+    </div>
+    <div class="form-group row mb-1">
+        <label class="form-label">Line Style</label>
+        <div>
+            <select class="form-select" data-style-property="strokeStyle">
+                <option selected value="solid">Solid</option>
+                <option value="dashed">Dashed</option>
+                <option value="dotted">Dotted</option>
+            </select>
+        </div>
+    </div>
+`;
+
 export const TextTool = new AnnotationTool(
   "Text",
   "Add text",

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
@@ -257,11 +257,11 @@ CircleTool.optionsHTML = `
 `;
 
 export const BufferTool = new AnnotationTool(
-    "Buffer",
-    "Draw a buffer",
-    "gifw-buffer-control",
-    '<i class="bi bi-record-circle"></i>',
-    "Point",
+  "Buffer",
+  "Draw a buffer",
+  "gifw-buffer-control",
+  '<i class="bi bi-record-circle"></i>',
+  "Point",
 );
 BufferTool.optionsHTML = `
     <div class="form-group row mb-1">
@@ -269,11 +269,11 @@ BufferTool.optionsHTML = `
         <div class="input-group mb-3">
             <input type="text" class="form-control" id="radiusNumber" data-style-property="radiusNumber">
                 <select class="form-select" id="radiusUnit" data-style-property="radiusUnit">
-                    <option selected value="Metres">Metres</option>
-                    <option value="Kilometres">Kilometres</option>
-                    <option value="Miles">Miles</option>
-                    <option value="Yards">Yards</option>
-                    <option value="Feet">Feet</option>
+                    <option selected value="meters">Metres</option>
+                    <option value="kilometers">Kilometres</option>
+                    <option value="miles">Miles</option>
+                    <option value="yards">Yards</option>
+                    <option value="feet">Feet</option>
                 </select>
         </div>
     </div>

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
@@ -266,15 +266,17 @@ export const BufferTool = new AnnotationTool(
 BufferTool.optionsHTML = `
     <div class="form-group row mb-1">
         <label class="form-label">Radius</label>
-        <div class="input-group mb-3">
-            <input type="text" class="form-control" id="radiusNumber" data-style-property="radiusNumber">
-                <select class="form-select" id="radiusUnit" data-style-property="radiusUnit">
-                    <option selected value="meters">Metres</option>
-                    <option value="kilometers">Kilometres</option>
-                    <option value="miles">Miles</option>
-                    <option value="yards">Yards</option>
-                    <option value="feet">Feet</option>
-                </select>
+        <div class="col-sm-10 col-md-8">
+            <div class="input-group mb-3">
+                <input type="text" class="form-control" id="radiusNumber" data-style-property="radiusNumber">
+                    <select class="form-select" id="radiusUnit" data-style-property="radiusUnit">
+                        <option selected value="meters">Metres</option>
+                        <option value="kilometers">Kilometres</option>
+                        <option value="miles">Miles</option>
+                        <option value="yards">Yards</option>
+                        <option value="feet">Feet</option>
+                    </select>
+            </div>
         </div>
     </div>
     <div class="form-group row mb-1">

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
@@ -267,8 +267,8 @@ BufferTool.optionsHTML = `
     <div class="form-group row mb-1">
         <label class="form-label">Radius</label>
         <div class="input-group mb-3">
-            <input type="text" class="form-control" id="radiusNumber">
-                <select class="form-select" id="radiusUnit">
+            <input type="text" class="form-control" id="radiusNumber" data-style-property="radiusNumber">
+                <select class="form-select" id="radiusUnit" data-style-property="radiusUnit">
                     <option selected value="Metres">Metres</option>
                     <option value="Kilometres">Kilometres</option>
                     <option value="Miles">Miles</option>

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
@@ -261,7 +261,7 @@ export const BufferTool = new AnnotationTool(
     "Draw a buffer",
     "gifw-buffer-control",
     '<i class="bi bi-record-circle"></i>',
-    "Circle",
+    "Point",
 );
 BufferTool.optionsHTML = `
     <div class="form-group row mb-1">

--- a/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
@@ -22,12 +22,12 @@ export default class AnnotationStylePanel implements SidebarPanel {
     this.render();
   }
 
-  render(editMode: "create" | "edit" = "create") {
+  render() {
     if (this.optionsPanel) {
       if (this.activeStyle) {
         this.optionsPanel.innerHTML = this.activeStyle.activeTool.optionsHTML;
 
-        this.rebuildFromStyle(this.activeStyle, true, editMode);
+        this.rebuildFromStyle(this.activeStyle, true);
       } else {
         Sidebar.close();
       }
@@ -70,7 +70,7 @@ export default class AnnotationStylePanel implements SidebarPanel {
         "gifw-annotate-update-panel",
         (e: AnnotationStyleEvent) => {
           if (e.detail?.style) {
-            this.rebuildFromStyle(e.detail.style, undefined, e.detail.editMode);
+            this.rebuildFromStyle(e.detail.style);
             sidebar.open();
           } else {
             this.activeStyle = undefined;
@@ -102,12 +102,11 @@ export default class AnnotationStylePanel implements SidebarPanel {
   private rebuildFromStyle(
     style: AnnotationStyle,
       inhibitRender: boolean = false,
-    editMode: "create" | "edit" = "create",
   ) {
     this.activeStyle = style;
     if (this.activeStyle) {
       if (!inhibitRender) {
-        this.render(editMode);
+        this.render();
         return;
       }
       if (this.optionsPanel) {
@@ -141,7 +140,7 @@ export default class AnnotationStylePanel implements SidebarPanel {
             case "radiusNumber":
               control.value = this.activeStyle.radiusNumber.toString();
                   control.setAttribute("input-text", control.value);
-                  if (editMode === "edit") {
+                  if (this.activeStyle.editMode === "edit") {
                       control.disabled = true;
                   } else {
                       control.disabled = false;

--- a/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
@@ -143,7 +143,8 @@ export default class AnnotationStylePanel implements SidebarPanel {
               control.value = this.activeStyle.size.toString();
               break;
             case "radiusNumber":
-              control.value = this.activeStyle.radiusNumber.toString();
+                  control.value = this.activeStyle.radiusNumber.toString();
+                  control.setAttribute("input-text", control.value);
               break;
             case "radiusUnit":
               control.value = this.activeStyle.radiusUnit;
@@ -185,6 +186,9 @@ export default class AnnotationStylePanel implements SidebarPanel {
             });
             if (control.getAttribute("data-style-property") == "labelText") {
               control.setAttribute("input-text", control.value); // Strangely, the text value does not get passed with the control to this.updateStyle, and so I have had to create this new attribute...
+              }
+            if (control.getAttribute("data-style-property") == "radiusNumber") {
+                control.setAttribute("input-text", control.value);
             }
             if (
               control.getAttribute("data-style-property") == "pointHasBorder"
@@ -235,7 +239,7 @@ export default class AnnotationStylePanel implements SidebarPanel {
         this.activeStyle.size = parseFloat(control.value);
         break;
       case "radiusNumber":
-         this.activeStyle.radiusNumber = parseFloat(control.value);
+         this.activeStyle.radiusNumber = parseFloat(control.getAttribute("input-text"));
         break;
       case "radiusUnit":
          this.activeStyle.radiusUnit = control.value;

--- a/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
@@ -147,7 +147,12 @@ export default class AnnotationStylePanel implements SidebarPanel {
                   }
               break;
             case "radiusUnit":
-              control.value = this.activeStyle.radiusUnit;
+                  control.value = this.activeStyle.radiusUnit;
+                  if (this.activeStyle.editMode === "edit") {
+                      control.disabled = true;
+                  } else {
+                      control.disabled = false;
+                  }
               break;
             case "strokeColour":
               control.value = `#${this.activeStyle.strokeColourHex}`;

--- a/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
@@ -142,6 +142,12 @@ export default class AnnotationStylePanel implements SidebarPanel {
             case "size":
               control.value = this.activeStyle.size.toString();
               break;
+            case "radiusNumber":
+              control.value = this.activeStyle.radiusNumber.toString();
+              break;
+            case "radiusUnit":
+              control.value = this.activeStyle.radiusUnit;
+              break;
             case "strokeColour":
               control.value = `#${this.activeStyle.strokeColourHex}`;
               break;
@@ -227,6 +233,12 @@ export default class AnnotationStylePanel implements SidebarPanel {
         break;
       case "size":
         this.activeStyle.size = parseFloat(control.value);
+        break;
+      case "radiusNumber":
+         this.activeStyle.radiusNumber = parseFloat(control.value);
+        break;
+      case "radiusUnit":
+         this.activeStyle.radiusUnit = control.value;
         break;
       case "strokeColour":
         this.activeStyle.strokeColourHex = control.value.slice(1);

--- a/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
@@ -143,8 +143,8 @@ export default class AnnotationStylePanel implements SidebarPanel {
               control.value = this.activeStyle.size.toString();
               break;
             case "radiusNumber":
-                  control.value = this.activeStyle.radiusNumber.toString();
-                  control.setAttribute("input-text", control.value);
+              control.value = this.activeStyle.radiusNumber.toString();
+              control.setAttribute("input-text", control.value);
               break;
             case "radiusUnit":
               control.value = this.activeStyle.radiusUnit;
@@ -186,9 +186,9 @@ export default class AnnotationStylePanel implements SidebarPanel {
             });
             if (control.getAttribute("data-style-property") == "labelText") {
               control.setAttribute("input-text", control.value); // Strangely, the text value does not get passed with the control to this.updateStyle, and so I have had to create this new attribute...
-              }
+            }
             if (control.getAttribute("data-style-property") == "radiusNumber") {
-                control.setAttribute("input-text", control.value);
+              control.setAttribute("input-text", control.value);
             }
             if (
               control.getAttribute("data-style-property") == "pointHasBorder"
@@ -239,10 +239,17 @@ export default class AnnotationStylePanel implements SidebarPanel {
         this.activeStyle.size = parseFloat(control.value);
         break;
       case "radiusNumber":
-         this.activeStyle.radiusNumber = parseFloat(control.getAttribute("input-text"));
+        this.activeStyle.radiusNumber = parseFloat(
+          control.getAttribute("input-text"),
+        );
         break;
       case "radiusUnit":
-         this.activeStyle.radiusUnit = control.value;
+        this.activeStyle.radiusUnit = control.value as
+          | "meters"
+          | "kilometers"
+          | "miles"
+          | "yards"
+          | "feet";
         break;
       case "strokeColour":
         this.activeStyle.strokeColourHex = control.value.slice(1);

--- a/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
@@ -22,19 +22,14 @@ export default class AnnotationStylePanel implements SidebarPanel {
     this.render();
   }
 
-  render() {
+  render(editMode: "create" | "edit" = "create") {
     if (this.optionsPanel) {
       if (this.activeStyle) {
         this.optionsPanel.innerHTML = this.activeStyle.activeTool.optionsHTML;
 
-        this.rebuildFromStyle(this.activeStyle, true);
+        this.rebuildFromStyle(this.activeStyle, true, editMode);
       } else {
         Sidebar.close();
-        //let alertDiv = document.createElement('div');
-        //alertDiv.classList.add('alert', 'alert-info');
-        //alertDiv.innerHTML = 'There are no drawing tools currently active and no annotations selected for modification. You can close this sidebar.';
-        //this.optionsPanel.innerHTML = '';
-        //this.optionsPanel.appendChild(alertDiv);
       }
     }
   }
@@ -75,7 +70,7 @@ export default class AnnotationStylePanel implements SidebarPanel {
         "gifw-annotate-update-panel",
         (e: AnnotationStyleEvent) => {
           if (e.detail?.style) {
-            this.rebuildFromStyle(e.detail.style);
+            this.rebuildFromStyle(e.detail.style, undefined, e.detail.editMode);
             sidebar.open();
           } else {
             this.activeStyle = undefined;
@@ -106,12 +101,13 @@ export default class AnnotationStylePanel implements SidebarPanel {
    */
   private rebuildFromStyle(
     style: AnnotationStyle,
-    inhibitRender: boolean = false,
+      inhibitRender: boolean = false,
+    editMode: "create" | "edit" = "create",
   ) {
     this.activeStyle = style;
     if (this.activeStyle) {
       if (!inhibitRender) {
-        this.render();
+        this.render(editMode);
         return;
       }
       if (this.optionsPanel) {
@@ -144,7 +140,12 @@ export default class AnnotationStylePanel implements SidebarPanel {
               break;
             case "radiusNumber":
               control.value = this.activeStyle.radiusNumber.toString();
-              control.setAttribute("input-text", control.value);
+                  control.setAttribute("input-text", control.value);
+                  if (editMode === "edit") {
+                      control.disabled = true;
+                  } else {
+                      control.disabled = false;
+                  }
               break;
             case "radiusUnit":
               control.value = this.activeStyle.radiusUnit;

--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -68,17 +68,20 @@
 .giframeworkMap .gifw-annotation-control.gifw-circle-control {
   left: 9.5rem;
 }
-.giframeworkMap .gifw-annotation-control.gifw-text-control {
+.giframeworkMap .gifw-annotation-control.gifw-buffer-control {
   left: 11.75rem;
 }
-.giframeworkMap .gifw-annotation-control.gifw-export-annotation-control {
+.giframeworkMap .gifw-annotation-control.gifw-text-control {
   left: 14rem;
 }
-.giframeworkMap .gifw-annotation-control.gifw-modify-annotation-control {
+.giframeworkMap .gifw-annotation-control.gifw-export-annotation-control {
   left: 16.25rem;
 }
-.giframeworkMap .gifw-annotation-control.gifw-clear-annotation-control {
+.giframeworkMap .gifw-annotation-control.gifw-modify-annotation-control {
   left: 18.5rem;
+}
+.giframeworkMap .gifw-annotation-control.gifw-clear-annotation-control {
+  left: 20.75rem;
 }
 .giframeworkMap .gifw-info-control {
   right: unset;


### PR DESCRIPTION
Following feedback from users, we have created a buffer tool so that a point can be drawn on the map with a buffer where the user can specify the size and measurement unit. The buffer tool is included with the annotation tools in the left sidebar.

![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/f651bb89-fba3-4ef7-a259-a44baba71685)

Just like with other annotation tools, the fill/stroke colours, opacity etc can be chosen to style the buffer as you like.

![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/7992686d-27a0-4799-bcf8-2c3d2809103c)

Closes #209 