### PR TITLE
Allow the map to have a projection other than 3857

### DIFF
--- a/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
@@ -50,6 +50,7 @@ namespace GIFrameworkMaps.Data
             modelBuilder.Entity<VersionCategory>().HasKey(v => new { v.CategoryId, v.VersionId });
             modelBuilder.Entity<VersionAnalytic>().HasKey(v => new { v.AnalyticsDefinitionId, v.VersionId });
             modelBuilder.Entity<VersionContact>().HasKey(v => new { v.VersionContactId, v.VersionId });
+			modelBuilder.Entity<VersionProjection>().HasKey(v => new { v.ProjectionId, v.VersionId });
             modelBuilder.Entity<CategoryLayer>().HasKey(c => new { c.CategoryId, c.LayerId });
             modelBuilder.Entity<VersionSearchDefinition>().HasKey(v => new { v.SearchDefinitionId, v.VersionId });
             modelBuilder.Entity<VersionPrintConfiguration>().HasKey(v => new { v.PrintConfigurationId, v.VersionId });

--- a/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/ApplicationDbContext.cs
@@ -5,45 +5,41 @@ using Microsoft.EntityFrameworkCore;
 
 namespace GIFrameworkMaps.Data
 {
-    public class ApplicationDbContext : DbContext, IApplicationDbContext
+    public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : DbContext(options), IApplicationDbContext
     {
-        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
-            : base(options)
-        {
-        }
-
-        public virtual DbSet<Models.Version> Versions { get; set; }
-        public DbSet<Models.VersionLayer> VersionLayer { get; set; }
-        public DbSet<Models.VersionUser> VersionUser { get; set; }
-        public DbSet<Models.VersionContact> VersionContact { get; set; }
-        public DbSet<Models.VersionSearchDefinition> VersionSearchDefinition { get; set; }
+		public virtual DbSet<Version> Versions { get; set; }
+        public DbSet<VersionLayer> VersionLayer { get; set; }
+        public DbSet<VersionUser> VersionUser { get; set; }
+        public DbSet<VersionContact> VersionContact { get; set; }
+        public DbSet<VersionSearchDefinition> VersionSearchDefinition { get; set; }
         public DbSet<Models.Search.SearchDefinition> SearchDefinitions { get; set; }
         public DbSet<Models.Search.APISearchDefinition> APISearchDefinitions { get; set; }
         public DbSet<Models.Search.DatabaseSearchDefinition> DatabaseSearchDefinitions { get; set; }
         public DbSet<Models.Search.LocalSearchDefinition> LocalSearchDefinitions { get; set; }
         public DbSet<Models.Search.DatabaseSearchResult> DatabaseSearchResults { get; set; }
-        public DbSet<Models.VersionPrintConfiguration> VersionPrintConfiguration { get; set; }
+        public DbSet<VersionPrintConfiguration> VersionPrintConfiguration { get; set; }
         public DbSet<Models.Print.PrintConfiguration> PrintConfigurations { get; set; }
-        public DbSet<Models.WelcomeMessage> WelcomeMessages { get; set; }
-        public DbSet<Models.Tour.TourDetails> TourDetails { get; set; }
-        public DbSet<Models.Tour.TourStep> TourStep { get; set; }
-        public DbSet<Models.Layer> Layer { get; set; }
-        public DbSet<Models.Basemap> Basemap { get; set; }
-        public DbSet<Models.Category> Category { get; set; }
-        public DbSet<Models.CategoryLayer> CategoryLayer { get; set; }
-        public DbSet<Models.Authorization.ApplicationRole> ApplicationRoles { get; set; }
-        public DbSet<Models.Authorization.ApplicationUserRole> ApplicationUserRoles { get; set; }
-        public DbSet<Models.WebLayerServiceDefinition> WebLayerServiceDefinitions { get; set; }
-        public DbSet<Models.ProxyAllowedHost> ProxyAllowedHosts{get;set;}
-        public DbSet<Models.Attribution> Attribution { get; set; }
-        public DbSet<Models.Theme> Theme { get; set; }
-        public DbSet<Models.Bound> Bound { get; set; }
-        public DbSet<Models.LayerSource> LayerSource { get; set; }
-        public DbSet<Models.LayerSourceType> LayerSourceType { get; set; }
-        public DbSet<Models.LayerSourceOption> LayerSourceOption { get; set; }
-        public DbSet<Models.ShortLink> ShortLink { get; set; }
-        public DbSet<Models.AnalyticsDefinition> AnalyticsDefinitions { get; set; }
-        public DbSet<Models.Bookmark> Bookmarks { get; set; }
+        public DbSet<WelcomeMessage> WelcomeMessages { get; set; }
+        public DbSet<TourDetails> TourDetails { get; set; }
+        public DbSet<TourStep> TourStep { get; set; }
+        public DbSet<Layer> Layer { get; set; }
+        public DbSet<Basemap> Basemap { get; set; }
+        public DbSet<Category> Category { get; set; }
+        public DbSet<CategoryLayer> CategoryLayer { get; set; }
+        public DbSet<ApplicationRole> ApplicationRoles { get; set; }
+        public DbSet<ApplicationUserRole> ApplicationUserRoles { get; set; }
+        public DbSet<WebLayerServiceDefinition> WebLayerServiceDefinitions { get; set; }
+        public DbSet<ProxyAllowedHost> ProxyAllowedHosts{get;set;}
+        public DbSet<Attribution> Attribution { get; set; }
+        public DbSet<Theme> Theme { get; set; }
+        public DbSet<Bound> Bound { get; set; }
+        public DbSet<LayerSource> LayerSource { get; set; }
+        public DbSet<LayerSourceType> LayerSourceType { get; set; }
+        public DbSet<LayerSourceOption> LayerSourceOption { get; set; }
+        public DbSet<ShortLink> ShortLink { get; set; }
+        public DbSet<AnalyticsDefinition> AnalyticsDefinitions { get; set; }
+        public DbSet<Bookmark> Bookmarks { get; set; }
+		public DbSet<Projection> Projections { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -67,6 +63,7 @@ namespace GIFrameworkMaps.Data
             modelBuilder.Entity<Layer>().Property(l => l.ProxyMapRequests).HasDefaultValue(false);
             modelBuilder.Entity<ShortLink>().HasKey(s => new { s.ShortId });
             modelBuilder.Entity<ShortLink>().Property(s => s.Created).HasDefaultValueSql("CURRENT_TIMESTAMP");
+			modelBuilder.Entity<Projection>().HasKey(p => p.EPSGCode);
             /*Exclude DB search results from EF Migrations - https://stackoverflow.com/a/65151839/863487 */
             modelBuilder.Entity<Models.Search.DatabaseSearchResult>().HasNoKey().ToTable(nameof(DatabaseSearchResults), t => t.ExcludeFromMigrations());
         }

--- a/GIFrameworkMap.Data/Data/CommonRepository.cs
+++ b/GIFrameworkMap.Data/Data/CommonRepository.cs
@@ -95,6 +95,7 @@ namespace GIFrameworkMaps.Data
                                     .Include(v => v.Bound)
                                     .Include(v => v.Theme)
                                     .Include(v => v.WelcomeMessage)
+									.Include(v => v.MapProjection)
                                     .Include(v => v.TourDetails)
                                         .ThenInclude(t => t!.Steps)
                                     .Include(v => v.VersionBasemaps)

--- a/GIFrameworkMap.Data/Data/IApplicationDbContext.cs
+++ b/GIFrameworkMap.Data/Data/IApplicationDbContext.cs
@@ -34,5 +34,6 @@ namespace GIFrameworkMaps.Data
         DbSet<Models.ShortLink> ShortLink { get; set; }
         DbSet<Models.AnalyticsDefinition> AnalyticsDefinitions { get; set; }
         DbSet<Models.Bookmark> Bookmarks { get; set; }
+		DbSet<Models.Projection> Projections { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Data/IManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/IManagementRepository.cs
@@ -45,6 +45,8 @@ namespace GIFrameworkMaps.Data
         Task<List<LocalSearchDefinition>> GetLocalSearchDefinitions();
         Task<List<Microsoft.Graph.Beta.Models.User>> GetUsers();
         Task<Microsoft.Graph.Beta.Models.User?> GetUser(string id);
-        AnalyticsViewModel GetAnalyticsModel();
+		Task<Projection?> GetProjection(int id);
+		Task<List<Projection>> GetProjections();
+		AnalyticsViewModel GetAnalyticsModel();
     }
 }

--- a/GIFrameworkMap.Data/Data/ManagementRepository.cs
+++ b/GIFrameworkMap.Data/Data/ManagementRepository.cs
@@ -406,5 +406,21 @@ namespace GIFrameworkMaps.Data
 
             return viewModel;
         }
-    }
+
+		public async Task<Projection?> GetProjection(int id)
+		{
+			var projection = await _context.Projections.FirstOrDefaultAsync(a => a.EPSGCode == id);
+
+			return projection;
+		}
+
+		public async Task<List<Projection>> GetProjections()
+		{
+			var projections = await _context.Projections
+				.AsNoTracking()
+				.ToListAsync();
+
+			return projections;
+		}
+	}
 }

--- a/GIFrameworkMap.Data/Data/Models/AutoMapping.cs
+++ b/GIFrameworkMap.Data/Data/Models/AutoMapping.cs
@@ -50,15 +50,15 @@ namespace GIFrameworkMaps.Data
                 .ForMember(cl => cl.ProxyMetaRequests, lvm => lvm.MapFrom(s => s.Layer!.ProxyMetaRequests));
 
 			CreateMap<VersionProjection, ProjectionViewModel>()
-				.ForMember(vp => vp.EPSGCode, pvm => pvm.MapFrom(s => s.Projection.EPSGCode))
-				.ForMember(vp => vp.Name, pvm => pvm.MapFrom(s => s.Projection.Name))
-				.ForMember(vp => vp.Description, pvm => pvm.MapFrom(s => s.Projection.Description))
-				.ForMember(vp => vp.Proj4Definition, pvm => pvm.MapFrom(s => s.Projection.Proj4Definition))
-				.ForMember(vp => vp.DefaultRenderedDecimalPlaces, pvm => pvm.MapFrom(s => s.Projection.DefaultRenderedDecimalPlaces))
-				.ForMember(vp => vp.MinBoundX, pvm => pvm.MapFrom(s => s.Projection.MinBoundX))
-				.ForMember(vp => vp.MinBoundY, pvm => pvm.MapFrom(s => s.Projection.MinBoundY))
-				.ForMember(vp => vp.MaxBoundX, pvm => pvm.MapFrom(s => s.Projection.MaxBoundX))
-				.ForMember(vp => vp.MaxBoundY, pvm => pvm.MapFrom(s => s.Projection.MaxBoundY))
+				.ForMember(vp => vp.EPSGCode, pvm => pvm.MapFrom(s => s.Projection!.EPSGCode))
+				.ForMember(vp => vp.Name, pvm => pvm.MapFrom(s => s.Projection!.Name))
+				.ForMember(vp => vp.Description, pvm => pvm.MapFrom(s => s.Projection!.Description))
+				.ForMember(vp => vp.Proj4Definition, pvm => pvm.MapFrom(s => s.Projection!.Proj4Definition))
+				.ForMember(vp => vp.DefaultRenderedDecimalPlaces, pvm => pvm.MapFrom(s => s.Projection!.DefaultRenderedDecimalPlaces))
+				.ForMember(vp => vp.MinBoundX, pvm => pvm.MapFrom(s => s.Projection!.MinBoundX))
+				.ForMember(vp => vp.MinBoundY, pvm => pvm.MapFrom(s => s.Projection!.MinBoundY))
+				.ForMember(vp => vp.MaxBoundX, pvm => pvm.MapFrom(s => s.Projection!.MaxBoundX))
+				.ForMember(vp => vp.MaxBoundY, pvm => pvm.MapFrom(s => s.Projection!.MaxBoundY))
 				.ForMember(vp => vp.IsDefaultViewProjection, pvm => pvm.MapFrom(s => s.IsDefaultViewProjection))
 				.ForMember(vp => vp.IsDefaultMapProjection, pvm => pvm.MapFrom(s => s.IsDefaultMapProjection));
 

