### PR TITLE
Allow layer groups to be filtered when layer group is published as a named tree

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Metadata/Metadata.ts
+++ b/GIFrameworkMaps.Web/Scripts/Metadata/Metadata.ts
@@ -72,7 +72,7 @@ export async function getDescribeFeatureType(
     return json;
   } catch (error) {
     console.error(`Could not get feature description: ${error}`);
-}
+  }
 }
 
 /**
@@ -226,6 +226,24 @@ export async function getStylesForLayer(
     
 }
 
+export async function isLayerGroup(baseUrl: string,
+  layerName: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  version: string = "1.1.0",
+  proxyEndpoint: string = "",
+  httpHeaders: Headers = new Headers()) {
+  ogcClientSetFetchOptions({ headers: Object.fromEntries(httpHeaders) });
+  if (proxyEndpoint !== "") {
+    baseUrl = `${proxyEndpoint}?url=${encodeURIComponent(baseUrl)}`;
+  }
+  const endpoint = await new WmsEndpoint(baseUrl).isReady();
+  const layer = endpoint.getLayerByName(layerName);
+  if (layer.children) {
+    return layer.children.length !== 0;
+  }
+  return false;
+}
+
 export async function getLayerMetadataFromCapabilities(
   baseUrl: string,
   layerName: string,
@@ -347,6 +365,19 @@ export async function getLayersFromCapabilities(
   } catch (error) {
     console.error(`Could not get capabilities doc: ${error}`);
   }
+}
+
+export async function getChildrenOfLayerGroup(baseUrl: string,
+  layerGroupName: string,
+  proxyEndpoint: string = "",
+  httpHeaders: Headers = new Headers()) {
+  ogcClientSetFetchOptions({ headers: Object.fromEntries(httpHeaders) });
+  if (proxyEndpoint !== "") {
+    baseUrl = `${proxyEndpoint}?url=${encodeURIComponent(baseUrl)}`;
+  }
+  const endpoint = await new WmsEndpoint(baseUrl).isReady();
+  const layers = endpoint.getLayerByName(layerGroupName);
+  return layers.children;
 }
 
 export function createLayerResourcesFromWMSLayer(endpoint: WmsEndpoint, layer: WmsLayerSummary, serviceInfo: GenericEndpointInfo, baseUrl: string, proxyEndpoint?: string) {


### PR DESCRIPTION
This PR allows layer groups to be filtered when the layer group is published as a named tree.

Layer groups in map servers such as GeoServer can be defined in multiple ways. When using the ['Named Tree'](https://docs.geoserver.org/stable/en/user/data/webadmin/layergroups.html) mode, the layer group is published as a parent with the layers that make it up as children. 

In our current implementation of filtering, the process to find the layer properties for the layer group fails, as it can't find the layer group name in the WFS request. To get round this, it now determines if the layer is a group (by detecting if there are any children), and if it is, it will pick the first layer of the children to use in the subsequent requests to fetch the properties. 

This isn't perfect, but it is assumed that if you have a layer group that is filterable and set up in this manner, it must be made of layers that all share the same properties.

Fixes #182