### PR TITLE
Bump GH action deps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,24 +29,24 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL (JS)
       if: ${{ matrix.language == 'javascript' }}
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-ts-config.yml
 
     - name: Initialize CodeQL
       if: ${{ matrix.language != 'javascript' }}
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies
@@ -65,7 +65,7 @@ jobs:
       run: dotnet build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
 


### PR DESCRIPTION
The current version (v2) of the `github/codeql-action` is set to be deprecated on December 5th, 2024.
![image](https://github.com/user-attachments/assets/1849d5a2-a041-4f23-abe1-b88aec70191c)

This PR bumps the version to v3.

I ran this action on my Fork and as far as I can see it worked as expected.
https://github.com/Zoobdude/GIFramework-Maps/actions/runs/11846373952/job/33013868299

