### PR TITLE
Make SVG Icon generation work cross platform

### DIFF
--- a/GIFrameworkMaps.Web/Controllers/APIController.cs
+++ b/GIFrameworkMaps.Web/Controllers/APIController.cs
@@ -104,16 +104,12 @@ namespace GIFrameworkMaps.Web.Controllers
                 source_svg.GetElementById("shape").Stroke = new SvgColourServer(System.Drawing.ColorTranslator.FromHtml("#" + border_colour));
                 source_svg.GetElementById("shape").StrokeWidth = 15;
             }
-            #pragma warning disable CA1416
-            //warning disabled as tracked in GitHub issue https://github.com/Dorset-Council-UK/GIFramework-Maps/issues/47
             source_svg.Width = width;
             source_svg.Height = height;
-            var outputImage = source_svg.Draw();
             // stream it
             using var ms = new MemoryStream();
-            outputImage.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
-            return File(ms.ToArray(), "image/png");
-            #pragma warning restore CA1416
+			source_svg.Write(ms);
+            return File(ms.ToArray(), "image/svg+xml");
         }
 
         public IActionResult WebManifest(int id)

--- a/GIFrameworkMaps.Web/wwwroot/css/site.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/site.css
@@ -29,8 +29,8 @@ a:focus {
   color: #23527c;
 }
 [data-bs-theme="dark"] a:hover,
-a:focus {
-  color: rgba(255, 255, 255, 1);
+[data-bs-theme="dark"] a:focus {
+    color: rgba(255, 255, 255, 1);
 }
 .btn-primary {
   color: #fff;


### PR DESCRIPTION
This PR make the SVG Icon generator work cross platform by returning it as an actual SVG rather than converting it to a PNG, which involved Windows specific APIs.

Fixes #47 