### PR TITLE
Layer list orders alphabetically if no order is set

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Panels/LayerList.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/LayerList.ts
@@ -125,7 +125,12 @@ export class LayerList {
     listContainer.className = `list-unstyled`;
 
     category.layers
-      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .sort((a, b) => {
+        if (a.sortOrder === b.sortOrder) {
+          return a.name.localeCompare(b.name);
+        }
+        return a.sortOrder - b.sortOrder;
+      })
       .forEach((layer) => {
         const listItem = this.createLayerListItem(layer);
         listContainer.appendChild(listItem);

--- a/GIFrameworkMaps.Web/Scripts/Panels/LayersPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/LayersPanel.ts
@@ -417,6 +417,7 @@ export class LayersPanel implements SidebarPanel {
       includeMatches: true,
       threshold: 0.2,
       keys: ["name"],
+      ignoreLocation: true,
     };
     const allLayers: Layer[] = [];
     const allCategories: Category[] = [];


### PR DESCRIPTION
Layers will now list themselves alphabetically if no sort order is set, rather than by the order they were added to the database.

On staging ready for testing.

Fixes #332 

Bonus fix: I've tweaked the layer search options to make sure they bring back all expected results.