### PR TITLE
Fix migration issue with Tour Step entity

### DIFF
--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240327102830_FixTourDetailsColumn.Designer.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240327102830_FixTourDetailsColumn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GIFrameworkMaps.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240327102830_FixTourDetailsColumn")]
+    partial class FixTourDetailsColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240327102830_FixTourDetailsColumn.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240327102830_FixTourDetailsColumn.cs
@@ -19,7 +19,7 @@ namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 			migrationBuilder.Sql(
 				@"
 					UPDATE giframeworkmaps.""TourSteps""
-					SET ""TourDetailId"" = ""TourDetailsId""
+					SET ""TourDetailId"" = ""TourDetailsId"";
 				");
 
             migrationBuilder.DropColumn(

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240327102830_FixTourDetailsColumn.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240327102830_FixTourDetailsColumn.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class FixTourDetailsColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_TourSteps_TourDetails_TourDetailId",
+                schema: "giframeworkmaps",
+                table: "TourSteps");
+
+			//migrate column data
+			migrationBuilder.Sql(
+				@"
+					UPDATE giframeworkmaps.""TourSteps""
+					SET ""TourDetailId"" = ""TourDetailsId""
+				");
+
+            migrationBuilder.DropColumn(
+                name: "TourDetailsId",
+                schema: "giframeworkmaps",
+                table: "TourSteps");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "TourDetailId",
+                schema: "giframeworkmaps",
+                table: "TourSteps",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TourSteps_TourDetails_TourDetailId",
+                schema: "giframeworkmaps",
+                table: "TourSteps",
+                column: "TourDetailId",
+                principalSchema: "giframeworkmaps",
+                principalTable: "TourDetails",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_TourSteps_TourDetails_TourDetailId",
+                schema: "giframeworkmaps",
+                table: "TourSteps");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "TourDetailId",
+                schema: "giframeworkmaps",
+                table: "TourSteps",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "TourDetailsId",
+                schema: "giframeworkmaps",
+                table: "TourSteps",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TourSteps_TourDetails_TourDetailId",
+                schema: "giframeworkmaps",
+                table: "TourSteps",
+                column: "TourDetailId",
+                principalSchema: "giframeworkmaps",
+                principalTable: "TourDetails",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/GIFrameworkMap.Data/Models/Tour/TourStep.cs
+++ b/GIFrameworkMap.Data/Models/Tour/TourStep.cs
@@ -23,6 +23,6 @@ namespace GIFrameworkMaps.Data.Models.Tour
         public int StepNumber { get; set; }
 
         [Display(Name = "Tour to link step to")]
-        public int TourDetailsId { get; set; }
+        public int TourDetailId { get; set; }
     }
 }

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementTourController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementTourController.cs
@@ -132,7 +132,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                         "contact your system administrator.");
                 }
             }
-            tourToUpdate.Steps = await _context.TourSteps.Where(a => a.TourDetailsId == id).ToListAsync();
+            tourToUpdate.Steps = await _context.TourSteps.Where(a => a.TourDetailId == id).ToListAsync();
             return View(tourToUpdate);
         }
 

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementTourStepController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementTourStepController.cs
@@ -40,10 +40,10 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 return NotFound();
             }
 
-            var step = new TourStep { TourDetailsId = tourDetails.Id, StepNumber = tourDetails.Steps.Count + 1 };
+            var step = new TourStep { TourDetailId = tourDetails.Id, StepNumber = tourDetails.Steps.Count + 1 };
             return View(step);
         }
-
+		 
         //POST: TourStep/Create
         [HttpPost, ActionName("Create")]
         [ValidateAntiForgeryToken]
@@ -59,9 +59,9 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                     TempData["MessageType"] = "success";
                     if (addAnother)
                     {
-                        return RedirectToAction("Create", new { tourId = step.TourDetailsId });
+                        return RedirectToAction("Create", new { tourId = step.TourDetailId });
                     }
