### PR TITLE
Remove automatic prettier watching

### DIFF
--- a/GIFrameworkMaps.Web/package.json
+++ b/GIFrameworkMaps.Web/package.json
@@ -66,8 +66,7 @@
   },
   "-vs-binding": {
     "ProjectOpened": [
-      "watch:webpack",
-      "watch:prettier"
+      "watch:webpack"
     ]
   }
 }


### PR DESCRIPTION
This PR removes the automatic starting up of `watch:prettier` in the `-vs-binding` section of the `package.json`. 

The automatic start up sometimes forced a prettier update of all files when switching branches etc. which for now is more of a hindrance than a help. Prettier can still be fired up manually using the standard or 'watch' tasks as defined in the package.