### PR TITLE
Web layer service definition sorting order now automatic

### DIFF
--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240410131023_RemoveSortOrderFromWebLayerServiceDefinition.Designer.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240410131023_RemoveSortOrderFromWebLayerServiceDefinition.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GIFrameworkMaps.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240410131023_RemoveSortOrderFromWebLayerServiceDefinition")]
+    partial class RemoveSortOrderFromWebLayerServiceDefinition
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMap.Data/Migrations/ApplicationDb/20240410131023_RemoveSortOrderFromWebLayerServiceDefinition.cs
+++ b/GIFrameworkMap.Data/Migrations/ApplicationDb/20240410131023_RemoveSortOrderFromWebLayerServiceDefinition.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class RemoveSortOrderFromWebLayerServiceDefinition : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SortOrder",
+                schema: "giframeworkmaps",
+                table: "WebLayerServiceDefinitions");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SortOrder",
+                schema: "giframeworkmaps",
+                table: "WebLayerServiceDefinitions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}

--- a/GIFrameworkMap.Data/Models/WebLayerServiceDefinition.cs
+++ b/GIFrameworkMap.Data/Models/WebLayerServiceDefinition.cs
@@ -27,11 +27,11 @@ namespace GIFrameworkMaps.Data.Models
         [DisplayName("Category (optional)")]
         public string? Category { get; set; }
 
-        [Required]
-        [DisplayName("Sort order")]
-        public int SortOrder { get; set; }
+		[Required]
+		[DisplayName("Sort order")]
+		public int SortOrder { get; set; }
 
-        public bool ProxyMetaRequests { get; set; }
+		public bool ProxyMetaRequests { get; set; }
 
         public bool ProxyMapRequests { get; set; }
 

--- a/GIFrameworkMap.Data/Models/WebLayerServiceDefinition.cs
+++ b/GIFrameworkMap.Data/Models/WebLayerServiceDefinition.cs
@@ -27,10 +27,6 @@ namespace GIFrameworkMaps.Data.Models
         [DisplayName("Category (optional)")]
         public string? Category { get; set; }
 
-		[Required]
-		[DisplayName("Sort order")]
-		public int SortOrder { get; set; }
-
 		public bool ProxyMetaRequests { get; set; }
 
         public bool ProxyMapRequests { get; set; }

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementWebLayerServiceDefinitionController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementWebLayerServiceDefinitionController.cs
@@ -98,7 +98,6 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 a => a.Type, 
                 a => a.Version, 
                 a => a.Category, 
-                a => a.SortOrder, 
                 a => a.ProxyMapRequests, 
                 a => a.ProxyMetaRequests,
                 a => a.AdminOnly))

--- a/GIFrameworkMaps.Web/Scripts/WebLayerService.ts
+++ b/GIFrameworkMaps.Web/Scripts/WebLayerService.ts
@@ -132,7 +132,7 @@ export class WebLayerService {
       'select[name="ogc-server-name"]',
     );
     selectEle.innerHTML = "";
-    this.serviceDefinitions.sort((a, b) => a.sortOrder - b.sortOrder);
+    this.serviceDefinitions.sort((a, b) => a.name.localeCompare(b.name));
     const groupedDefs = Helper.groupBy(
       this.serviceDefinitions,
       (defs) => defs.category,

--- a/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
@@ -40,13 +40,13 @@
                                 <select class="form-select" id="service-select">
 
                                     @{
-                                        var grouped = Model.OrderBy(d => d.SortOrder).GroupBy(d => d.Category);
+                                        var grouped = Model.OrderBy(d => d.Name).GroupBy(d => d.Category);
                                     }
 
                                     @foreach (var group in grouped)
                                     {
                                         <optgroup label="@group.First().Category">
-                                            @foreach (var definition in group.OrderBy(d => d.SortOrder))
+                                            @foreach (var definition in group.OrderBy(d => d.Name))
                                             {
 
                                                 <option value="@definition.Url"

--- a/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Create.cshtml
@@ -56,12 +56,6 @@
             </div>
 
             <div class="mb-3">
-                <label asp-for="SortOrder" class="control-label"></label>
-                <input asp-for="SortOrder" class="form-control" />
-                <span asp-validation-for="SortOrder" class="text-danger"></span>
-            </div>
-
-            <div class="mb-3">
                 <input asp-for="ProxyMapRequests" class="form-check-input" type="checkbox" />
                 <label asp-for="ProxyMapRequests" class="control-label"> Enable proxy map requests?</label>
                 <span asp-validation-for="ProxyMapRequests" class="text-danger"></span>

--- a/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementWebLayerServiceDefinition/Edit.cshtml
@@ -57,12 +57,6 @@
             </div>
 
             <div class="mb-3">
-                <label asp-for="SortOrder" class="control-label"></label>
-                <input asp-for="SortOrder" class="form-control" />
-                <span asp-validation-for="SortOrder" class="text-danger"></span>
-            </div>
-
-            <div class="mb-3">
                 <input asp-for="ProxyMapRequests" class="form-check-input" type="checkbox" />
                 <label asp-for="ProxyMapRequests" class="control-label"> Enable proxy map requests?</label>
                 <span asp-validation-for="ProxyMapRequests" class="text-danger"></span>


### PR DESCRIPTION
Web layer service definitions now sort automatically by group > alphabet rather than by the SortOrder value, and the option to choose a sort order has been removed from the admin area.

The now-unused SortOrder column has also been removed from the database.

Closes #249 