### PR TITLE
Add scale bar switching functionality

### DIFF
--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -171,9 +171,14 @@
 .giframeworkMap .ol-touch .ol-control button {
   font-size: 1rem;
 }
+.giframeworkMap .ol-scale-line, .giframeworkMap .ol-scale-bar {
+  bottom: 2rem;
+  pointer-events: auto !important;
+  cursor: pointer;
+}
 .giframeworkMap .ol-scale-line {
   background-color: var(--primary-color-transparent-50);
-  bottom: 2rem;
+
 }
 .giframeworkMap .ol-scale-line-inner {
   color: white;


### PR DESCRIPTION
This PR adds the ability for users to switch between a scale line (the current default) and a more traditional scale bar. Users can simply click the scale line and it will toggle between a line and bar style. Their preference is saved in their localStorage.

Closes #220 