### PR TITLE
Fix issue with search result pins being in wrong projection

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -1060,12 +1060,15 @@ export class GIFWMap {
    * @returns A number indicating the percentage of the map that is covered by overlays
    */
   public getPercentOfMapCoveredWithOverlays(): number {
-    const mapPadding = this.getPaddingForMapCenter();
+    const leftPanelWidth = (document.querySelector("#gifw-sidebar-left") as HTMLDivElement
+    ).getBoundingClientRect().width;
+    const rightPanelWidth = (document.querySelector("#gifw-sidebar-right") as HTMLDivElement
+    ).getBoundingClientRect().width;
     const screenWidth = this.olMap
       .getOverlayContainer()
       .getBoundingClientRect().width;
-    const leftPanelPercentWidth = (mapPadding[3] / screenWidth) * 100;
-    const rightPanelPercentWidth = (mapPadding[1] / screenWidth) * 100;
+    const leftPanelPercentWidth = (leftPanelWidth / screenWidth) * 100;
+    const rightPanelPercentWidth = (rightPanelWidth / screenWidth) * 100;
     return leftPanelPercentWidth + rightPanelPercentWidth;
   }
 

--- a/GIFrameworkMaps.Web/Scripts/Search.ts
+++ b/GIFrameworkMaps.Web/Scripts/Search.ts
@@ -202,11 +202,13 @@ export class Search {
             ]),
             name: searchResultData.title,
           });
+          const searchResultEPSG = parseInt(permalinkParams.srepsg) ? parseInt(permalinkParams.srepsg) : 3857;
           this.drawSearchResultFeatureOnMap(
             resultIcon,
             searchResultData.content,
             searchResultData.title,
             this._iconStyle,
+            searchResultEPSG
           );
         }
       } catch (e) {

--- a/GIFrameworkMaps.Web/Scripts/Util.ts
+++ b/GIFrameworkMaps.Web/Scripts/Util.ts
@@ -646,6 +646,7 @@ export class Mapping {
     //get the current view
     const view = map.olMap.getView();
     const center = view.getCenter();
+    const projectionCode = view.getProjection().getCode();
     const lonlat = toLonLat(center, view.getProjection());
     let hash = `#map=${view.getZoom().toFixed(2)}/${lonlat[1].toFixed(
       5,
@@ -712,7 +713,7 @@ export class Mapping {
             const encodedSRData = Helper.b64EncodeUnicode(
               JSON.stringify(searchResultData),
             );
-            hash += `&sr=${coords[0]},${coords[1]}&srdata=${encodedSRData}`;
+            hash += `&sr=${coords[0]},${coords[1]}&srepsg=${projectionCode.replace("EPSG:", "")}&srdata=${encodedSRData}`;
           } catch (e) {
             console.warn(
               "Could not generate search result component for permalink",


### PR DESCRIPTION
This PR fixes a regression where search result pins encoded into URLs are encoded in the projection of the map, but this is not respected when reloading the map and it is assumed to be in Spherical Mercator, meaning the pin doesn't appear in the right place.

The search pin in the URL now has an additional parameter, `srepsg`, which uses the current map projection. This is then read on load to tell the map what projection the search result pin is in. For backwards compatibility, omitting this parameter will assume Spherical Mercator.

An additional fix has been added to the calculation that is used to determine how much space is taken up by panels. This was incorrect resulting in the search result panel being closed when users clicked a search result more often than we intended.

Fixes #228 