--- a/GIFrameworkMap.Data/Data/Models/AutoMapping.cs
+++ b/GIFrameworkMap.Data/Data/Models/AutoMapping.cs
@@ -49,6 +49,21 @@ namespace GIFrameworkMaps.Data
                 .ForMember(cl => cl.ProxyMapRequests, lvm => lvm.MapFrom(s => s.Layer!.ProxyMapRequests))
                 .ForMember(cl => cl.ProxyMetaRequests, lvm => lvm.MapFrom(s => s.Layer!.ProxyMetaRequests));
 
-        }
+			CreateMap<VersionProjection, ProjectionViewModel>()
+				.ForMember(vp => vp.EPSGCode, pvm => pvm.MapFrom(s => s.Projection.EPSGCode))
+				.ForMember(vp => vp.Name, pvm => pvm.MapFrom(s => s.Projection.Name))
+				.ForMember(vp => vp.Description, pvm => pvm.MapFrom(s => s.Projection.Description))
+				.ForMember(vp => vp.Proj4Definition, pvm => pvm.MapFrom(s => s.Projection.Proj4Definition))
+				.ForMember(vp => vp.MinBoundX, pvm => pvm.MapFrom(s => s.Projection.MinBoundX))
+				.ForMember(vp => vp.MinBoundY, pvm => pvm.MapFrom(s => s.Projection.MinBoundY))
+				.ForMember(vp => vp.MaxBoundX, pvm => pvm.MapFrom(s => s.Projection.MaxBoundX))
+				.ForMember(vp => vp.MaxBoundY, pvm => pvm.MapFrom(s => s.Projection.MaxBoundY))
+				.ForMember(vp => vp.IsDefaultViewProjection, pvm => pvm.MapFrom(s => s.IsDefaultViewProjection))
+				.ForMember(vp => vp.IsDefaultMapProjection, pvm => pvm.MapFrom(s => s.IsDefaultMapProjection));
+
+
+
+
+		}
     }
 }

--- a/GIFrameworkMap.Data/Data/Models/AutoMapping.cs
+++ b/GIFrameworkMap.Data/Data/Models/AutoMapping.cs
@@ -54,15 +54,13 @@ namespace GIFrameworkMaps.Data
 				.ForMember(vp => vp.Name, pvm => pvm.MapFrom(s => s.Projection.Name))
 				.ForMember(vp => vp.Description, pvm => pvm.MapFrom(s => s.Projection.Description))
 				.ForMember(vp => vp.Proj4Definition, pvm => pvm.MapFrom(s => s.Projection.Proj4Definition))
+				.ForMember(vp => vp.DefaultRenderedDecimalPlaces, pvm => pvm.MapFrom(s => s.Projection.DefaultRenderedDecimalPlaces))
 				.ForMember(vp => vp.MinBoundX, pvm => pvm.MapFrom(s => s.Projection.MinBoundX))
 				.ForMember(vp => vp.MinBoundY, pvm => pvm.MapFrom(s => s.Projection.MinBoundY))
 				.ForMember(vp => vp.MaxBoundX, pvm => pvm.MapFrom(s => s.Projection.MaxBoundX))
 				.ForMember(vp => vp.MaxBoundY, pvm => pvm.MapFrom(s => s.Projection.MaxBoundY))
 				.ForMember(vp => vp.IsDefaultViewProjection, pvm => pvm.MapFrom(s => s.IsDefaultViewProjection))
 				.ForMember(vp => vp.IsDefaultMapProjection, pvm => pvm.MapFrom(s => s.IsDefaultMapProjection));
-
-
-
 
 		}
     }

--- a/GIFrameworkMap.Data/Data/Models/Projection.cs
+++ b/GIFrameworkMap.Data/Data/Models/Projection.cs
@@ -1,0 +1,14 @@
+﻿namespace GIFrameworkMaps.Data.Models
+{
+	public class Projection
+	{
+		public int EPSGCode { get; set; }
+		public required string Name { get; set; }
+		public string? Description { get; set; }
+		public string? Proj4Definition {  get; set; }	
+		public decimal MinBoundX { get; set; }
+		public decimal MinBoundY { get; set; }
+		public decimal MaxBoundX { get; set; }
+		public decimal MaxBoundY { get; set; }
+	}
+}

--- a/GIFrameworkMap.Data/Data/Models/Projection.cs
+++ b/GIFrameworkMap.Data/Data/Models/Projection.cs
@@ -10,5 +10,6 @@
 		public decimal MinBoundY { get; set; }
 		public decimal MaxBoundX { get; set; }
 		public decimal MaxBoundY { get; set; }
+		public int DefaultRenderedDecimalPlaces { get; set; }
 	}
 }

--- a/GIFrameworkMap.Data/Data/Models/Projection.cs
+++ b/GIFrameworkMap.Data/Data/Models/Projection.cs
@@ -1,15 +1,23 @@
-﻿namespace GIFrameworkMaps.Data.Models
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace GIFrameworkMaps.Data.Models
 {
 	public class Projection
 	{
 		public int EPSGCode { get; set; }
 		public required string Name { get; set; }
 		public string? Description { get; set; }
-		public string? Proj4Definition {  get; set; }	
+		[Display(Name="Proj4 or WKT Definition")]
+		public string? Proj4Definition {  get; set; }
+		[Display(Name = "Bottom Left X (Min X)")]
 		public decimal MinBoundX { get; set; }
+		[Display(Name = "Bottom Left Y (Min Y)")]
 		public decimal MinBoundY { get; set; }
+		[Display(Name = "Top Right X (Max X)")]
 		public decimal MaxBoundX { get; set; }
+		[Display(Name = "Top Right Y (Max Y)")]
 		public decimal MaxBoundY { get; set; }
+		[Display(Name = "Default display decimal places")]
 		public int DefaultRenderedDecimalPlaces { get; set; }
 	}
 }

--- a/GIFrameworkMap.Data/Data/Models/Version.cs
+++ b/GIFrameworkMap.Data/Data/Models/Version.cs
@@ -36,8 +36,7 @@ namespace GIFrameworkMaps.Data.Models
         public int? TourDetailsId { get; set; }
         [Display(Name = "Version Notes (optional)"), MaxLength(500)]
         public string? VersionNotes { get; set; }
-		[Display(Name="Map Projection")]
-		public int? MapProjectionId { get; set; }
+		public List<VersionProjection> VersionProjections { get; set; } = [];
         public List<VersionUser> VersionUsers { get; set; } = [];
         public List<VersionBasemap> VersionBasemaps { get; set; } = [];
         public List<VersionCategory> VersionCategories { get; set; } = [];
@@ -49,6 +48,5 @@ namespace GIFrameworkMaps.Data.Models
         public virtual Theme? Theme { get; set; }
         public virtual WelcomeMessage? WelcomeMessage { get; set; }
         public virtual TourDetails? TourDetails { get; set; }
-		public virtual Projection? MapProjection { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Data/Models/Version.cs
+++ b/GIFrameworkMap.Data/Data/Models/Version.cs
@@ -36,16 +36,19 @@ namespace GIFrameworkMaps.Data.Models
         public int? TourDetailsId { get; set; }
         [Display(Name = "Version Notes (optional)"), MaxLength(500)]
         public string? VersionNotes { get; set; }
-        public List<VersionUser> VersionUsers { get; set; } = new();
-        public List<VersionBasemap> VersionBasemaps { get; set; } = new();
-        public List<VersionCategory> VersionCategories { get; set; } = new();
-        public List<VersionAnalytic> VersionAnalytics { get; set; } = new();
-        public List<VersionContact> VersionContacts { get; set; } = new();
-        public List<VersionLayer> VersionLayerCustomisations { get; set; } = new();  
+		[Display(Name="Map Projection")]
+		public int? MapProjectionId { get; set; }
+        public List<VersionUser> VersionUsers { get; set; } = [];
+        public List<VersionBasemap> VersionBasemaps { get; set; } = [];
+        public List<VersionCategory> VersionCategories { get; set; } = [];
+        public List<VersionAnalytic> VersionAnalytics { get; set; } = [];
+        public List<VersionContact> VersionContacts { get; set; } = [];
+        public List<VersionLayer> VersionLayerCustomisations { get; set; } = [];  
         //navigation properties
         public virtual Bound? Bound { get; set; }
         public virtual Theme? Theme { get; set; }
         public virtual WelcomeMessage? WelcomeMessage { get; set; }
         public virtual TourDetails? TourDetails { get; set; }
+		public virtual Projection? MapProjection { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Data/Models/VersionProjection.cs
+++ b/GIFrameworkMap.Data/Data/Models/VersionProjection.cs
@@ -6,6 +6,6 @@
 		public int ProjectionId { get; set; }
 		public bool IsDefaultMapProjection { get; set; }
 		public bool IsDefaultViewProjection {  get; set; }
-		public required Projection Projection { get; set; }
+		public Projection? Projection { get; set; }
     }
 }

--- a/GIFrameworkMap.Data/Data/Models/VersionProjection.cs
+++ b/GIFrameworkMap.Data/Data/Models/VersionProjection.cs
@@ -1,0 +1,11 @@
+﻿namespace GIFrameworkMaps.Data.Models
+{
+	public class VersionProjection
+	{
+		public int VersionId { get; set; }
+		public int ProjectionId { get; set; }
+		public bool IsDefaultMapProjection { get; set; }
+		public bool IsDefaultViewProjection {  get; set; }
+		public required Projection Projection { get; set; }
+    }
+}

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/Management/VersionEditModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/Management/VersionEditModel.cs
@@ -13,17 +13,23 @@ namespace GIFrameworkMaps.Data.Models.ViewModels.Management
         public SelectList? AvailableTours { get; set; }
         public SelectList? AvailableWelcomeMessages { get; set; }
 
-        public List<int> SelectedBasemaps { get; set; } = new();
+        public List<int> SelectedBasemaps { get; set; } = [];
         [Display(Name = "Default basemap")]
         public int DefaultBasemap { get; set; }
-        public List<Basemap> AvailableBasemaps { get; set; } = new();
+        public List<Basemap> AvailableBasemaps { get; set; } = [];
 
