### PR TITLE
Add embed mode

### DIFF
--- a/GIFrameworkMaps.Web/Controllers/SearchController.cs
+++ b/GIFrameworkMaps.Web/Controllers/SearchController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace GIFrameworkMaps.Web.Controllers
@@ -38,21 +39,16 @@ namespace GIFrameworkMaps.Web.Controllers
             var searchOpts = await _repository.GetSearchDefinitionsByVersion(id);
 
             //convert to smaller payload required for map
-            //This might be better converted with something like AutoMapper
-            //but for now this works
             List<RequiredSearch> searches = [];
-            
-            foreach(var opt in searchOpts)
-            {
-                searches.Add(new RequiredSearch
-                {
-                    Enabled = opt.Enabled,
-                    Name = opt.SearchDefinition.Name,
-                    Order = opt.Order,
-                    SearchDefinitionId = opt.SearchDefinition.Id,
-                    StopIfFound = opt.StopIfFound
-                });
-            }
+
+			searches = searchOpts.Select(s => new RequiredSearch 
+			{ 
+				Enabled = s.Enabled, 
+				Name = s.SearchDefinition.Name,
+				Order = s.Order,
+				SearchDefinitionId = s.SearchDefinition.Id,
+				StopIfFound = s.StopIfFound
+			}).ToList();
 
             return Json(searches);
         }

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/SidebarPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/SidebarPanel.ts
@@ -1,4 +1,5 @@
 ﻿import { Map as olMap } from "ol";
