### PR TITLE
Improved template helper messages

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Management/CreateLayerFromSource.ts
+++ b/GIFrameworkMaps.Web/Scripts/Management/CreateLayerFromSource.ts
@@ -355,17 +355,21 @@ export class CreateLayerFromSource {
   ) {
     if (template) {
       //get an example value from the service if possible.
-
-      const props = (await this.getExampleFeature()) as object;
-      if (props !== null) {
-        const renderedTemplate = FeatureQueryTemplateHelper.renderTemplate(
-          template,
-          props,
-        );
-        previewContainer.innerHTML = renderedTemplate;
-      } else {
+      try {
+        const props = (await this.getExampleFeature()) as object;
+        if (props !== null) {
+          const renderedTemplate = FeatureQueryTemplateHelper.renderTemplate(
+            template,
+            props,
+          );
+          previewContainer.innerHTML = renderedTemplate;
+        } else {
+          previewContainer.innerHTML =
+            '<div class="alert alert-warning p-2 my-1">We couldn\'t get an example feature from the feature server</div>';
+        }
+      } catch (e) {
         previewContainer.innerHTML =
-          '<div class="alert alert-warning p-2 my-1">We couldn\'t get an example feature from the feature server</div>';
+          '<div class="alert alert-warning p-2 my-1">Something went wrong! Check your template</div>';
       }
     } else {
       previewContainer.innerHTML =
@@ -421,13 +425,13 @@ export class CreateLayerFromSource {
         searchUrl: getFeatureCapability.url,
         searchMethod: getFeatureCapability.method,
       };
-      const resp = await this.getFeatureInfoForLayer(request);
+        const resp = await this.getFeatureInfoForLayer(request);
 
-      const props = resp.features[0].getProperties();
-      if (props) {
-        this._cachedExampleFeature = props;
-      }
-      return props;
+        const props = resp.features[0].getProperties();
+        if (props) {
+          this._cachedExampleFeature = props;
+        }
+        return props;
     }
     return null;
   }


### PR DESCRIPTION
This PR improves how the template helper handles errors when previewing a template.

If a template is incorrect, a new error will now be displayed to the user to let them know something has gone wrong when they click 'Generate preview', instead of nothing happening.
![image](https://github.com/Dorset-Council-UK/GIFramework-Maps/assets/114388582/64417a0e-c9ce-4093-84af-1bedd34e0f8f)

A more useful error will also now be shown if there are any issues getting a feature example from a server when the template itself has no errors.

Closes #264 