-        public List<int> SelectedCategories { get; set; } = new();
-        public List<Category> AvailableCategories { get; set; } = new();
+		public List<Projection> AvailableProjections { get; set; } = [];
+		[Display(Name = "Map Projection")]
+		public int MapProjection { get; set; }
+		[Display(Name = "Projection shown to users")]
+		public int ViewProjection { get; set; }
+		public List<int> SelectedProjections { get; set; } = [];
+		public List<int> SelectedCategories { get; set; } = [];
+        public List<Category> AvailableCategories { get; set; } = [];
 
         [Display(Name="Purge memory cache on save?")]
         public bool PurgeCache { get; set; }
 
-        public Dictionary<string, User> UserDetails { get; set; } = new();
+        public Dictionary<string, User> UserDetails { get; set; } = [];
     }
 }

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/ProjectionViewModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/ProjectionViewModel.cs
@@ -1,16 +1,8 @@
 ﻿
 namespace GIFrameworkMaps.Data.Models.ViewModels
 {
-	public class ProjectionViewModel
+	public class ProjectionViewModel : Projection
 	{
-		public int EPSGCode { get; set; }
-		public required string Name { get; set; }
-		public string? Description { get; set; }
-		public string? Proj4Definition { get; set; }
-		public decimal MinBoundX { get; set; }
-		public decimal MinBoundY { get; set; }
-		public decimal MaxBoundX { get; set; }
-		public decimal MaxBoundY { get; set; }
 		public bool IsDefaultMapProjection { get; set; }
 		public bool IsDefaultViewProjection { get; set; }
 	}

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/ProjectionViewModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/ProjectionViewModel.cs
@@ -1,0 +1,17 @@
+﻿
+namespace GIFrameworkMaps.Data.Models.ViewModels
+{
+	public class ProjectionViewModel
+	{
+		public int EPSGCode { get; set; }
+		public required string Name { get; set; }
+		public string? Description { get; set; }
+		public string? Proj4Definition { get; set; }
+		public decimal MinBoundX { get; set; }
+		public decimal MinBoundY { get; set; }
+		public decimal MaxBoundX { get; set; }
+		public decimal MaxBoundY { get; set; }
+		public bool IsDefaultMapProjection { get; set; }
+		public bool IsDefaultViewProjection { get; set; }
+	}
+}

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/VersionViewModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/VersionViewModel.cs
@@ -18,6 +18,7 @@ namespace GIFrameworkMaps.Data.Models.ViewModels
         public Bound? Bound { get; set; }
         public WelcomeMessage? WelcomeMessage { get; set; }
         public TourDetails? TourDetails { get; set; }
+		public Projection? MapProjection { get; set; }
         public string? AppRoot { get; set; }
         public string? GoogleMapsAPIKey { get; set; }
         public bool IsLoggedIn { get; set; }

--- a/GIFrameworkMap.Data/Data/Models/ViewModels/VersionViewModel.cs
+++ b/GIFrameworkMap.Data/Data/Models/ViewModels/VersionViewModel.cs
@@ -9,8 +9,8 @@ namespace GIFrameworkMaps.Data.Models.ViewModels
         public string? Name { get; set; }
         public string? Description { get; set; }
         public string? Slug { get; set; }
-        public List<CategoryViewModel> Categories { get; set; } = new();
-        public List<BasemapViewModel> Basemaps { get; set; } = new();
+        public List<CategoryViewModel> Categories { get; set; } = [];
+        public List<BasemapViewModel> Basemaps { get; set; } = [];
         public string? HelpURL { get; set; }
         public string? FeedbackURL { get; set; }
         public bool ShowLogin { get; set; }
@@ -18,7 +18,7 @@ namespace GIFrameworkMaps.Data.Models.ViewModels
         public Bound? Bound { get; set; }
         public WelcomeMessage? WelcomeMessage { get; set; }
         public TourDetails? TourDetails { get; set; }
-		public Projection? MapProjection { get; set; }
+		public List<ProjectionViewModel> AvailableProjections { get; set; } = [];
         public string? AppRoot { get; set; }
         public string? GoogleMapsAPIKey { get; set; }
         public bool IsLoggedIn { get; set; }

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240119144621_AddProjectionTable.Designer.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240119144621_AddProjectionTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GIFrameworkMaps.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240119144621_AddProjectionTable")]
+    partial class AddProjectionTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -424,18 +427,6 @@ namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 
                     b.Property<string>("Description")
                         .HasColumnType("text");
-
-                    b.Property<decimal>("MaxBoundX")
-                        .HasColumnType("numeric");
-
-                    b.Property<decimal>("MaxBoundY")
-                        .HasColumnType("numeric");
-
-                    b.Property<decimal>("MinBoundX")
-                        .HasColumnType("numeric");
-
-                    b.Property<decimal>("MinBoundY")
-                        .HasColumnType("numeric");
 
                     b.Property<string>("Name")
                         .IsRequired()

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240119144621_AddProjectionTable.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240119144621_AddProjectionTable.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddProjectionTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Discriminator",
+                schema: "giframeworkmaps",
+                table: "SearchDefinitions",
+                type: "character varying(34)",
+                maxLength: 34,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.CreateTable(
+                name: "Projections",
+                schema: "giframeworkmaps",
+                columns: table => new
+                {
+                    EPSGCode = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    Proj4Definition = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Projections", x => x.EPSGCode);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Versions_MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions",
+                column: "MapProjectionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Versions_Projections_MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions",
+                column: "MapProjectionId",
+                principalSchema: "giframeworkmaps",
+                principalTable: "Projections",
+                principalColumn: "EPSGCode");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Versions_Projections_MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions");
+
+            migrationBuilder.DropTable(
+                name: "Projections",
+                schema: "giframeworkmaps");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Versions_MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions");
+
+            migrationBuilder.DropColumn(
+                name: "MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Discriminator",
+                schema: "giframeworkmaps",
+                table: "SearchDefinitions",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(34)",
+                oldMaxLength: 34);
+        }
+    }
+}

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240124163628_AddBoundsToProjection.Designer.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240124163628_AddBoundsToProjection.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GIFrameworkMaps.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240124163628_AddBoundsToProjection")]
+    partial class AddBoundsToProjection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240124163628_AddBoundsToProjection.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240124163628_AddBoundsToProjection.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddBoundsToProjection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "MaxBoundX",
+                schema: "giframeworkmaps",
+                table: "Projections",
+                type: "numeric",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "MaxBoundY",
+                schema: "giframeworkmaps",
+                table: "Projections",
+                type: "numeric",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "MinBoundX",
+                schema: "giframeworkmaps",
+                table: "Projections",
+                type: "numeric",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "MinBoundY",
+                schema: "giframeworkmaps",
+                table: "Projections",
+                type: "numeric",
+                nullable: false,
+                defaultValue: 0m);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaxBoundX",
+                schema: "giframeworkmaps",
+                table: "Projections");
+
+            migrationBuilder.DropColumn(
+                name: "MaxBoundY",
+                schema: "giframeworkmaps",
+                table: "Projections");
+
+            migrationBuilder.DropColumn(
+                name: "MinBoundX",
+                schema: "giframeworkmaps",
+                table: "Projections");
+
+            migrationBuilder.DropColumn(
+                name: "MinBoundY",
+                schema: "giframeworkmaps",
+                table: "Projections");
+        }
+    }
+}

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240205161742_AddProjectionListToVersion.Designer.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240205161742_AddProjectionListToVersion.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GIFrameworkMaps.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240205161742_AddProjectionListToVersion")]
+    partial class AddProjectionListToVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240205161742_AddProjectionListToVersion.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240205161742_AddProjectionListToVersion.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddProjectionListToVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Versions_Projections_MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Versions_MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions");
+
+            migrationBuilder.DropColumn(
+                name: "MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions");
+
+            migrationBuilder.CreateTable(
+                name: "VersionProjection",
+                schema: "giframeworkmaps",
+                columns: table => new
+                {
+                    VersionId = table.Column<int>(type: "integer", nullable: false),
+                    ProjectionId = table.Column<int>(type: "integer", nullable: false),
+                    IsDefaultMapProjection = table.Column<bool>(type: "boolean", nullable: false),
+                    IsDefaultViewProjection = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VersionProjection", x => new { x.ProjectionId, x.VersionId });
+                    table.ForeignKey(
+                        name: "FK_VersionProjection_Projections_ProjectionId",
+                        column: x => x.ProjectionId,
+                        principalSchema: "giframeworkmaps",
+                        principalTable: "Projections",
+                        principalColumn: "EPSGCode",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_VersionProjection_Versions_VersionId",
+                        column: x => x.VersionId,
+                        principalSchema: "giframeworkmaps",
+                        principalTable: "Versions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VersionProjection_VersionId",
+                schema: "giframeworkmaps",
+                table: "VersionProjection",
+                column: "VersionId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "VersionProjection",
+                schema: "giframeworkmaps");
+
+            migrationBuilder.AddColumn<int>(
+                name: "MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Versions_MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions",
+                column: "MapProjectionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Versions_Projections_MapProjectionId",
+                schema: "giframeworkmaps",
+                table: "Versions",
+                column: "MapProjectionId",
+                principalSchema: "giframeworkmaps",
+                principalTable: "Projections",
+                principalColumn: "EPSGCode");
+        }
+    }
+}

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240222102051_AddDecimalsToProjection.Designer.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240222102051_AddDecimalsToProjection.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GIFrameworkMaps.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240222102051_AddDecimalsToProjection")]
+    partial class AddDecimalsToProjection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240222102051_AddDecimalsToProjection.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240222102051_AddDecimalsToProjection.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddDecimalsToProjection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "DefaultRenderedDecimalPlaces",
+                schema: "giframeworkmaps",
+                table: "Projections",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DefaultRenderedDecimalPlaces",
+                schema: "giframeworkmaps",
+                table: "Projections");
+        }
+    }
+}

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerWizardController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerWizardController.cs
@@ -123,7 +123,6 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             {
                 try
                 {
-
                     var urlOpt = new LayerSourceOption { Name = "url", Value = model.BaseURL };
                     var paramsOpt = new LayerSourceOption
                     {
@@ -132,13 +131,13 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                         @$"{{
                                 ""LAYERS"":""{model.LayerName}"", 
                                 ""FORMAT"":""{model.Format}"",
-                                ""CRS"": ""{model.Projection}"",
-                                ""VERSION"": ""{model.Version}""
+                                {(!string.IsNullOrEmpty(model.Projection) ? @$"""CRS"": ""{model.Projection}""," : "")}
+								""VERSION"": ""{model.Version}""
                             }}"
                     };
                     model.LayerSource.LayerSourceOptions.Add(urlOpt);
                     model.LayerSource.LayerSourceOptions.Add(paramsOpt);
-                    if(model.Projection != "EPSG:3857")
+                    if(!string.IsNullOrEmpty(model.Projection))
                     {
                         model.LayerSource.LayerSourceOptions.Add(new LayerSourceOption { Name = "projection", Value = model.Projection });
                     }

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementProjectionController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementProjectionController.cs
@@ -1,0 +1,162 @@
+﻿using GIFrameworkMaps.Data;
+using GIFrameworkMaps.Data.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace GIFrameworkMaps.Web.Controllers.Management
+{
+    [Authorize(Roles = "GIFWAdmin")]
+    public class ManagementProjectionController : Controller
+    {
+        //dependancy injection
+        /*NOTE: A repository pattern is used for much basic data access across the project
+         * however, write and update are done directly on the context based on the advice here
+         * https://learn.microsoft.com/en-us/aspnet/mvc/overview/getting-started/getting-started-with-ef-using-mvc/advanced-entity-framework-scenarios-for-an-mvc-web-application#create-an-abstraction-layer
+         * */
+        private readonly ILogger<ManagementProjectionController> _logger;
+        private readonly IManagementRepository _repository;
+        private readonly ApplicationDbContext _context;
+        public ManagementProjectionController(
+            ILogger<ManagementProjectionController> logger,
+            IManagementRepository repository,
+            ApplicationDbContext context
+            )
+        {
+            _logger = logger;
+            _repository = repository;
+            _context = context;
+        }
+
+        // GET: Projection
+        public async Task<IActionResult> Index()
+        {
+            var projections = await _repository.GetProjections();
+            return View(projections);
+        }
+
+		// GET: Projection/Register
+		public IActionResult Register()
+        {
+            return View();
+        }
+
+		//POST: Projection/Create
+		[HttpPost, ActionName("Register")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> RegisterPost(Projection projection)
+        {
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Add(projection);
+                    await _context.SaveChangesAsync();
+                    TempData["Message"] = "New projection registered";
+                    TempData["MessageType"] = "success";
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogError(ex, "Projection registration failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            return View(projection);
+        }
+
+		// GET: projection/Edit/1
+		public async Task<IActionResult> Edit(int id)
+        {
+            var projection = await _repository.GetProjection(id);
+
+            if (projection == null)
+            {
+                return NotFound();
+            }
+
+            return View(projection);
+        }
+
+		// POST: projection/Edit/1
+		[HttpPost, ActionName("Edit")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> EditPost(int id)
+        {
+            var projectionToUpdate = await _context.Projections.FirstOrDefaultAsync(a => a.EPSGCode == id);
+
+            if (await TryUpdateModelAsync(
+				projectionToUpdate,
+                "",
+                a => a.Name, 
+                a => a.Description, 
+                a => a.MaxBoundX,
+				a => a.MaxBoundY,
+				a => a.MinBoundX,
+				a => a.MinBoundY,
+				a => a.DefaultRenderedDecimalPlaces,
+				a => a.Proj4Definition))
+            {
+
+                try
+                {
+                    await _context.SaveChangesAsync();
+                    TempData["Message"] = "Projection definition edited";
+                    TempData["MessageType"] = "success";
+                    return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex )
+                {
+                    _logger.LogError(ex, "Projection definition edit failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+            }
+            return View(projectionToUpdate);
+        }
+
+		// GET: projection/Delete/1
+		public async Task<IActionResult> Delete(int id)
+        {
+            var projection = await _repository.GetProjection(id);
+
+            if (projection == null)
+            {
+                return NotFound();
+            }
+
+            return View(projection);
+        }
+
+		// POST: projection/Delete/1
+		[HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirm(int id)
+        {
+            var projectionToDelete = await _context.Projections.FirstOrDefaultAsync(a => a.EPSGCode == id);
+           
+                try
+                {
+                    _context.Projections.Remove(projectionToDelete);
+                    await _context.SaveChangesAsync();
+                TempData["Message"] = "Projection definition deleted";
+                TempData["MessageType"] = "success";
+                return RedirectToAction(nameof(Index));
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogError(ex, "Projection delete failed");
+                    ModelState.AddModelError("", "Unable to save changes. " +
+                        "Try again, and if the problem persists, " +
+                        "contact your system administrator.");
+                }
+           
+            return View(projectionToDelete);
+        }
+    }
+}

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementSystemController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementSystemController.cs
@@ -25,11 +25,6 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             return View();
         }
 
-        public IActionResult Cache()
-        {
-            return View();
-        }
-
         [HttpPost]
         public IActionResult PurgeCache()
         {
@@ -43,5 +38,5 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             TempData["MessageType"] = success ? "success" : "error";
             return RedirectToAction("Index");
         }
-    }
+	}
 }

--- a/GIFrameworkMaps.Web/Filters/UnwantedTelemetryFilter.cs
+++ b/GIFrameworkMaps.Web/Filters/UnwantedTelemetryFilter.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace GIFrameworkMaps.Web.Filters
+{
+	public class UnwantedTelemetryFilter(ITelemetryProcessor next) : ITelemetryProcessor
+	{
+		private ITelemetryProcessor Next { get; set; } = next;
+
+		public void Process(ITelemetry item)
+		{
+			if (item is RequestTelemetry request && request.Name != null)
+				if (request.Name.Contains("broadcasthub"))
+					return;
+
+			// Send everything else:
+			Next.Process(item);
+		}
+	}
+}

--- a/GIFrameworkMaps.Web/GIFrameworkMaps.Web.csproj
+++ b/GIFrameworkMaps.Web/GIFrameworkMaps.Web.csproj
@@ -88,4 +88,11 @@
     <_ContentIncludedByDefault Remove="Views\ManagementLayer\ListTemplateHelperPartial.cshtml" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="Views\Shared\ManagementPartials\VersionProjectionList.cshtml">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/GIFrameworkMaps.Web/Program.cs
+++ b/GIFrameworkMaps.Web/Program.cs
@@ -21,6 +21,7 @@ using NodaTime.Serialization.SystemTextJson;
 using NodaTime;
 using Npgsql;
 using Microsoft.Extensions.Hosting;
+using GIFrameworkMaps.Web.Filters;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -116,6 +117,8 @@ ApplicationInsightsServiceOptions AppInsightOptions = new()
   ConnectionString = builder.Configuration["ApplicationInsights:ConnectionString"]
 };
 builder.Services.AddApplicationInsightsTelemetry(AppInsightOptions);
+builder.Services.AddApplicationInsightsTelemetryProcessor<UnwantedTelemetryFilter>();
+
 
 var app = builder.Build();
 var forwarder = app.Services.GetService<IHttpForwarder>();

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationSelect.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationSelect.ts
@@ -263,9 +263,7 @@ export default class AnnotationSelect extends Select {
   ) {
     const bufferSize = 10;
     const mapExtent = this.gifwMapInstance.olMap
-      .getView()
-      .getProjection()
-      .getExtent(); // Is this okay?
+      .getView().getViewStateAndExtent().extent;
     const backdropGeometry = olPolygon.fromExtent(mapExtent);
     const resolution = this.gifwMapInstance.olMap.getView().getResolution();
     let featureHalfWidth = 0;

--- a/GIFrameworkMaps.Web/Scripts/FeatureQuery/FeatureQuerySearch.ts
+++ b/GIFrameworkMaps.Web/Scripts/FeatureQuery/FeatureQuerySearch.ts
@@ -498,7 +498,7 @@ export class FeatureQuerySearch {
               }
 
               const wfsFeatureInfoRequest = new WFS().writeGetFeature({
-                srsName: "EPSG:3857",
+                srsName: this._gifwMapInstance.olMap.getView().getProjection().getCode(),
                 featureTypes: [featureTypeName],
                 featureNS: featureDescription.targetNamespace,
                 featurePrefix: featureDescription.targetPrefix,
@@ -660,8 +660,9 @@ export class FeatureQuerySearch {
         })
         .then((data) => {
           //if the request was a WFS, use the GML reader, else use the WMSGetFeatureInfo reader
+          const viewProjection = this._gifwMapInstance.olMap.getView().getProjection();
           const features = request.wfsRequest
-            ? new GML3().readFeatures(data)
+            ? new GML3().readFeatures(data, {dataProjection: viewProjection})
             : new WMSGetFeatureInfo().readFeatures(data);
 
           const response: FeatureQueryResponse = {

--- a/GIFrameworkMaps.Web/Scripts/Geolocation.ts
+++ b/GIFrameworkMaps.Web/Scripts/Geolocation.ts
@@ -150,7 +150,7 @@ export class GIFWGeolocation extends olControl {
 
     //    this.olGeolocation.getAccuracy = () => { return this.simulatedAccuracy[Math.floor(Math.random() * (this.simulatedAccuracy.length - 0 + 1) + 0)];}
     //    this.olGeolocation.getHeading = () => { return this.simulatedHeading[Math.floor(Math.random() * (this.simulatedHeading.length - 0 + 1) + 0)];}
-    //    this.olGeolocation.getPosition = () => {return transform(this.simulatedCoordinates[this._simModeIndex],'EPSG:4326','EPSG:3857');}
+    //this.olGeolocation.getPosition = () => { return transform(this.simulatedCoordinates[this._simModeIndex], 'EPSG:4326', this.olGeolocation.getProjection()); }
 
     //}
   }

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/Projection.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/Projection.ts
@@ -7,6 +7,7 @@
   minBoundY: number;
   maxBoundX: number;
   maxBoundY: number;
+  defaultRenderedDecimalPlaces: number;
   isDefaultMapProjection: boolean;
   isDefaultViewProjection: boolean;
 }

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/Projection.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/Projection.ts
@@ -1,9 +1,12 @@
 ﻿export interface Projection {
   epsgCode: number;
+  name: string;
   description: string | null;
   proj4Definition: string | null;
   minBoundX: number;
   minBoundY: number;
   maxBoundX: number;
   maxBoundY: number;
+  isDefaultMapProjection: boolean;
+  isDefaultViewProjection: boolean;
 }

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/Projection.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/Projection.ts
@@ -1,0 +1,9 @@
+﻿export interface Projection {
+  epsgCode: number;
+  description: string | null;
+  proj4Definition: string | null;
+  minBoundX: number;
+  minBoundY: number;
+  maxBoundX: number;
+  maxBoundY: number;
+}

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/VersionViewModel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/VersionViewModel.ts
@@ -20,7 +20,7 @@ export interface VersionViewModel {
   bound: Bound;
   welcomeMessage: WelcomeMessage;
   tourDetails: TourDetails;
-  mapProjection: Projection;
+  availableProjections: Projection[];
   appRoot: string;
   appInsightsKey: string;
   googleMapsAPIKey: string;

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/VersionViewModel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/VersionViewModel.ts
@@ -4,6 +4,7 @@ import { Category } from "./Category";
 import { Theme } from "./Theme";
 import { TourDetails } from "./Tour/TourDetails";
 import { WelcomeMessage } from "./WelcomeMessage";
+import { Projection } from "./Projection";
 
 export interface VersionViewModel {
   id: number;
@@ -19,6 +20,7 @@ export interface VersionViewModel {
   bound: Bound;
   welcomeMessage: WelcomeMessage;
   tourDetails: TourDetails;
+  mapProjection: Projection;
   appRoot: string;
   appInsightsKey: string;
   googleMapsAPIKey: string;

--- a/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
+++ b/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
@@ -46,8 +46,9 @@ export class GIFWLayerGroup implements LayerGroup {
       | olLayer.Tile<olSource.XYZ>
       | olLayer.Tile<olSource.TileWMS>
       | olLayer.Image<olSource.ImageWMS>
-    > = [];
-    const viewProj = `EPSG:${this.gifwMapInstance.config.mapProjection?.epsgCode ?? "3857"}`;
+      > = [];
+    const defaultMapProjection = this.gifwMapInstance.config.availableProjections.filter(p => p.isDefaultMapProjection === true)[0];
+    const viewProj = `EPSG:${defaultMapProjection.epsgCode ?? "3857"}`;
     if (this.layers !== null) {
       this.layers.forEach((layer) => {
         //let opts: Record<string, any> = {};
@@ -94,11 +95,11 @@ export class GIFWLayerGroup implements LayerGroup {
           ];
           const extentProj = olProj.get('EPSG:3857');
           const reprojectedSourceExtent = transformExtent(extent, extentProj, "EPSG:4326");
-          const viewProj = olProj.get(`EPSG:${this.gifwMapInstance.config.mapProjection?.epsgCode ?? '3857'}`);
+          const viewProj = olProj.get(`EPSG:${defaultMapProjection.epsgCode ?? '3857'}`);
           if (containsExtent(reprojectedSourceExtent, viewProj.getWorldExtent())) {
-            extent = transformExtent(viewProj.getWorldExtent(), 'EPSG:4326', `EPSG:${this.gifwMapInstance.config.mapProjection?.epsgCode ?? '3857'}`);
+            extent = transformExtent(viewProj.getWorldExtent(), 'EPSG:4326', `EPSG:${defaultMapProjection.epsgCode ?? '3857'}`);
           } else {
-            extent = transformExtent(extent, 'EPSG:3857', `EPSG:${this.gifwMapInstance.config.mapProjection?.epsgCode ?? '3857'}`);
+            extent = transformExtent(extent, 'EPSG:3857', `EPSG:${defaultMapProjection.epsgCode ?? '3857'}`);
           }
         }
         switch (layer.layerSource.layerSourceType.name) {

--- a/GIFrameworkMaps.Web/Scripts/Management/SelectWebService.ts
+++ b/GIFrameworkMaps.Web/Scripts/Management/SelectWebService.ts
@@ -3,11 +3,16 @@ import { LayerResource } from "../Interfaces/OGCMetadata/LayerResource";
 import { Metadata } from "../Metadata/Metadata";
 
 export class SelectWebService {
+  preferredProjections: string[] = [];
   _fuseInstance: Fuse<LayerResource>;
 
   constructor() {}
 
   public init() {
+    //set preferred projections
+    const preferredProjectionsInput = (document.getElementById('preferred-projections-list') as HTMLInputElement);
+    this.preferredProjections = preferredProjectionsInput.value.split(",");
+
     //hook up connect buttons
     const listConnectBtn = document.getElementById("web-service-list-connect");
     const urlConnectBtn = document.getElementById("web-service-text-connect");
@@ -115,14 +120,7 @@ export class SelectWebService {
     container.id = layer.name;
     header.textContent = layer.title;
     desc.textContent = layer.abstract;
-    const preferredProjections = [
-      "EPSG:3857",
-      "EPSG:900913",
-      "EPSG:27700",
-      "EPSG:4326",
-      "CRS:84",
-    ];
-    const preferredProjection = preferredProjections.find((p) =>
+    const preferredProjection = this.preferredProjections.find((p) =>
       layer.projections.includes(p),
     );
     if (preferredProjection) {

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -250,12 +250,6 @@ export class GIFWMap {
     let startMinZoom: number = 0;
     const startBasemap = this.config.basemaps.find((b) => b.isDefault);
     if (startBasemap !== null) {
-      //startExtent = [
-      //  startBasemap.bound.bottomLeftX,
-      //  startBasemap.bound.bottomLeftY,
-      //  startBasemap.bound.topRightX,
-      //  startBasemap.bound.topRightY,
-      //];
       startMaxZoom = startBasemap.maxZoom;
       startMinZoom = startBasemap.minZoom;
     }

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -1171,12 +1171,14 @@ export class GIFWMap {
           if (source instanceof TileWMS || source instanceof ImageWMS) {
             const view = this.olMap.getView();
             const viewport = this.olMap.getViewport();
+            //version is forced to 1.1.0 to get around lat/lon flipping issues
             let params = {
               LEGEND_OPTIONS: additionalLegendOptions,
               bbox: view.calculateExtent().toString(),
               srcwidth: viewport.clientWidth,
               srcheight: viewport.clientHeight,
-              crs: view.getProjection().getCode(),
+              srs: view.getProjection().getCode(),
+              version: "1.1.0",
             };
             //merge valid params from the source and add to the legend
             // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Disabled to make make handling this generic object easier. The code is safe as written

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -118,7 +118,7 @@ export class GIFWMap {
     //mouse position controls. TODO - alow DB setting of initial coord system
     const mousePosition = new GIFWMousePositionControl(
       defaultMapProjection.epsgCode.toString(),
-      0,
+      defaultMapProjection.defaultRenderedDecimalPlaces,
       this.config.availableProjections,
     );
     const contextMenu = new GIFWContextMenu(mousePosition);

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -91,6 +91,9 @@ export class GIFWMap {
     const defaultMapProjection = this.config.availableProjections.filter(
       (p) => p.isDefaultMapProjection === true,
     )[0];
+    const defaultViewProjection = this.config.availableProjections.filter(
+      (p) => p.isDefaultViewProjection === true,
+    )[0];
     const mapProjectionCode = `EPSG:${defaultMapProjection.epsgCode}`;
     const viewProjection = olProj.get(mapProjectionCode);
     const fromLonLat = olProj.getTransform("EPSG:4326", viewProjection);
@@ -117,8 +120,8 @@ export class GIFWMap {
     });
     //mouse position controls. TODO - alow DB setting of initial coord system
     const mousePosition = new GIFWMousePositionControl(
-      defaultMapProjection.epsgCode.toString(),
-      defaultMapProjection.defaultRenderedDecimalPlaces,
+      defaultViewProjection.epsgCode.toString(),
+      defaultViewProjection.defaultRenderedDecimalPlaces,
       this.config.availableProjections,
     );
     const contextMenu = new GIFWContextMenu(mousePosition);

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -87,9 +87,19 @@ export class GIFWMap {
         `EPSG:${this.config.mapProjection.epsgCode}`,
         this.config.mapProjection.proj4Definition,
       );
+      //Adds GML version to get round GML readFeature issues - https://github.com/openlayers/openlayers/issues/3898#issuecomment-120899034
+      proj4.defs(
+        `http://www.opengis.net/gml/srs/epsg.xml#${this.config.mapProjection.epsgCode}`,
+        this.config.mapProjection.proj4Definition,
+      );
       register(proj4);
       const addedProj = olProj.get(`EPSG:${this.config.mapProjection.epsgCode}`);
+      const addedGMLProj = olProj.get(`http://www.opengis.net/gml/srs/epsg.xml#${this.config.mapProjection.epsgCode}`);
       addedProj.setWorldExtent([this.config.mapProjection.minBoundX, this.config.mapProjection.minBoundY, this.config.mapProjection.maxBoundX, this.config.mapProjection.maxBoundY]);
+      addedGMLProj.setWorldExtent([this.config.mapProjection.minBoundX, this.config.mapProjection.minBoundY, this.config.mapProjection.maxBoundX, this.config.mapProjection.maxBoundY]);
+
+      olProj.addEquivalentProjections([addedProj, addedGMLProj])
+
     }
     const viewProjection = olProj.get(viewProjectionCode);
     const fromLonLat = olProj.getTransform('EPSG:4326', viewProjection);
@@ -115,7 +125,7 @@ export class GIFWMap {
       tipLabel: "Reset rotation (Alt-Shift and Drag to rotate)",
     });
     //mouse position controls. TODO - alow DB setting of initial coord system
-    const mousePosition = new GIFWMousePositionControl("27700", 0);
+    const mousePosition = new GIFWMousePositionControl(viewProjectionCode, 0);
     const contextMenu = new GIFWContextMenu(mousePosition);
     //add measure
     const measureControl = new Measure(this);

--- a/GIFrameworkMaps.Web/Scripts/MousePositionControl.ts
+++ b/GIFrameworkMaps.Web/Scripts/MousePositionControl.ts
@@ -85,8 +85,17 @@ export class GIFWMousePositionControl extends olControl.Control {
         const opt = document.createElement("option");
         opt.value = proj.epsgCode.toString();
         opt.text = proj.name;
-        opt.dataset.gifwDefaultDecimals = "2"; //TODO - Make this DB settable
+        opt.dataset.gifwDefaultDecimals =
+          proj.defaultRenderedDecimalPlaces.toString();
         list.add(opt);
+        if (proj.epsgCode === 27700) {
+          //add the 277001 fake projection for BNG Alphanumeric representation
+          //TODO - Make this smarter!
+          const opt = document.createElement("option");
+          opt.value = "277001";
+          opt.text = "British National Grid Alphanumeric";
+          list.add(opt);
+        }
       });
     }
 

--- a/GIFrameworkMaps.Web/Scripts/MousePositionControl.ts
+++ b/GIFrameworkMaps.Web/Scripts/MousePositionControl.ts
@@ -32,7 +32,9 @@ export class GIFWMousePositionControl extends olControl.Control {
   }
 
   public init(): olControl.MousePosition {
-    let mousePositionProjection = olProj.get(this.projection);
+    let mousePositionProjection = olProj.get(
+      this.getProjectionString(this.projection),
+    );
     const preferredProjectionEPSG = UserSettings.getItem(
       "MousePositionProjection-Code",
     );

--- a/GIFrameworkMaps.Web/Scripts/MousePositionControl.ts
+++ b/GIFrameworkMaps.Web/Scripts/MousePositionControl.ts
@@ -25,7 +25,7 @@ export class GIFWMousePositionControl extends olControl.Control {
   }
 
   public init(): olControl.MousePosition {
-    let mousePositionProjection = olProj.get("EPSG:27700");
+    let mousePositionProjection = olProj.get(this.projection);
     const preferredProjectionEPSG = UserSettings.getItem(
       "MousePositionProjection-Code",
     );
@@ -151,7 +151,7 @@ export class GIFWMousePositionControl extends olControl.Control {
     } else if (code === "43261") {
       return `EPSG:4326`;
     } else {
-      return `EPSG:${code}`;
+      return `EPSG:${code.replace("EPSG:", "")}`;
     }
   }
 
@@ -159,6 +159,7 @@ export class GIFWMousePositionControl extends olControl.Control {
     code: string,
     decimals: number,
     coord: number[],
+    includeUnit: boolean = true,
   ): string {
     const x = coord[0];
     const y = coord[1];
@@ -172,9 +173,13 @@ export class GIFWMousePositionControl extends olControl.Control {
       return toStringHDMS([x, y], decimals);
     } else if (code === "4326") {
       /*lat/lon requires flipping the x/y values*/
-      return `Lat: ${y.toFixed(decimals)} Lon: ${x.toFixed(decimals)}`;
+      return `${includeUnit ? "Lat: " : ""}${y.toFixed(decimals)} ${
+        includeUnit ? "Lon: " : ""
+      }${x.toFixed(decimals)}`;
     } else {
-      return `X: ${x.toFixed(decimals)} Y: ${y.toFixed(decimals)}`;
+      return `${includeUnit ? "X: " : ""}${x.toFixed(decimals)} ${
+        includeUnit ? "Y: " : ""
+      }${y.toFixed(decimals)}`;
     }
   }
 
@@ -182,6 +187,7 @@ export class GIFWMousePositionControl extends olControl.Control {
     code: string,
     decimals: number,
     coord: number[],
+    includeUnit: boolean = true,
   ): string[] {
     const x = coord[0];
     const y = coord[1];
@@ -198,9 +204,15 @@ export class GIFWMousePositionControl extends olControl.Control {
       return [`${splitString[0]}${splitString[1]}`, `${splitString[2].trim()}`];
     } else if (code === "4326") {
       /*lat/lon requires flipping the x/y values*/
-      return [`Lat: ${y.toFixed(decimals)}`, `Lon: ${x.toFixed(decimals)}`];
+      return [
+        `${includeUnit ? "Lat: " : ""}${y.toFixed(decimals)}`,
+        `${includeUnit ? "Lon: " : ""}${x.toFixed(decimals)}`,
+      ];
     } else {
-      return [`X: ${x.toFixed(decimals)}`, `Y: ${y.toFixed(decimals)}`];
+      return [
+        `${includeUnit ? "X: " : ""}${x.toFixed(decimals)}`,
+        `${includeUnit ? "Y: " : ""}${y.toFixed(decimals)}`,
+      ];
     }
   }
 

--- a/GIFrameworkMaps.Web/Scripts/Panels/BasemapsPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/BasemapsPanel.ts
@@ -122,20 +122,6 @@ export class BasemapsPanel implements SidebarPanel {
     }`;
     meta.id = `basemaps-meta-${basemapConfiguration.id}`;
 
-    const source = basemap.getSource();
-    if (source.getProjection) {
-      const proj = source.getProjection() as Projection;
-      if (
-        proj &&
-        proj.getCode() !==
-          this.gifwMapInstance.olMap.getView().getProjection().getCode()
-      ) {
-        meta.insertAdjacentHTML(
-          "afterbegin",
-          `<div class="alert alert-warning">The projection of the source data is different from the map. This basemap may have some rendering issues (such as blurring or mis-matching)</div>`,
-        );
-      }
-    }
     const opacityControls = PanelHelper.renderSliderControl(
       basemapConfiguration.id,
       basemap.getOpacity() * 100,
@@ -159,6 +145,21 @@ export class BasemapsPanel implements SidebarPanel {
     meta.appendChild(opacityControls);
     meta.appendChild(saturationControls);
     meta.appendChild(aboutLink);
+
+    const source = basemap.getSource();
+    if (source.getProjection) {
+      const proj = source.getProjection() as Projection;
+      if (
+        proj &&
+        proj.getCode() !==
+        this.gifwMapInstance.olMap.getView().getProjection().getCode()
+      ) {
+        meta.insertAdjacentHTML(
+          "beforeend",
+          `<p><span class="bi bi-exclamation-circle"></span> The projection of the source data is different from the map. This basemap may have some rendering issues (such as blurring or mis-matching)</p>`,
+        );
+      }
+    }
     return meta;
   }
 

--- a/GIFrameworkMaps.Web/Scripts/Search.ts
+++ b/GIFrameworkMaps.Web/Scripts/Search.ts
@@ -429,6 +429,19 @@ export class Search {
    */
   private zoomToResult(result: SearchResult) {
     const sourceProj = olProj.get(`EPSG:${result.epsg}`);
+    if (sourceProj === null) {
+      console.error(
+        `Source projection EPSG:${result.epsg} is not available in this version.`,
+      );
+      const errDialog = new CustomError(
+        AlertType.Popup,
+        AlertSeverity.Danger,
+        "Something went wrong",
+        "<p>We couldn't zoom you to your search result due to an internal error. The developers have been informed.</p>",
+      );
+      errDialog.show();
+      return;
+    }
     const targetProj = this.gifwMapInstance.olMap.getView().getProjection();
     let closeOnRender = false;
     if (this.gifwMapInstance.getPercentOfMapCoveredWithOverlays() > 50) {

--- a/GIFrameworkMaps.Web/Scripts/Streetview.ts
+++ b/GIFrameworkMaps.Web/Scripts/Streetview.ts
@@ -39,7 +39,10 @@ export class Streetview {
       );
       link.textContent = "Checking for Street View Imagery";
       (link as HTMLElement).dataset.gifwStreetViewUrl = "";
-      const latlon = toLonLat(event.coordinate);
+      const latlon = toLonLat(
+        event.coordinate,
+        contextMenu.control.getMap().getView().getProjection(),
+      );
       const streetviewURL = await this.getGoogleStreetviewAtLocation(
         latlon[1],
         latlon[0],

--- a/GIFrameworkMaps.Web/Scripts/WebLayerService.ts
+++ b/GIFrameworkMaps.Web/Scripts/WebLayerService.ts
@@ -172,14 +172,23 @@ export class WebLayerService {
     addLayerButton.addEventListener("click", (e) => {
       try {
         let source: olSource.ImageWMS | olSource.TileWMS;
+        const mapProjection = this.gifwMapInstance.olMap
+          .getView()
+          .getProjection();
+        const supportedProjections =
+          this.gifwMapInstance.config.availableProjections.flatMap(
+            (p) => `EPSG:${p.epsgCode}`,
+          );
         const preferredProjections = [
+          mapProjection.getCode(),
+          ...supportedProjections,
           "EPSG:3857",
           "EPSG:900913",
-          "EPSG:27700",
           "EPSG:4326",
           "CRS:84",
         ];
-        let selectedProjection = preferredProjections.find((p) =>
+        const uniqueProjections = [...new Set(preferredProjections)];
+        let selectedProjection = uniqueProjections.find((p) =>
           layerDetails.projections.includes(p),
         );
         if (!selectedProjection) {

--- a/GIFrameworkMaps.Web/Scripts/app.ts
+++ b/GIFrameworkMaps.Web/Scripts/app.ts
@@ -5,7 +5,10 @@ import { BroadcastReceiver } from "./BroadcastReceiver";
 import { BasemapsPanel } from "./Panels/BasemapsPanel";
 import { LayersPanel } from "./Panels/LayersPanel";
 import { PrintPanel } from "./Panels/PrintPanel";
-import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+import {
+  ApplicationInsights,
+  ITelemetryItem,
+} from "@microsoft/applicationinsights-web";
 import { LegendsPanel } from "./Panels/LegendsPanel";
 import { SharePanel } from "./Panels/SharePanel";
 import { Welcome } from "./Welcome";
@@ -26,11 +29,15 @@ if (gifw_appinsights_key != "") {
       disableCookiesUsage: true,
     },
   });
-  try {
-    appInsights.loadAppInsights();
-  } catch (ex) {
-    console.error("Failed to load application insights", ex);
-  }
+  //the following telemetry filter removes the broadcasthub pings
+  const filteringFunction = (envelope: ITelemetryItem) => {
+    if ((envelope.baseData["name"] as string).indexOf("broadcasthub") !== -1) {
+      return false;
+    }
+    return true;
+  };
+  appInsights.addTelemetryInitializer(filteringFunction);
+  appInsights.loadAppInsights();
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -162,7 +169,7 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     })
     .catch((error) => {
-      console.error("Failed to get load the app", error);
+      console.error("Failed to load the app", error);
       //show an alert that covers the screen
       const alert = new Alert(
         AlertType.Popup,

--- a/GIFrameworkMaps.Web/Startup.cs
+++ b/GIFrameworkMaps.Web/Startup.cs
@@ -171,7 +171,12 @@ namespace GIFrameworkMaps.Web
                     pattern: "Management/User/{action=Index}/{id?}",
                     defaults: new { controller = "ManagementUser", action = "Index" });
 
-                endpoints.MapControllerRoute("General_Map_Redirect", "Map", new { controller = "Map", action = "RedirectToGeneral" });
+				endpoints.MapControllerRoute(
+					name: "ManagementInterface-System-Projection",
+					pattern: "Management/System/Projection/{action=Index}/{id?}",
+					defaults: new { controller = "ManagementProjection", action = "Index" });
+
+				endpoints.MapControllerRoute("General_Map_Redirect", "Map", new { controller = "Map", action = "RedirectToGeneral" });
                 
                 endpoints.MapControllerRoute(
                     name: "default",

--- a/GIFrameworkMaps.Web/Views/ManagementLayerWizard/CreateSource.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerWizard/CreateSource.cshtml
@@ -39,6 +39,13 @@
                 </div>
             </div>
 
+            <div class="mb-3">
+                <label asp-for="Projection" class="control-label"></label>
+                <input asp-for="Projection" class="form-control" />
+                <span asp-validation-for="Projection" class="text-danger"></span>
+                <span class="form-text">Leave blank for automatic projection selection based on map - <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/layers/#auto-projection" target="_blank">Learn more</a></span>
+            </div>
+
             <a href="#advancedSettings" class="btn btn-link my-3 ps-0" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="advancedSettings"><i class="bi bi-caret-right"></i> Advanced settings</a>
 
             <div class="collapse border-start border-bottom border-5 ps-3 mb-3" id="advancedSettings">
@@ -59,12 +66,6 @@
                     <label asp-for="Format" class="control-label"></label>
                     <input asp-for="Format" class="form-control" />
                     <span asp-validation-for="Format" class="text-danger"></span>
-                </div>
-
-                <div class="mb-3">
-                    <label asp-for="Projection" class="control-label"></label>
-                    <input asp-for="Projection" class="form-control" />
-                    <span asp-validation-for="Projection" class="text-danger"></span>
                 </div>
 
                 <div class="mb-3">

--- a/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
@@ -130,7 +130,7 @@
         <p class="mb-1"></p>
         <div class="container">
             <div class="row row-cols-lg-auto align-items-center">
-                <select data-epsg-selector="true" class="form-select-sm me-2" aria-label="Projection"></select>
+                <select data-epsg-selector="true" class="form-select-sm me-2" aria-label="Projection"><option value="">Auto Projection</option></select>
                 <select data-format-selector="true" class="form-select-sm me-2" aria-label="Format"></select>
                 <button class="btn btn-sm btn-primary"><i class="bi bi-plus-circle"></i> Add</button>
             </div>

--- a/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
@@ -1,4 +1,6 @@
 ﻿@model List<GIFrameworkMaps.Data.Models.WebLayerServiceDefinition>
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
 @{
     ViewData["Title"] = "Create a layer";
     //TODO Temporary hack using url.content to generate correct link
@@ -67,6 +69,7 @@
                                     <input class="form-check-input mt-0" type="checkbox" value="@proxyEndpoint" id="use-proxy"><label class="ms-2" for="use-proxy">Use proxy</label>
                                 </div>
                                 <button class="btn btn-outline-primary" type="button" id="web-service-text-connect">Connect</button>
+                                <input type="hidden" id="preferred-projections-list" value="@Configuration["GIFrameworkMaps:PreferredProjections"]" />
                             </div>
                         </div>
                     </form>

--- a/GIFrameworkMaps.Web/Views/ManagementProjection/Delete.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementProjection/Delete.cshtml
@@ -5,7 +5,7 @@
 
 <h1>@ViewData["Title"]</h1>
 <div class="row mt-2">
-    <h2>Are you sure you want to delete this projectionn?</h2>
+    <h2>Are you sure you want to delete this projection?</h2>
     <p class="lead">This action cannot be undone.</p>
 
     <form asp-action="Delete">

--- a/GIFrameworkMaps.Web/Views/ManagementProjection/Delete.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementProjection/Delete.cshtml
@@ -1,0 +1,27 @@
+﻿@model GIFrameworkMaps.Data.Models.Projection
+@{
+    ViewData["Title"] = $"Delete projection '{Model.Name}'";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row mt-2">
+    <h2>Are you sure you want to delete this projectionn?</h2>
+    <p class="lead">This action cannot be undone.</p>
+
+    <form asp-action="Delete">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+        <input type="hidden" asp-for="EPSGCode" />
+        <div class="mb-3">
+            <input type="submit" value="Delete" class="btn btn-danger" />
+        </div>
+    </form>
+
+</div>
+
+<div>
+    <a asp-action="Index">Cancel</a>
+</div>
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementProjection/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementProjection/Edit.cshtml
@@ -1,0 +1,105 @@
+﻿@model GIFrameworkMaps.Data.Models.Projection
+@{
+    ViewData["Title"] = $"Edit projection '{Model.Name}' (EPSG:{Model.EPSGCode})";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/system/#projections" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
+<div class="row mt-2 mb-2">
+    <div class="col-md-8">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+            <input type="hidden" asp-for="EPSGCode" />
+            <div class="mb-3">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Description" class="control-label"></label>
+                <input asp-for="Description" class="form-control" />
+                <span asp-validation-for="Description" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Proj4Definition" class="control-label"></label>
+                <textarea asp-for="Proj4Definition" class="form-control"></textarea>
+                <div class="form-text">You can use Proj4JS or WKT style definitions. Get the definitions from <a href="https://epsg.io" target="_blank">https://epsg.io</a> or <a href="https://epsg.org/home.html" target="_blank">https://epsg.org/</a></div>
+                <span asp-validation-for="Proj4Definition" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="DefaultRenderedDecimalPlaces" class="control-label"></label>
+                <div class="row">
+                    <div class="col-lg-3 col-md-4 col-6">
+                        <input asp-for="DefaultRenderedDecimalPlaces" class="form-control" type="number" />
+                    </div>
+                </div>
+                <div class="form-text">This controls how many decimal places will be shown by default when rendering these coordinates</div>
+                <span asp-validation-for="DefaultRenderedDecimalPlaces" class="text-danger"></span>
+            </div>
+
+            <h2>Bounds of coordinate system</h2>
+            <div class="mb-3">
+                <label asp-for="MinBoundX" class="control-label"></label>
+                <div class="row">
+                    <div class="col-lg-3 col-md-4 col-6">
+                        <input asp-for="MinBoundX" class="form-control" />
+                    </div>
+                </div>
+                <span asp-validation-for="MinBoundX" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="MinBoundY" class="control-label"></label>
+                <div class="row">
+                    <div class="col-lg-3 col-md-4 col-6">
+                        <input asp-for="MinBoundY" class="form-control" />
+                    </div>
+                </div>
+                <span asp-validation-for="MinBoundY" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="MaxBoundX" class="control-label"></label>
+                <div class="row">
+                    <div class="col-lg-3 col-md-4 col-6">
+                        <input asp-for="MaxBoundX" class="form-control" />
+                    </div>
+                </div>
+                <span asp-validation-for="MaxBoundX" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="MaxBoundY" class="control-label"></label>
+                <div class="row">
+                    <div class="col-lg-3 col-md-4 col-6">
+                        <input asp-for="MaxBoundY" class="form-control" />
+                    </div>
+                </div>
+                <span asp-validation-for="MaxBoundY" class="text-danger"></span>
+            </div>
+
+
+
+            <div class="mb-3">
+                <input type="submit" value="Save" class="btn btn-primary btn-lg" />
+                <a asp-action="Index" class="btn btn-link">Cancel</a>
+            </div>
+        </form>
+        
+    </div>
+</div>
+<a asp-action="Delete" asp-route-id="@Model.EPSGCode" class="btn btn-danger">Delete</a>
+
+
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementProjection/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementProjection/Index.cshtml
@@ -1,0 +1,61 @@
+﻿@model List<GIFrameworkMaps.Data.Models.Projection>
+@{
+    ViewData["Title"] = "Projections";
+}
+
+<partial name="ManagementPartials/BackToManagementHome" />
+
+<h1>@ViewData["Title"]</h1>
+<p class="lead">Register, edit and delete projections</p>
+
+<a href="@Url.Action("Register")" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Register new projection</a>
+
+@if (Model != null)
+{
+    <table id="projectionTable" class="table table-bordered table-striped mt-2">
+        <thead>
+            <tr>
+                <th>EPSG Code</th><th>Name</th><th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (GIFrameworkMaps.Data.Models.Projection projection in Model.OrderBy(a => a.EPSGCode))
+            {
+                <tr>
+                    <td>@projection.EPSGCode</td>
+                    <td>@Html.ActionLink(projection.Name, "Edit", new { id = projection.EPSGCode })</td>
+                    <td>@projection.Description</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+else
+{
+    <div class="alert alert-warning">No projections have been registered yet</div>
+}
+
+@section Scripts {
+    <script>
+        const opts = {
+            perPage: 50,
+            perPageSelect: [10, 25, 50, 100, ["All", 0]],
+            classes:
+            {
+                input: "form-control",
+                top: "datatable-top px-0",
+                selector: "form-select",
+                paginationList: "pagination",
+                paginationListItem: "page-item",
+                paginationListItemLink: "page-link",
+                active: 'active',
+                disabled: 'disabled'
+            }
+        };
+        const dataTable = new simpleDatatables.DataTable("#projectionTable", opts);
+    </script>
+}
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementProjection/Register.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementProjection/Register.cshtml
@@ -1,0 +1,112 @@
+﻿@model GIFrameworkMaps.Data.Models.Projection
+@{
+    ViewData["Title"] = $"Register new projection";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<div>
+    <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/system/#projections" class="btn btn-outline-primary" target="_blank"
+       role="button">Stuck? Read the help documentation</a>
+</div>
+
+<div class="row mt-2">
+    <div class="col-md-8">
+        <form asp-action="Register">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+
+            <div class="mb-3">
+                <label asp-for="EPSGCode" class="control-label"></label>
+                <div class="row">
+                    <div class="col-lg-3 col-md-4 col-6">
+                        <input asp-for="EPSGCode" class="form-control" type="number" />
+                    </div>
+                </div>
+                <span asp-validation-for="EPSGCode" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Description" class="control-label"></label>
+                <input asp-for="Description" class="form-control" />
+                <span asp-validation-for="Description" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Proj4Definition" class="control-label"></label>
+                <textarea asp-for="Proj4Definition" class="form-control"></textarea>
+                <div class="form-text">You can use Proj4JS or WKT style definitions. Get the definitions from <a href="https://epsg.io" target="_blank">https://epsg.io</a> or <a href="https://epsg.org/home.html" target="_blank">https://epsg.org/</a></div>
+                <span asp-validation-for="Proj4Definition" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="DefaultRenderedDecimalPlaces" class="control-label"></label>
+                <div class="row">
+                    <div class="col-lg-3 col-md-4 col-6">
+                        <input asp-for="DefaultRenderedDecimalPlaces" class="form-control" type="number" />
+                    </div>
+                </div>
+                <div class="form-text">This controls how many decimal places will be shown by default when rendering these coordinates</div>
+                <span asp-validation-for="DefaultRenderedDecimalPlaces" class="text-danger"></span>
+            </div>
+
+            <h2>Bounds of coordinate system</h2>
+            <div class="mb-3">
+                <label asp-for="MinBoundX" class="control-label"></label>
+                <div class="row">
+                    <div class="col-lg-3 col-md-4 col-6">
+                        <input asp-for="MinBoundX" class="form-control" />
+                    </div>
+                </div>
+                <span asp-validation-for="MinBoundX" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="MinBoundY" class="control-label"></label>
+                <div class="row">
+                    <div class="col-lg-3 col-md-4 col-6">
+                        <input asp-for="MinBoundY" class="form-control" />
+                    </div>
+                </div>
+                <span asp-validation-for="MinBoundY" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="MaxBoundX" class="control-label"></label>
+                <div class="row">
+                    <div class="col-lg-3 col-md-4 col-6">
+                        <input asp-for="MaxBoundX" class="form-control" />
+                    </div>
+                </div>
+                <span asp-validation-for="MaxBoundX" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="MaxBoundY" class="control-label"></label>
+                <div class="row">
+                    <div class="col-lg-3 col-md-4 col-6">
+                        <input asp-for="MaxBoundY" class="form-control" />
+                    </div>
+                </div>
+                <span asp-validation-for="MaxBoundY" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <input type="submit" value="Register" class="btn btn-lg btn-primary" />
+                <a asp-action="Index" class="btn btn-link">Cancel</a>
+
+            </div>
+        </form>
+    </div>
+</div>
+
+
+
+            
+
+

--- a/GIFrameworkMaps.Web/Views/ManagementSystem/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementSystem/Index.cshtml
@@ -8,7 +8,7 @@
 <h1>@ViewData["Title"]</h1>
 <p class="lead">Check and update system settings and cache</p>
 
-<div class="row">
+@* <div class="row">
     <h2>Cache</h2>
     <p>Click the big red button below to clear the in memory cache for the application.</p>
     <p>All cached objects will be purged and will need to be retrieved from storage again.</p>
@@ -31,8 +31,61 @@
     <p>
         <a href="@Url.Action("Index","ManagementAnalytics")" class="btn btn-primary"><i class="bi"></i> Manage analytics</a>
     </p>
-</div>
+</div> *@
 
             
+
+<div class="container">
+    <div class="row row-cols-1 row-cols-md-3 g-4">
+        <div class="col">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h4 class="card-title"><i class="bi bi-rocket-takeoff"></i> Cache</h4>
+                    <p class="card-text">Click the big red button below to clear the in memory cache for the application.</p>
+                    <p class="card-text">All cached objects will be purged and will need to be retrieved from storage again.</p>
+                </div>
+                <div class="card-footer">
+                    <form asp-controller="ManagementSystem" asp-action="PurgeCache" method="post">
+                        <input type="submit" class="btn btn-danger" value="Purge Memory Cache" />
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h4 class="card-title"><i class="bi bi-plug"></i> Web layer service definitions</h4>
+                    <p class="card-text">Create, edit and delete web layer service definitions available to users and administrators</p>
+                </div>
+                <div class="card-footer">
+                    <a href="@Url.Action("Index","ManagementWebLayerServiceDefinition")" class="btn btn-primary"><i class="bi"></i> Manage web layer service definitions</a>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h4 class="card-title"><i class="bi bi-graph-up"></i> Site analytics and cookie control</h4>
+                    <p class="card-text">Create, edit and delete analytics providers and cookie control</p>
+                </div>
+                <div class="card-footer">
+                    <a href="@Url.Action("Index","ManagementAnalytics")" class="btn btn-primary"><i class="bi"></i> Manage analytics</a>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h4 class="card-title"><i class="bi bi-globe"></i> Projections</h4>
+                    <p class="card-text">Create, edit and delete projections available in the app</p>
+                </div>
+                <div class="card-footer">
+                    <a href="@Url.Action("Index","ManagementProjection")" class="btn btn-primary"><i class="bi"></i> Manage projections</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+        
 
 

--- a/GIFrameworkMaps.Web/Views/ManagementSystem/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementSystem/Index.cshtml
@@ -8,33 +8,6 @@
 <h1>@ViewData["Title"]</h1>
 <p class="lead">Check and update system settings and cache</p>
 
-@* <div class="row">
-    <h2>Cache</h2>
-    <p>Click the big red button below to clear the in memory cache for the application.</p>
-    <p>All cached objects will be purged and will need to be retrieved from storage again.</p>
-    <form asp-controller="ManagementSystem" asp-action="PurgeCache" method="post">
-        <input type="submit" class="btn btn-danger" value="Purge Memory Cache" />
-    </form>
-</div>
-<br>
-<div class="row">
-    <h2>Web layer service definitions</h2>
-    <p>Create, edit and delete web layer service definitions</p>
-    <p>
-        <a href="@Url.Action("Index","ManagementWebLayerServiceDefinition")" class="btn btn-primary"><i class="bi"></i> Manage web layer service definitions</a>
-    </p>
-</div>
-<br>
-<div class="row">
-    <h2>Site analytics and cookie control</h2>
-    <p>Add and manage analytics</p>
-    <p>
-        <a href="@Url.Action("Index","ManagementAnalytics")" class="btn btn-primary"><i class="bi"></i> Manage analytics</a>
-    </p>
-</div> *@
-
-            
-
 <div class="container">
     <div class="row row-cols-1 row-cols-md-3 g-4">
         <div class="col">
@@ -58,7 +31,7 @@
                     <p class="card-text">Create, edit and delete web layer service definitions available to users and administrators</p>
                 </div>
                 <div class="card-footer">
-                    <a href="@Url.Action("Index","ManagementWebLayerServiceDefinition")" class="btn btn-primary"><i class="bi"></i> Manage web layer service definitions</a>
+                    <a href="@Url.Action("Index","ManagementWebLayerServiceDefinition")" class="btn btn-primary">Manage web layer service definitions</a>
                 </div>
             </div>
         </div>
@@ -69,7 +42,7 @@
                     <p class="card-text">Create, edit and delete analytics providers and cookie control</p>
                 </div>
                 <div class="card-footer">
-                    <a href="@Url.Action("Index","ManagementAnalytics")" class="btn btn-primary"><i class="bi"></i> Manage analytics</a>
+                    <a href="@Url.Action("Index","ManagementAnalytics")" class="btn btn-primary">Manage analytics</a>
                 </div>
             </div>
         </div>
@@ -80,12 +53,9 @@
                     <p class="card-text">Create, edit and delete projections available in the app</p>
                 </div>
                 <div class="card-footer">
-                    <a href="@Url.Action("Index","ManagementProjection")" class="btn btn-primary"><i class="bi"></i> Manage projections</a>
+                    <a href="@Url.Action("Index","ManagementProjection")" class="btn btn-primary">Manage projections</a>
                 </div>
             </div>
         </div>
     </div>
 </div>
-        
-
-

--- a/GIFrameworkMaps.Web/Views/ManagementVersion/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementVersion/Create.cshtml
@@ -129,7 +129,14 @@
                     <partial name="ManagementPartials/VersionBasemapList" model="Model" view-data="ViewData" />
                 </div>
             </div>
-
+            <div class="card mb-2">
+                <div class="card-header">
+                    Projections
+                </div>
+                <div class="card-body">
+                    <partial name="ManagementPartials/VersionProjectionList" model="Model" view-data="ViewData" />
+                </div>
+            </div>
             <div class="card mb-2">
                 <div class="card-header">
                     Categories

--- a/GIFrameworkMaps.Web/Views/ManagementVersion/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementVersion/Edit.cshtml
@@ -113,7 +113,9 @@
                 <input type="submit" value="Save" class="btn btn-primary btn-lg" />
                 <a asp-action="Index" class="btn btn-link">Cancel</a>
             </div>
-
+            <div class="mb-3">
+                <a asp-action="Delete" asp-route-id="@Model.Version.Id" class="btn btn-danger">Delete</a>
+            </div>
         
         </div>
         <div class="col-md-6">
@@ -135,7 +137,14 @@
                     <partial name="ManagementPartials/VersionBasemapList" model="Model" view-data="ViewData" />
                 </div>
             </div>
-
+            <div class="card mb-2">
+                <div class="card-header">
+                    Projections
+                </div>
+                <div class="card-body">
+                    <partial name="ManagementPartials/VersionProjectionList" model="Model" view-data="ViewData" />
+                </div>
+            </div>
             <div class="card mb-2">
                 <div class="card-header">
                     Categories
@@ -146,7 +155,7 @@
             </div>
         </div>
     </div>
-    <a asp-action="Delete" asp-route-id="@Model.Version.Id" class="btn btn-danger">Delete</a>
+
 
 </form>
 

--- a/GIFrameworkMaps.Web/Views/Map/Partials/Modals/CoordinateConfiguratorModal.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Partials/Modals/CoordinateConfiguratorModal.cshtml
@@ -10,8 +10,6 @@
                     <div class="mb-3 col-12">
                         <label for="coordConfigProjection" class="form-label">Projection setting</label>
                         <select class="form-select" id="coordConfigProjection" aria-describedby="coordConfigProjection">
-                            <option value="27700" selected data-gifw-default-decimals="0">British National Grid</option>
-                            <option value="277001">British National Grid Alpha Numeric</option>
                             <option value="4326" data-gifw-default-decimals="4">Latitude/Longitude (WGS84)</option>
                             <option value="43261" data-gifw-default-decimals="1">Degrees/Minutes/Seconds (WGS84)</option>
                             <option value="3857" data-gifw-default-decimals="0">Spherical Mercator</option>

--- a/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/VersionProjectionList.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/VersionProjectionList.cshtml
@@ -1,0 +1,45 @@
+﻿@model GIFrameworkMaps.Data.Models.ViewModels.Management.VersionEditModel
+
+@foreach (var projection in Model.AvailableProjections)
+{
+    bool isChecked = Model.SelectedProjections != null && Model.SelectedProjections.Where(p => p == projection.EPSGCode).Count() != 0;
+    <div class="form-check">
+        <input type="checkbox"
+        class="form-check-input"
+        name="SelectedProjections"
+        value="@projection.EPSGCode"
+        id="SelectedProjections__@projection.EPSGCode"
+        @(Html.Raw(isChecked ? "checked=\"checked\"" : "")) />
+        <label class="form-check-label" for="SelectedProjections__@projection.EPSGCode">@projection.Name</label>
+    </div>
+}
+
+<div class="mt-3">
+
+    <label asp-for="MapProjection" class="control-label"></label>
+    <select name="MapProjection" class="form-select" id="MapProjection">
+    @foreach (var projection in Model.AvailableProjections)
+    {
+        bool isSelected = Model.MapProjection == projection.EPSGCode;
+            <!option value="@projection.EPSGCode" @(Html.Raw(isSelected ? "selected" : ""))>
+                @projection.Name (EPSG:@projection.EPSGCode)
+        </!option>
+    }
+    </select>
+    <span asp-validation-for="MapProjection" class="text-danger"></span>
+</div>
+
+<div class="mt-3">
+
+    <label asp-for="ViewProjection" class="control-label"></label>
+    <select name="ViewProjection" class="form-select" id="ViewProjection">
+        @foreach (var projection in Model.AvailableProjections)
+        {
+            bool isSelected = Model.ViewProjection == projection.EPSGCode;
+            <!option value="@projection.EPSGCode" @(Html.Raw(isSelected ? "selected" : ""))>
+                @projection.Name (EPSG:@projection.EPSGCode)
+            </!option>
+        }
+    </select>
+    <span asp-validation-for="ViewProjection" class="text-danger"></span>
+</div>

--- a/GIFrameworkMaps.Web/appsettings.json
+++ b/GIFrameworkMaps.Web/appsettings.json
@@ -20,7 +20,7 @@
     "ToSLink": "",
     "PrivacyLink": "",
     "AdminDocsLink": "",
-    "MapServicesAccessURL": "",
+    "MapServicesAccessURL": "https://gi-staging.dorsetcouncil.gov.uk/geoserver/www/sso.xml",
     "AuthenticateWithMapServices": false
   }
 }

--- a/GIFrameworkMaps.Web/appsettings.json
+++ b/GIFrameworkMaps.Web/appsettings.json
@@ -20,7 +20,8 @@
     "ToSLink": "",
     "PrivacyLink": "",
     "AdminDocsLink": "",
-    "MapServicesAccessURL": "https://gi-staging.dorsetcouncil.gov.uk/geoserver/www/sso.xml",
-    "AuthenticateWithMapServices": false
+    "MapServicesAccessURL": "",
+    "AuthenticateWithMapServices": false,
+    "PreferredProjections": ""
   }
 }

--- a/GIFrameworkMaps.Web/package.json
+++ b/GIFrameworkMaps.Web/package.json
@@ -38,7 +38,7 @@
     "nunjucks": "3.2.4",
     "ol": "8.2.0",
     "ol-contextmenu": "5.3.0",
-    "proj4": "2.9.2",
+    "proj4": "2.10.0",
     "shepherd.js": "11.2.0",
     "sortablejs": "1.15.1",
     "uuid": "9.0.1"


### PR DESCRIPTION
This PR adds the ability for maps to be in projections other than EPSG:3857 (Spherical Mercator).

To facilitate this, a new 'Projections' table has been added to the database, and **all versions must now have a projection defined**. The Projections table (and linked management UI) allows you to add supported projections using WKT or Proj4 format. Built in projections (3857, 4326,  4269, 900913) do not need the WKT/Proj4 string added.

Layers will attempt to be rendered in the projection of the map, if there are layers which can not be rendered in the projection of the map, then they will need their projection explicitly defined. This is no different to how it works at the moment, except that if you want a layer available in two different maps in different projections, and ONE of the map projections is not supported by the layer, you will need to create two layers or define a compatible projection (such as EPSG:3857). This is unlikely to crop up often unless you have particularly obscure projections in use.

Versions can have multiple projections applied, but only one will be used for actual map rendering (by applying the 'IsDefaultMapProjection' boolean or appropriate checkbox in management UI), the rest will be used for rendering coordinates on screen (with the default being set using the 'IsDefaultViewProjection' boolean or appropriate checkbox in management UI).

Additional tweaks:
- Requests to the SignalR broadcasthub endpoint have been filtered out of telemetry
- UI and URLs of 'System' section of management UI have been updated for consistency

Closes #172 