-                    return RedirectToAction("Edit","ManagementTour",new {id=step.TourDetailsId});
+                    return RedirectToAction("Edit","ManagementTour",new {id=step.TourDetailId});
                 }
                 catch (DbUpdateException ex)
                 {
@@ -102,7 +102,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 a => a.AttachToSelector,
                 a => a.AttachToPosition,
                 a => a.StepNumber,
-                a => a.TourDetailsId))
+                a => a.TourDetailId))
             {
 
                 try
@@ -110,7 +110,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                     await _context.SaveChangesAsync();
                     TempData["Message"] = "Tour step edited";
                     TempData["MessageType"] = "success";
-                    return RedirectToAction("Edit", "ManagementTour",new {id=stepToUpdate.TourDetailsId});
+                    return RedirectToAction("Edit", "ManagementTour",new {id=stepToUpdate.TourDetailId});
                 }
                 catch (DbUpdateException ex )
                 {
@@ -142,7 +142,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
         public async Task<IActionResult> DeleteConfirm(int id)
         {
             var stepToDelete = await _context.TourSteps.FirstOrDefaultAsync(a => a.Id == id);
-            var redirectTo = stepToDelete.TourDetailsId;
+            var redirectTo = stepToDelete.TourDetailId;
                 try
                 {
                     _context.TourSteps.Remove(stepToDelete);

--- a/GIFrameworkMaps.Web/Views/ManagementTourStep/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementTourStep/Create.cshtml
@@ -5,14 +5,14 @@
 
 <h1>@ViewData["Title"]</h1>
 
-<a asp-action="Edit" asp-controller="ManagementTour" asp-route-id="@Model.TourDetailsId" class="btn btn-link">Cancel</a>
+<a asp-action="Edit" asp-controller="ManagementTour" asp-route-id="@Model.TourDetailId" class="btn btn-link">Cancel</a>
 
 <form asp-action="Create">
     <div class="row mt-4">
         <div class="col-md-6">
 
             <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
-            <input type="hidden" asp-for="TourDetailsId" class="form-control" />
+            <input type="hidden" asp-for="TourDetailId" class="form-control" />
 
             <div class="mb-3">
                 <label asp-for="Title" class="control-label"></label>
@@ -58,7 +58,7 @@
             </div>
             <div class="mb-3">
                 <input type="submit" value="Create" class="btn btn-lg btn-primary" />
-                <a asp-action="Edit" asp-controller="ManagementTour" asp-route-id="@Model.TourDetailsId" class="btn btn-link">Cancel</a>
+                <a asp-action="Edit" asp-controller="ManagementTour" asp-route-id="@Model.TourDetailId" class="btn btn-link">Cancel</a>
             </div>
 
         </div>

--- a/GIFrameworkMaps.Web/Views/ManagementTourStep/Delete.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementTourStep/Delete.cshtml
@@ -18,7 +18,7 @@
 </div>
 
 <div>
-    <a asp-action="Edit" asp-controller="ManagementTour" asp-route-id="@Model.TourDetailsId" class="btn btn-link">Cancel</a>
+    <a asp-action="Edit" asp-controller="ManagementTour" asp-route-id="@Model.TourDetailId" class="btn btn-link">Cancel</a>
 </div>
 
             

--- a/GIFrameworkMaps.Web/Views/ManagementTourStep/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementTourStep/Edit.cshtml
@@ -5,14 +5,14 @@
 
 <h1>@ViewData["Title"]</h1>
 
-<a asp-action="Edit" asp-controller="ManagementTour" asp-route-id="@Model.TourDetailsId" class="btn btn-link">Cancel</a>
+<a asp-action="Edit" asp-controller="ManagementTour" asp-route-id="@Model.TourDetailId" class="btn btn-link">Cancel</a>
 
 <form asp-action="Edit">
     <div class="row mt-4">
         <div class="col-md-6">
 
             <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
-            <input type"hidden" asp-for="TourDetailsId" class="form-control" />
+            <input type"hidden" asp-for="TourDetailId" class="form-control" />
 
             <div class="mb-3">
                 <label asp-for="Title" class="control-label"></label>
@@ -56,7 +56,7 @@
 
             <div class="mb-3">
                 <input type="submit" value="Save changes" class="btn btn-lg btn-primary" />
-                <a asp-action="Edit" asp-controller="ManagementTour" asp-route-id="@Model.TourDetailsId" class="btn btn-link">Cancel</a>
+                <a asp-action="Edit" asp-controller="ManagementTour" asp-route-id="@Model.TourDetailId" class="btn btn-link">Cancel</a>
             </div>
 
         </div>


### PR DESCRIPTION
This PR fixes a minor issue with the previous migration. I believe (but could be wrong!) that the cause of the issue was as follows:
- Entity `TourDetails` was renamed to `TourDetail` as part of #237 
- `TourDetail` has a List of `TourStep` creating a foreign key relationship
- The entity `TourStep` had a property of `TourDetailsId`, which represented the key used in the foreign key relationship
- When the entity was renamed, the convention called for a new property called `TourDetailId` (note the removal of the plural). This column was added as part of the migration, but the old column was not removed, and even if it was, data would have been lost

To resolve this, I've renamed the `TourDetailsId` property or `TourStep` to `TourDetailId`, this now matches the convention and EF was able to work out the purpose of the column. To prevent loss of data, I manually updated the migration code to copy the data from the old column to the new column before removing it. 

This seems to have resulted in the correct expected structure in the database