### PR TITLE
Improvements to text annotations

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
@@ -278,6 +278,14 @@ export default class AnnotationStyle extends Style {
       );
       this.getImage().setOpacity(1);
     } else if (tool.name == "Text") {
+        let fontStrokeWidth = 0.5
+        if (this.fontSize > 16 && this.fontSize <= 24) {
+            fontStrokeWidth = 1;
+        } else if (this.fontSize > 24 && this.fontSize <= 48) {
+            fontStrokeWidth = 2;
+        } else if (this.fontSize >= 48) {
+            fontStrokeWidth = 3;
+        }
       this.setText(
         new Text({
           fill: new Fill({
@@ -285,7 +293,7 @@ export default class AnnotationStyle extends Style {
           }),
           stroke: new Stroke({
             color: "#FFFFFF",
-            width: 1,
+            width: fontStrokeWidth,
           }),
           text: this.labelText,
             font: `${this.fontStyle} ${this.fontSize}px "${this.fontFamily}", sans-serif`,

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
@@ -12,6 +12,7 @@ export default class AnnotationStyle extends Style {
   fontColourHex: string;
   fontFamily: string;
   fontStyle: string;
+  fontSize: number;
   gifwMapInstance: GIFWMap;
   labelText: string;
   opacity: number;
@@ -53,6 +54,7 @@ export default class AnnotationStyle extends Style {
     this.strokeWidth = 2;
     this.fontFamily = "Arial";
     this.fontStyle = "normal";
+    this.fontSize = 24;
     this.pointHasBorder = false;
     this.borderColour = "rgb(0, 0, 0)";
     this.borderColourHex = "000000";
@@ -143,6 +145,7 @@ export default class AnnotationStyle extends Style {
     clone.fontColourHex = this.fontColourHex;
     clone.fontFamily = this.fontFamily;
     clone.fontStyle = this.fontStyle;
+    clone.fontSize = this.fontSize;
     clone.labelText = this.labelText;
     clone.opacity = this.opacity;
     clone.pointType = this.pointType;
@@ -285,7 +288,7 @@ export default class AnnotationStyle extends Style {
             width: 1,
           }),
           text: this.labelText,
-            font: `${this.fontStyle} ${this.size}px "${this.fontFamily}", sans-serif`,
+            font: `${this.fontStyle} ${this.fontSize}px "${this.fontFamily}", sans-serif`,
           scale: window.devicePixelRatio,
         }),
       );
@@ -299,6 +302,7 @@ export default class AnnotationStyle extends Style {
     this.fontColourHex = e.detail.style.fontColourHex || this.fontColourHex;
     this.fontFamily = e.detail.style.fontFamily || this.fontFamily;
     this.fontStyle = e.detail.style.fontStyle || this.fontStyle;
+    this.fontSize = e.detail.style.fontSize || this.fontSize;
     this.labelText = e.detail.style.labelText || this.labelText;
     if (e.detail.style.opacity != undefined && e.detail.style.opacity != null) {
       this.opacity = e.detail.style.opacity;

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationStyle.ts
@@ -11,6 +11,7 @@ export default class AnnotationStyle extends Style {
   fontColour: string;
   fontColourHex: string;
   fontFamily: string;
+  fontStyle: string;
   gifwMapInstance: GIFWMap;
   labelText: string;
   opacity: number;
@@ -51,6 +52,7 @@ export default class AnnotationStyle extends Style {
     this.strokeStyle = "solid";
     this.strokeWidth = 2;
     this.fontFamily = "Arial";
+    this.fontStyle = "normal";
     this.pointHasBorder = false;
     this.borderColour = "rgb(0, 0, 0)";
     this.borderColourHex = "000000";
@@ -140,6 +142,7 @@ export default class AnnotationStyle extends Style {
     clone.fontColour = this.fontColour;
     clone.fontColourHex = this.fontColourHex;
     clone.fontFamily = this.fontFamily;
+    clone.fontStyle = this.fontStyle;
     clone.labelText = this.labelText;
     clone.opacity = this.opacity;
     clone.pointType = this.pointType;
@@ -282,7 +285,7 @@ export default class AnnotationStyle extends Style {
             width: 1,
           }),
           text: this.labelText,
-          font: `${this.size}px "${this.fontFamily}", sans-serif`,
+            font: `${this.fontStyle} ${this.size}px "${this.fontFamily}", sans-serif`,
           scale: window.devicePixelRatio,
         }),
       );
@@ -295,6 +298,7 @@ export default class AnnotationStyle extends Style {
     this.fillColourHex = e.detail.style.fillColourHex || this.fillColourHex;
     this.fontColourHex = e.detail.style.fontColourHex || this.fontColourHex;
     this.fontFamily = e.detail.style.fontFamily || this.fontFamily;
+    this.fontStyle = e.detail.style.fontStyle || this.fontStyle;
     this.labelText = e.detail.style.labelText || this.labelText;
     if (e.detail.style.opacity != undefined && e.detail.style.opacity != null) {
       this.opacity = e.detail.style.opacity;

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
@@ -350,6 +350,16 @@ TextTool.optionsHTML = `
         </div>
     </div>
     <div class="form-group row mb-1">
+        <label class="form-label">Font style</label>
+        <div>
+            <select class="form-select" aria-label="Style" data-style-property="fontStyle">
+                <option selected value="normal">Normal</option>
+                <option value="italic">Italic</option>
+                <option value="bold">Bold</option>
+            </select>
+        </div>
+    </div>
+    <div class="form-group row mb-1">
         <label class="form-label">Font colour</label>
         <div>
             <input type="color" class="form-range" data-style-property="fontColour" list="annotationColors" id="colors" />

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
@@ -342,7 +342,10 @@ TextTool.optionsHTML = `
         <div>
             <select class="form-select" aria-label="Font" data-style-property="font">
                 <option selected value="Arial">Arial</option>
-                <option value="Tahoma">Tahoma</option>
+                <option value="Verdana">Verdana</option>
+                <option value="Impact">Impact</option>
+                <option value="Georgia">Georgia</option>
+                <option value="Courier New">Courier New</option>
             </select>
         </div>
     </div>

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
@@ -422,7 +422,7 @@ TextTool.optionsHTML = `
         <label class="form-label" for="gifw-annotation-control-font-size">Font size</label>
         <div class="row">
             <div class="col">
-                <input type="range" class="form-range" data-style-property="size" id="gifw-annotation-control-font-size" min="16" max="64" value="24" step="8" oninput="document.querySelector('output[for=gifw-annotation-control-font-size]').value=this.value + 'px'">
+                <input type="range" class="form-range" data-style-property="fontSize" id="gifw-annotation-control-font-size" min="16" max="64" value="24" step="8" oninput="document.querySelector('output[for=gifw-annotation-control-font-size]').value=this.value + 'px'">
             </div>
             <div class="col-auto">
                 <output for="gifw-annotation-control-font-size" class="badge bg-primary" style="width:3rem;">24px</output>

--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationTool.ts
@@ -63,15 +63,25 @@ PolygonTool.optionsHTML = `
         </div>
     </div>
     <div class="form-group row mb-1">
-        <label class="form-label">Fill opacity</label>
-        <div>
-            <input type="range" class="form-range" data-style-property="opacity" min="0" max="1" value="0.2" step="0.1">
+        <label class="form-label" for="gifw-annotation-control-polygon-opacity">Fill opacity</label>
+        <div class="row">
+            <div class="col">
+                <input type="range" class="form-range" data-style-property="opacity" id="gifw-annotation-control-polygon-opacity" min="0" max="1" value="0.2" step="0.1" oninput="document.querySelector('output[for=gifw-annotation-control-polygon-opacity]').value=(this.value * 100) + '%'">
+            </div>
+            <div class="col-auto">
+                <output for="gifw-annotation-control-polygon-opacity" class="badge bg-primary" style="width:3rem;">20%</output>
+            </div>
         </div>
     </div>
     <div class="form-group row mb-1">
-        <label class="form-label">Line width</label>
-        <div>
-            <input type="range" class="form-range" data-style-property="strokeWidth" min="1" max="5" value="2">
+        <label class="form-label" for="gifw-annotation-control-polygon-line-width">Line width</label>
+        <div class="row">
+            <div class="col">
+                <input type="range" class="form-range" data-style-property="strokeWidth" id="gifw-annotation-control-polygon-line-width" min="1" max="5" value="2" oninput="document.querySelector('output[for=gifw-annotation-control-polygon-line-width]').value=this.value + 'px'">
+            </div>
+            <div class="col-auto">
+                <output for="gifw-annotation-control-polygon-line-width" class="badge bg-primary" style="width:3rem;">2px</output>
+            </div>
         </div>
     </div>
     <div class="form-group row mb-1">
@@ -109,9 +119,14 @@ LineTool.optionsHTML = `
         </div>
     </div>
     <div class="form-group row mb-1">
-        <label class="form-label">Line width</label>
-        <div>
-            <input type="range" class="form-range" data-style-property="strokeWidth" min="1" max="5" value="2">
+        <label class="form-label" for="gifw-annotation-control-line-width">Line width</label>
+        <div class="row">
+            <div class="col">
+                <input type="range" class="form-range" data-style-property="strokeWidth" id="gifw-annotation-control-line-width" min="1" max="5" value="2" oninput="document.querySelector('output[for=gifw-annotation-control-line-width]').value=this.value + 'px'">
+            </div>
+            <div class="col-auto">
+                <output for="gifw-annotation-control-line-width" class="badge bg-primary" style="width:3rem;">2px</output>
+            </div>
         </div>
     </div>
     <div class="form-group row mb-1">
@@ -168,9 +183,14 @@ PointTool.optionsHTML = `
         </div>
     </div>
     <div class="form-group row mb-1">
-        <label class="form-label">Size</label>
-        <div>
-            <input type="range" class="form-range" data-style-property="size" min="12" max="60" value="24" step="12">
+        <label class="form-label" for="gifw-annotation-control-point-size">Size</label>
+        <div class="row">
+            <div class="col">
+                <input type="range" class="form-range" data-style-property="size" id="gifw-annotation-control-point-size" min="12" max="60" value="24" step="12" oninput="document.querySelector('output[for=gifw-annotation-control-point-size]').value=this.value + 'px'">
+            </div>
+            <div class="col-auto">
+                <output for="gifw-annotation-control-point-size" class="badge bg-primary" style="width:3rem;">24px</output>
+            </div>
         </div>
     </div>
     <div class="form-group mb-1">
@@ -196,9 +216,14 @@ PointTool.optionsHTML = `
             </div>
         </div>
         <div class="form-group mb-1">
-            <label class="form-label" for="gifw-annotation-border-thickness">Border thickness</label>
-            <div>
-                <input id="gifw-annotation-border-thickness" type="range" class="form-range" data-style-property="borderWidth" min="0.2" max="1" value="0.5" step="0.1">
+            <label class="form-label" for="gifw-annotation-point-border-thickness">Border thickness</label>
+            <div class="row">
+                <div class="col">
+                    <input id="gifw-annotation-point-border-thickness" type="range" class="form-range" data-style-property="borderWidth" min="0.2" max="1" value="0.5" step="0.1" oninput="document.querySelector('output[for=gifw-annotation-point-border-thickness]').value=this.value + 'px'">
+                </div>
+                <div class="col-auto">
+                    <output for="gifw-annotation-point-border-thickness" class="badge bg-primary" style="width:3rem;">0.5px</output>
+                </div>
             </div>
         </div>
     </div>
@@ -233,15 +258,25 @@ CircleTool.optionsHTML = `
         </div>
     </div>
     <div class="form-group row mb-1">
-        <label class="form-label">Fill opacity</label>
-        <div>
-            <input type="range" class="form-range" data-style-property="opacity" min="0" max="1" value="0.2" step="0.1">
+        <label class="form-label" for="gifw-annotation-control-circle-opacity">Fill opacity</label>
+        <div class="row">
+            <div class="col">
+                <input type="range" class="form-range" data-style-property="opacity" id="gifw-annotation-control-circle-opacity" min="0" max="1" value="0.2" step="0.1" oninput="document.querySelector('output[for=gifw-annotation-control-circle-opacity]').value=(this.value * 100) + '%'">
+            </div>
+            <div class="col-auto">
+                <output for="gifw-annotation-control-circle-opacity" class="badge bg-primary" style="width:3rem;">20%</output>
+            </div>
         </div>
     </div>
     <div class="form-group row mb-1">
-        <label class="form-label">Line width</label>
-        <div>
-            <input type="range" class="form-range" data-style-property="strokeWidth" min="1" max="5" value="2">
+        <label class="form-label" for="gifw-annotation-control-circle-line-width">Line width</label>
+        <div class="row">
+            <div class="col">
+                <input type="range" class="form-range" data-style-property="strokeWidth" id="gifw-annotation-control-circle-line-width" min="1" max="5" value="2" oninput="document.querySelector('output[for=gifw-annotation-control-circle-line-width]').value=this.value + 'px'">
+            </div>
+            <div class="col-auto">
+                <output for="gifw-annotation-control-circle-line-width" class="badge bg-primary" style="width:3rem;">2px</output>
+            </div>
         </div>
     </div>
     <div class="form-group row mb-1">
@@ -300,15 +335,25 @@ BufferTool.optionsHTML = `
         </div>
     </div>
     <div class="form-group row mb-1">
-        <label class="form-label">Fill opacity</label>
-        <div>
-            <input type="range" class="form-range" data-style-property="opacity" min="0" max="1" value="0.2" step="0.1">
+        <label class="form-label" for="gifw-annotation-control-buffer-opacity">Fill opacity</label>
+        <div class="row">
+            <div class ="col">
+                <input type="range" class="form-range" data-style-property="opacity" id="gifw-annotation-control-buffer-opacity" min="0" max="1" value="0.2" step="0.1" oninput="document.querySelector('output[for=gifw-annotation-control-buffer-opacity]').value=(this.value * 100) + '%'">
+            </div>
+            <div class="col-auto">
+                <output for="gifw-annotation-control-buffer-opacity" class="badge bg-primary" style="width:3rem;">20%</output>
+            </div>
         </div>
     </div>
     <div class="form-group row mb-1">
-        <label class="form-label">Line width</label>
-        <div>
-            <input type="range" class="form-range" data-style-property="strokeWidth" min="1" max="5" value="2">
+        <label class="form-label" for="gifw-annotation-control-buffer-line-width">Line width</label>
+        <div class="row">
+            <div class ="col">
+                <input type="range" class="form-range" data-style-property="strokeWidth" id="gifw-annotation-control-buffer-line-width" min="1" max="5" value="2" oninput="document.querySelector('output[for=gifw-annotation-control-buffer-line-width]').value=this.value + 'px'">
+            </div>
+            <div class="col-auto">
+                <output for="gifw-annotation-control-buffer-line-width" class="badge bg-primary" style="width:3rem;">2px</output>
+            </div>
         </div>
     </div>
     <div class="form-group row mb-1">
@@ -374,9 +419,14 @@ TextTool.optionsHTML = `
         </div>
     </div>
     <div class="form-group row mb-1">
-        <label class="form-label">Font size</label>
-        <div>
-            <input type="range" class="form-range" data-style-property="size" min="16" max="64" value="24" step="8">
+        <label class="form-label" for="gifw-annotation-control-font-size">Font size</label>
+        <div class="row">
+            <div class="col">
+                <input type="range" class="form-range" data-style-property="size" id="gifw-annotation-control-font-size" min="16" max="64" value="24" step="8" oninput="document.querySelector('output[for=gifw-annotation-control-font-size]').value=this.value + 'px'">
+            </div>
+            <div class="col-auto">
+                <output for="gifw-annotation-control-font-size" class="badge bg-primary" style="width:3rem;">24px</output>
+            </div>
         </div>
     </div>
 `;

--- a/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
@@ -127,6 +127,9 @@ export default class AnnotationStylePanel implements SidebarPanel {
             case "font":
               control.value = this.activeStyle.fontFamily;
               break;
+            case "fontStyle":
+              control.value = this.activeStyle.fontStyle;
+              break;
             case "labelText":
               control.value = this.activeStyle.labelText;
               control.setAttribute("input-text", control.value);
@@ -234,6 +237,9 @@ export default class AnnotationStylePanel implements SidebarPanel {
       case "font":
         this.activeStyle.fontFamily = control.value;
         break;
+      case "fontStyle":
+         this.activeStyle.fontStyle = control.value;
+         break;
       case "labelText":
         this.activeStyle.labelText = control.getAttribute("input-text");
         break;

--- a/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
@@ -134,6 +134,12 @@ export default class AnnotationStylePanel implements SidebarPanel {
             case "fontStyle":
               control.value = this.activeStyle.fontStyle;
               break;
+            case "fontSize":
+              control.value = this.activeStyle.fontSize.toString();
+                if (outputEle) {
+                    (outputEle as HTMLOutputElement).value = `${this.activeStyle.fontSize}px`;
+                }
+              break;
             case "labelText":
               control.value = this.activeStyle.labelText;
               control.setAttribute("input-text", control.value);
@@ -248,8 +254,11 @@ export default class AnnotationStylePanel implements SidebarPanel {
         this.activeStyle.fontFamily = control.value;
         break;
       case "fontStyle":
-         this.activeStyle.fontStyle = control.value;
-         break;
+        this.activeStyle.fontStyle = control.value;
+        break;
+      case "fontSize":
+        this.activeStyle.fontSize = parseFloat(control.value);
+        break;
       case "labelText":
         this.activeStyle.labelText = control.getAttribute("input-text");
         break;

--- a/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/AnnotationStylePanel.ts
@@ -113,13 +113,17 @@ export default class AnnotationStylePanel implements SidebarPanel {
         const controls = this.optionsPanel.querySelectorAll<
           HTMLInputElement | HTMLSelectElement
         >("input, select");
-        controls.forEach((control) => {
+          controls.forEach((control) => {
+              const outputEle = document.querySelector(`output[for=${control.id || "invalid"}]`);
           switch (control.getAttribute("data-style-property")) {
             case "fillColour":
               control.value = `#${this.activeStyle.fillColourHex}`;
               break;
             case "opacity":
-              control.value = this.activeStyle.opacity.toString();
+                  control.value = this.activeStyle.opacity.toString();
+                  if (outputEle) {
+                      (outputEle as HTMLOutputElement).value = `${(this.activeStyle.opacity * 100)}%`;
+                  }
               break;
             case "fontColour":
               control.value = `#${this.activeStyle.fontColourHex}`;
@@ -138,7 +142,10 @@ export default class AnnotationStylePanel implements SidebarPanel {
               control.value = this.activeStyle.pointType;
               break;
             case "size":
-              control.value = this.activeStyle.size.toString();
+                  control.value = this.activeStyle.size.toString();
+                  if (outputEle) {
+                      (outputEle as HTMLOutputElement).value = `${this.activeStyle.size}px`;
+                  }
               break;
             case "radiusNumber":
               control.value = this.activeStyle.radiusNumber.toString();
@@ -164,7 +171,10 @@ export default class AnnotationStylePanel implements SidebarPanel {
               control.value = this.activeStyle.strokeStyle;
               break;
             case "strokeWidth":
-              control.value = this.activeStyle.strokeWidth.toString();
+                  control.value = this.activeStyle.strokeWidth.toString();
+                  if (outputEle) {
+                      (outputEle as HTMLOutputElement).value = `${this.activeStyle.strokeWidth}px`;
+                  }
               break;
             case "pointHasBorder": {
               (control as HTMLInputElement).checked =


### PR DESCRIPTION
Text annotations have been improved and more options are available to users.

- There is now a larger selection of fonts to pick from: Arial, Verdana, Impact, Georgia and Courier New.
- Fonts can now be styled as normal, bold or italic.
- There is now a white border around text that scales with the font size - this helps to make the text more readable when placed on the map.
- Labels have been added to all sliders in the annotations menu to make it clearer what the values of the sliders are.

![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/de6d1611-e27b-47eb-b7ee-79a4fbfa3259)

Closes #239