### PR TITLE
Added button to request access to version

### DIFF
--- a/GIFrameworkMaps.Web/Views/Map/Forbidden.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Forbidden.cshtml
@@ -24,3 +24,12 @@
         </dd>
     </dl>
 </div>
+
+@{
+    string appEmailContact = configuration.GetValue<string>("GIFrameworkMaps:appEmailContact");
+    string emailRequestAccessToVersionLink = "mailto:" + appEmailContact + "?subject=" + Model.Name + " access request for " + User.Identity.Name;
+}
+
+<a class="btn btn-primary" href="@emailRequestAccessToVersionLink" role="button">
+    Request access to this version
+</a>

--- a/GIFrameworkMaps.Web/Views/Map/Forbidden.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Forbidden.cshtml
@@ -26,10 +26,21 @@
 </div>
 
 @{
-    string appEmailContact = configuration.GetValue<string>("GIFrameworkMaps:appEmailContact");
-    string emailRequestAccessToVersionLink = "mailto:" + appEmailContact + "?subject=" + Model.Name + " access request for " + User.Identity.Name;
-}
+    // Request access to version button (conditional depending on whether there is a value in appSettings). 
+    // This can be a URL to an online form, a mailto: link or anything you prefer. Make sure your tokens match those detailed below to automatically pull through the details.
+    var userId = (User.Claims.FirstOrDefault(c => c.Type.Contains("nameidentifier")) != null ? User.Claims.FirstOrDefault(c => c.Type.Contains("nameidentifier")).Value : "Not provided");
+    string appAccessRequestLink = configuration.GetValue<string>("GIFrameworkMaps:AppAccessRequestLink");
 
-<a class="btn btn-primary" href="@emailRequestAccessToVersionLink" role="button">
-    Request access to this version
-</a>
+    if (configuration.GetValue<string>("GIFrameworkMaps:AppAccessRequestLink") != "")
+    {
+        string linkForVersionAccessRequest = appAccessRequestLink
+            .Replace("{{VERSIONID}}", Model.Id.ToString())
+            .Replace("{{VERSIONNAME}}", Model.Name)
+            .Replace("{{USERNAME}}", User.Identity.Name)
+            .Replace("{{USERID}}", userId);
+
+        <a class="btn btn-primary" href="@linkForVersionAccessRequest" role="button">
+            Request access to this version
+        </a>
+    }
+}

--- a/GIFrameworkMaps.Web/appsettings.json
+++ b/GIFrameworkMaps.Web/appsettings.json
@@ -1,19 +1,19 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        },
+        "ApplicationInsights": {
+            "LogLevel": {
+                "Default": "Information",
+                "Microsoft": "Warning",
+                "Microsoft.Hosting.Lifetime": "Information"
+            }
+        }
     },
-    "ApplicationInsights": {
-      "LogLevel": {
-        "Default": "Information",
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information"
-      }
-    }
-  },
-  "AllowedHosts": "*",
+    "AllowedHosts": "*",
     "GIFrameworkMaps": {
         "appName": "GIFramework Maps",
         "UseHttpsRedirection": false,
@@ -25,6 +25,6 @@
         "PreferredProjections": "",
         "HideEmbedOption": true,
         "SuppressXFrameOptions": false,
-        "appEmailContact": "gis@dorsetcouncil.gov.uk"
+        "AppAccessRequestLink": ""
     }
 }

--- a/GIFrameworkMaps.Web/appsettings.json
+++ b/GIFrameworkMaps.Web/appsettings.json
@@ -14,16 +14,17 @@
     }
   },
   "AllowedHosts": "*",
-  "GIFrameworkMaps": {
-    "appName": "GIFramework Maps",
-    "UseHttpsRedirection": false,
-    "ToSLink": "",
-    "PrivacyLink": "",
-    "AdminDocsLink": "",
-    "MapServicesAccessURL": "",
-    "AuthenticateWithMapServices": false,
-    "PreferredProjections": "",
-    "HideEmbedOption": true,
-    "SuppressXFrameOptions":  false
-  }
+    "GIFrameworkMaps": {
+        "appName": "GIFramework Maps",
+        "UseHttpsRedirection": false,
+        "ToSLink": "",
+        "PrivacyLink": "",
+        "AdminDocsLink": "",
+        "MapServicesAccessURL": "",
+        "AuthenticateWithMapServices": false,
+        "PreferredProjections": "",
+        "HideEmbedOption": true,
+        "SuppressXFrameOptions": false,
+        "appEmailContact": "gis@dorsetcouncil.gov.uk"
+    }
 }


### PR DESCRIPTION
A button has been added to the 'Forbidden' page that appears when a user does not have access to a version. Clicking the button will allow the user to request access for the version.

![image](https://github.com/user-attachments/assets/ba26a035-c9c4-4f54-8eb1-9037a0bbf705)

The button will only appear if there is a value for the `AppAccessRequestLink` property in `appsettings.json`.  

The link the button uses can either be a URL for an online form, a mailto: link for an email or anything else you prefer. If you want your link to automatically pull through the relevant values make sure to use the tokens we've used in your set up.

Closes #285 