### PR TITLE
Incorrect scale ratio removed from PDF exports

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Export.ts
+++ b/GIFrameworkMaps.Web/Scripts/Export.ts
@@ -1162,7 +1162,7 @@ export class Export {
       return canvas.toDataURL('image/png');
     } else {
       const scalelineData: HTMLElement = document.querySelector("div.ol-scale-bar");
-      const canvas = await html2canvas(scalelineData, { backgroundColor: null, width: scalelineData.clientWidth + 20, height: scalelineData.clientHeight + 20, x: -5, y: -15 });
+      const canvas = await html2canvas(scalelineData, { backgroundColor: null, width: scalelineData.clientWidth + 20, height: scalelineData.clientHeight + 20, x: -5, y: -1 });
       return canvas.toDataURL('image/png');
     }
   }


### PR DESCRIPTION
The scale ratio shown on the scalebar PDF exports is incorrect and not accurate. This is possibly due to how something works in OpenLayers and isn't something we can immediately fix. For now I have removed the ratio from the scalebar. The scaling of the actual scalebar is working correctly and shows accurate measurements.

Before removal:
![image](https://github.com/user-attachments/assets/554a3709-4243-4437-950e-2ed451a154c9)

After removal:
![image](https://github.com/user-attachments/assets/3a26daf2-283e-46e2-bc29-189e2fd574f1)
