### PR TITLE
Fixed URL override from some js links (#306)

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/FeatureQuery/FeatureQueryResultRenderer.ts
+++ b/GIFrameworkMaps.Web/Scripts/FeatureQuery/FeatureQueryResultRenderer.ts
@@ -253,8 +253,9 @@ export class FeatureQueryResultRenderer {
         const listItemLink = document.createElement("a");
         listItemLink.text = listItemContent;
         listItemLink.href = "#";
-        listItemLink.addEventListener("click", () => {
-          this.showFeaturePopup(coords, r.layer, f, responsesWithData);
+        listItemLink.addEventListener("click", (e) => {
+            this.showFeaturePopup(coords, r.layer, f, responsesWithData);
+            e.preventDefault();
         });
         listItem.appendChild(listItemLink);
         featureList.appendChild(listItem);

--- a/GIFrameworkMaps.Web/Scripts/Panels/LayersPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/LayersPanel.ts
@@ -330,7 +330,7 @@ export class LayersPanel implements SidebarPanel {
     const collapseTag: HTMLButtonElement = container.querySelector(
       "#gifw-layer-switcher-collapse",
     );
-    collapseTag.addEventListener("click", () => {
+    collapseTag.addEventListener("click", (e) => {
       const layerListContainer = document
       .querySelector(this.container)
       .querySelector(".layer-switcher-tree");
@@ -357,7 +357,7 @@ export class LayersPanel implements SidebarPanel {
 
         }
       })
-
+        e.preventDefault();
     });
 
     /*TURN OFF LAYERS BUTTON*/

--- a/GIFrameworkMaps.Web/Scripts/app.ts
+++ b/GIFrameworkMaps.Web/Scripts/app.ts
@@ -50,9 +50,12 @@ document.addEventListener("DOMContentLoaded", () => {
     configure_cookie_control == "Civic Cookie Control" &&
     typeof CookieControl != "undefined"
   ) {
-    document
-      .getElementById("CookieControlLink")
-      .addEventListener("click", CookieControl.open);
+      document
+          .getElementById("CookieControlLink")
+          .addEventListener("click", (e) => {
+              CookieControl.open;
+              e.preventDefault();
+          });
   }
 
   const mapId = "giframeworkMap";


### PR DESCRIPTION
Fixed problem with some links overriding the browser URL when clicked.  This is detailed in issue #306.    

Fixed this issue for 'collapse all' in the layer control, info click list results and cookie preference under help menu by adding e.preventDefault().

Closes #306