+import { GIFWMap } from "../Map";
 
 export interface SidebarPanel {
   container?: string;
@@ -6,4 +7,5 @@ export interface SidebarPanel {
   olMapInstance?: olMap;
   init: () => void;
   render: () => void;
+  setGIFWMapInstance: (map: GIFWMap) => void;
 }

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -50,6 +50,7 @@ export class GIFWMap {
   layerGroups: LayerGroup[];
   sidebars: gifwSidebar.Sidebar[];
   popupOverlay: GIFWPopupOverlay;
+  mode: 'full' | 'embed' = 'full';
   olMap: olMap;
   customControls: (
     | GIFWMousePositionControl
@@ -64,10 +65,12 @@ export class GIFWMap {
     id: string,
     config: VersionViewModel,
     sidebars: gifwSidebar.Sidebar[],
+    mode: 'full' | 'embed'
   ) {
     this.id = id;
     this.config = config;
     this.sidebars = sidebars;
+    this.mode = mode;
     this.delayPermalinkUpdate = debounce(() => {
       document
         .getElementById(this.id)
@@ -104,8 +107,10 @@ export class GIFWMap {
       );
     }
     // set up controls
+  
     const attribution = new olControl.Attribution({
-      collapsible: false,
+      collapsible: true,
+      collapsed: this.mode === 'embed',
     });
     const scaleline = new olControl.ScaleLine({
       units: "metric",
@@ -114,7 +119,7 @@ export class GIFWMap {
       autoHide: false,
       tipLabel: "Reset rotation (Alt-Shift and Drag to rotate)",
     });
-    //mouse position controls. TODO - alow DB setting of initial coord system
+    //add mouse position
     const mousePosition = new GIFWMousePositionControl(
       defaultViewProjection.epsgCode.toString(),
       defaultViewProjection.defaultRenderedDecimalPlaces,
@@ -821,9 +826,11 @@ export class GIFWMap {
     map: olMap,
     attribution: olControl.Attribution,
   ): void {
-    const small = map.getSize()[0] < 600;
-    attribution.setCollapsible(small);
-    attribution.setCollapsed(small);
+    if (this.mode !== "embed") {
+      const small = map.getSize()[0] < 600;
+      if(attribution.getCollapsed())
+      attribution.setCollapsed(small);
+    }
   }
 
   /**

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -395,10 +395,12 @@ export class GIFWMap {
       map.getView().fit(reprojectedExtent, { size: mapSize });
     }
     //add attribution size checker and app height variable
-    window.addEventListener("resize", () => {
+    if (this.mode !== "embed") {
+      window.addEventListener("resize", () => {
+        this.checkAttributionSize(map, attribution);
+      });
       this.checkAttributionSize(map, attribution);
-    });
-    this.checkAttributionSize(map, attribution);
+    }
 
     //add drag and drop
     this.addDragAndDropInteraction();
@@ -826,11 +828,8 @@ export class GIFWMap {
     map: olMap,
     attribution: olControl.Attribution,
   ): void {
-    if (this.mode !== "embed") {
       const small = map.getSize()[0] < 600;
-      if(attribution.getCollapsed())
       attribution.setCollapsed(small);
-    }
   }
 
   /**

--- a/GIFrameworkMaps.Web/Scripts/Util.ts
+++ b/GIFrameworkMaps.Web/Scripts/Util.ts
@@ -89,8 +89,15 @@ export class Browser {
         hashParams[hashParamKVP[0].toLowerCase()] = decodeURI(hashParamKVP[1]);
       }
     });
-
     return hashParams;
+  }
+
+  static extractParamFromHash(hash: string, paramName: string) {
+    const hashParams = this.extractParamsFromHash(hash);
+    if (hashParams[paramName]) {
+      return hashParams[paramName];
+    }
+    return null;
   }
 
   /**
@@ -722,6 +729,9 @@ export class Mapping {
           }
         }
       }
+    }
+    if (map.mode === 'embed') {
+      hash += '&embed=true';
     }
     const baseUrl = `${window.location.origin}${window.location.pathname}`;
     return `${baseUrl}${hash}`;

--- a/GIFrameworkMaps.Web/Views/Shared/_MapLayout.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/_MapLayout.cshtml
@@ -41,6 +41,23 @@
     <partial name="_AnalyticsHeadPartial" model=@analyticsModel />
 </head>
 <body class="d-flex flex-column giframeworkMap">
+    <script>
+        let hash = window.location.hash;
+        if (hash.startsWith("#")) {
+            hash = hash.substring(1);
+        }
+        const hashParams = {};
+        hash.split("&").map((hk) => {
+            //split method taken from https://stackoverflow.com/a/4607799/863487
+            const hashParamKVP = hk.split(/=(.*)/s).slice(0, 2);
+            if (hashParamKVP.length === 2) {
+                hashParams[hashParamKVP[0].toLowerCase()] = decodeURI(hashParamKVP[1]);
+            }
+        });
+        if (hashParams.embed) {
+            document.body.classList.add("embed");
+        }
+    </script>
     <partial name="_AnalyticsPartial" model=@analyticsModel />
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark box-shadow">

--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -39,7 +39,8 @@
   top: 13em;
 }
 .giframeworkMap.embed .gifw-measure-control {
-  top: calc(13em - var(--embed-vertical-shift));
+  /*top: calc(13em - var(--embed-vertical-shift));*/
+  display:none;
 }
 .giframeworkMap .gifw-measure-control.ol-hidden {
   opacity: 0;
@@ -66,7 +67,8 @@
   top: 15.5em;
 }
 .giframeworkMap.embed .gifw-annotation-control {
-  top: calc(15.5em - var(--embed-vertical-shift));
+  /*top: calc(15.5em - var(--embed-vertical-shift));*/
+  display:none;
 }
 .giframeworkMap .gifw-annotation-control.ol-hidden {
   opacity: 0;
@@ -108,7 +110,8 @@
   top: 18em;
 }
 .giframeworkMap.embed .gifw-info-control {
-  top: calc(18em - var(--embed-vertical-shift));
+  /*top: calc(18em - var(--embed-vertical-shift));*/
+  display:none;
 }
 .giframeworkMap .gifw-info-control.ol-hidden {
   opacity: 0;
@@ -136,7 +139,8 @@
   top: 20.5em;
 }
 .giframeworkMap.embed .gifw-geolocation-control {
-  top: calc(20.5em - var(--embed-vertical-shift));
+  /*top: calc(20.5em - var(--embed-vertical-shift));*/
+  display:none;
 }
 .giframeworkMap .gifw-geolocation-control.gifw-geolocation-recentre-control {
   left: 2.75rem;
@@ -186,14 +190,20 @@
   backdrop-filter: blur(2px);
 }
 .giframeworkMap .ol-attribution {
-  max-width: calc(100% - 10em);
+  max-width: 70%;
   backdrop-filter: blur(2px);
   font-size: 0.8rem;
   background: rgba(var(--bs-body-bg-rgb), 0.8);
+  bottom:0;
+  right:0;
 }
 .giframeworkMap .ol-attribution ul {
   text-shadow: none;
   color: var(--bs-body-color);
+}
+.giframeworkMap .ol-attribution button{
+  width:1.7rem;
+  height:1.7rem;
 }
 [data-bs-theme="dark"] .giframeworkMap .ol-attribution a {
   color: var(--bs-body-color);
@@ -475,7 +485,9 @@
   z-index: 101;
   top: 3.5rem;
 }
-
+.giframeworkMap.embed .gifw-search-control{
+  top: .5rem;
+}
 /*Medium devices (tablets, 768px and up)*/
 @media (min-width: 768px) {
   .giframeworkMap .search-control {

--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -5,6 +5,7 @@
   position: absolute;
   top: 0;
   overflow-y: hidden;
+  --embed-vertical-shift: 2em;
 }
 
 .giframeworkMap header {
@@ -15,18 +16,30 @@
   background-color: var(--primary-color-transparent-90);
   padding: 0.25rem 0.5rem;
 }
+.giframeworkMap.embed .navbar {
+  display: none;
+}
 .giframeworkMap .ol-zoom {
   top: 6em;
+}
+.giframeworkMap.embed .ol-zoom {
+  top: calc(6em - var(--embed-vertical-shift));
 }
 .giframeworkMap .ol-rotate {
   right: unset;
   left: 0.5rem;
   top: 10.5em;
 }
+.giframeworkMap.embed .ol-rotate {
+  top: calc(10.5em - var(--embed-vertical-shift));
+}
 .giframeworkMap .gifw-measure-control {
   right: unset;
   left: 0.5rem;
   top: 13em;
+}
+.giframeworkMap.embed .gifw-measure-control {
+  top: calc(13em - var(--embed-vertical-shift));
 }
 .giframeworkMap .gifw-measure-control.ol-hidden {
   opacity: 0;
@@ -45,12 +58,15 @@
   left: 7.25rem;
 }
 .giframeworkMap .gifw-measure-control.gifw-configure-measure-control {
-    left: 9.5rem;
+  left: 9.5rem;
 }
 .giframeworkMap .gifw-annotation-control {
   right: unset;
   left: 0.5rem;
   top: 15.5em;
+}
+.giframeworkMap.embed .gifw-annotation-control {
+  top: calc(15.5em - var(--embed-vertical-shift));
 }
 .giframeworkMap .gifw-annotation-control.ol-hidden {
   opacity: 0;
@@ -91,7 +107,9 @@
   left: 0.5rem;
   top: 18em;
 }
-
+.giframeworkMap.embed .gifw-info-control {
+  top: calc(18em - var(--embed-vertical-shift));
+}
 .giframeworkMap .gifw-info-control.ol-hidden {
   opacity: 0;
   visibility: hidden;
@@ -116,6 +134,9 @@
   right: unset;
   left: 0.5rem;
   top: 20.5em;
+}
+.giframeworkMap.embed .gifw-geolocation-control {
+  top: calc(20.5em - var(--embed-vertical-shift));
 }
 .giframeworkMap .gifw-geolocation-control.gifw-geolocation-recentre-control {
   left: 2.75rem;
@@ -204,6 +225,9 @@
   right: 0;
   top: 4rem;
 }
+.giframeworkMap.embed .sidebar-button {
+  top: calc(4rem - var(--embed-vertical-shift));
+}
 .giframeworkMap .sidebar-button.active {
   background-color: var(--primary-color-transparent-90);
 }
@@ -244,6 +268,34 @@
   top: calc(4rem + 360px);
 }
 
+.giframeworkMap.embed .sidebar-button.sidebar-order-2 {
+  top: calc(4rem - var(--embed-vertical-shift) + 40px);
+}
+.giframeworkMap.embed .sidebar-button.sidebar-order-3 {
+  top: calc(4rem - var(--embed-vertical-shift) + 80px);
+}
+.giframeworkMap.embed .sidebar-button.sidebar-order-4 {
+  top: calc(4rem - var(--embed-vertical-shift) + 120px);
+}
+.giframeworkMap.embed .sidebar-button.sidebar-order-5 {
+  top: calc(4rem - var(--embed-vertical-shift) + 160px);
+}
+.giframeworkMap.embed .sidebar-button.sidebar-order-6 {
+  top: calc(4rem - var(--embed-vertical-shift) + 200px);
+}
+.giframeworkMap.embed .sidebar-button.sidebar-order-7 {
+  top: calc(4rem - var(--embed-vertical-shift) + 240px);
+}
+.giframeworkMap.embed .sidebar-button.sidebar-order-8 {
+  top: calc(4rem - var(--embed-vertical-shift) + 280px);
+}
+.giframeworkMap.embed .sidebar-button.sidebar-order-9 {
+  top: calc(4rem - var(--embed-vertical-shift) + 320px);
+}
+.giframeworkMap.embed .sidebar-button.sidebar-order-10 {
+  top: calc(4rem - var(--embed-vertical-shift) + 360px);
+}
+
 /*SIDEBAR*/
 .giframeworkMap aside#sidebar-container .sidebar-panels {
   position: absolute;
@@ -275,13 +327,20 @@
   height: calc(100dvh - 46px);
 }
 
+.giframeworkMap aside#sidebar-container .sidebar-panels {
+  top: 48px;
+  max-height: calc(100% - 48px);
+}
+.giframeworkMap.embed aside#sidebar-container .sidebar-panels {
+  top: 0px;
+  max-height: 100%;
+}
 /*Medium devices (tablets, 768px and up)*/
 @media (min-width: 768px) {
   .giframeworkMap aside#sidebar-container .sidebar-panels {
     width: 45%;
-    top: 48px;
-    max-height: calc(100% - 48px);
   }
+
   .giframeworkMap .sidebar-button.sidebar-open {
     display: block;
     right: 45%;
@@ -292,6 +351,7 @@
   .giframeworkMap aside#sidebar-container .sidebar-panels {
     width: 35%;
   }
+
   .giframeworkMap .sidebar-button.sidebar-open {
     right: 35%;
   }


### PR DESCRIPTION
This PR adds a simple 'embed' mode, which strips out the header bar and various controls, to make it less cluttered when embedded in an iframe. Simply add `embed=true` into the map parameters hash and it will load in 'embed' mode.

This is particularly useful when embedded in a very small space, or when the map is simply used as a visual representation of some data, and users aren't expected to really interact with it much or need the tools.

![Side by side with and without embed mode turned on](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/109682469/ed50098d-fda1-4046-9890-bbd91a06ee5b)

The 'mode' is available to other scripts from the map object, and an additional 'embed' class is added to the root of the HTML for CSS changes. The currently implemented changes make use of both simple hiding with CSS and preventing initialization of the tools altogether. It is not a perfect system but should cover most use cases.

Collapsible attributions code has been tweaked to work a little bit more consistently, and an unrelated improvement to the search options code was also included.

Closes #152 