### PR TITLE
Add split querying to version edit screen

### DIFF
--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementVersionController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementVersionController.cs
@@ -92,6 +92,7 @@ namespace GIFrameworkMaps.Web.Controllers.Management
         public async Task<IActionResult> Edit(int id)
         {
 			var version = await _context.Versions
+				.AsSplitQuery()
 				.Include(v => v.VersionBasemaps)
 					.ThenInclude(v => v.Basemap)
 				.Include(v => v.VersionCategories)


### PR DESCRIPTION
Fixes issue with slow query, likely due to a Cartesian explosion - https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries#cartesian-explosion