### PR TITLE
Remove font overrides to fix issue with iOS zooming in on search box

### DIFF
--- a/GIFrameworkMaps.Web/wwwroot/css/site.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/site.css
@@ -122,15 +122,6 @@ a:focus {
 
 /* Sticky footer styles
 -------------------------------------------------- */
-html {
-  font-size: 14px;
-}
-
-@media (min-width: 768px) {
-  html {
-    font-size: 16px;
-  }
-}
 
 .border-top {
   border-top: 1px solid #e5e5e5;


### PR DESCRIPTION
This PR removes the font overrides in site.css, which made the font size reduce to 14px on mobile devices. This had the effect on causing iOS to zoom in on the search box on the map.

Fixes #265 