### PR TITLE
Bugfix - years in attributions now display correctly

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Metadata/Metadata.ts
+++ b/GIFrameworkMaps.Web/Scripts/Metadata/Metadata.ts
@@ -369,7 +369,7 @@ export class Metadata {
           if (n.nodeName === "Attribution") {
             n.childNodes.forEach((c) => {
               if (c.nodeName === "Title") {
-                attribution = c.textContent.replace(
+                attribution = c.textContent.replaceAll(
                   "{{CURRENT_YEAR}}",
                   new Date().getFullYear().toString(),
                 );


### PR DESCRIPTION
When looking at the attribution data on layers, if there are multiple years they should now all display correctly instead of only the first instance.

Before fix:
![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/2e16ddde-7aca-42bb-bf0a-37acf912b1d8)

After fix:
![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/8797c509-7b57-46b3-b884-a82dc5ef9a80)

Closes #216 
