### PR TITLE
Hotfix - some layers unable to be added using the layer wizard

### DIFF
--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerWizardController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerWizardController.cs
@@ -202,7 +202,8 @@ namespace GIFrameworkMaps.Web.Controllers.Management
 
 		private static readonly JsonSerializerOptions layerResourceDeserializationOpts = new()
 		{
-			AllowTrailingCommas = true
+			AllowTrailingCommas = true,
+			NumberHandling = JsonNumberHandling.AllowReadingFromString,
 		};
 	}
 }


### PR DESCRIPTION
Fixes a bug introduced with the previous vector format pull release (#310) where WMS layers were unable to be added using the layer wizard. This was because part of the JSON (extents) was coming in as a string when a number was expected.

A new option has been added to the JSON deserializer that allows numbers to be read from strings.

