### PR TITLE
Add split querying to version edit saving

### DIFF
--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementVersionController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementVersionController.cs
@@ -125,7 +125,8 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             bool purgeCache)
         {
 			var versionToUpdate = await _context.Versions
-                .Include(v => v.VersionBasemaps)
+				.AsSplitQuery()
+				.Include(v => v.VersionBasemaps)
                     .ThenInclude(v => v.Basemap)
 				.Include(v => v.VersionProjections)
 					.ThenInclude(v => v.Projection)


### PR DESCRIPTION
Fixed an issue with crashing when trying to save an edit to a version that has a lot of things in it (basemaps, categories etc).