### PR TITLE
Allow legend requests to use headers

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Export.ts
+++ b/GIFrameworkMaps.Web/Scripts/Export.ts
@@ -294,7 +294,7 @@ export class Export {
         try {
           const scaleImg = await this.getScaleLine();
           const imgData = scaleImg;
-          await this.createScalebarBox(pdf, pageMargin, imgData, this.startingAttrYPosition);
+          this.createScalebarBox(pdf, pageMargin, imgData, this.startingAttrYPosition);
         } catch (ex) {
           console.warn(`Getting the scaleline for a print failed.`);
           console.error(ex);

--- a/GIFrameworkMaps.Web/Scripts/Export.ts
+++ b/GIFrameworkMaps.Web/Scripts/Export.ts
@@ -795,8 +795,7 @@ export class Export {
     let maxWidth = 0;
     let rectangleWidth = 0;
     let rectangleHeight = 0;
-    const legendPromises = this.getLegendImages(legendUrls);
-    const allResolvedLegends = await Promise.allSettled(legendPromises);
+    const legends = await this.getLegendImages(legendUrls, map);
     const requiredTitleBoxDims = this.getTitleBoxRequiredDimensions(
       pdf,
       pageMargin,
@@ -829,11 +828,10 @@ export class Export {
         currentX = startingX;
         currentY = startingY;
         pdf.setFontSize(pageSettings.subtitleFontSize);
-        allResolvedLegends.forEach((p) => {
-          if (p.status === "fulfilled") {
-            const layerName = p.value[0];
+        legends.forEach((legend) => {
+            const layerName = legend[0];
             const layerNameWidth = pdf.getTextDimensions(layerName).w;
-            const img = p.value[1];
+            const img = legend[1];
             const imgProps = pdf.getImageProperties(img);
             const widthInMM = (imgProps.width * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
             const heightInMM = (imgProps.height * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
@@ -843,7 +841,6 @@ export class Export {
             if (widthInMM > maxWidth) maxWidth = widthInMM;
             if (layerNameWidth > maxWidth) maxWidth = layerNameWidth;
             currentY += heightInMM + 7.5;
-          }
         });
         break;
       case "float-left":
@@ -851,20 +848,18 @@ export class Export {
         rectangleHeight = pdf.getTextDimensions("Map key").h;
 
         /*get max width required*/
-        allResolvedLegends.forEach((p) => {
-          if (p.status === "fulfilled") {
-            const layerName = p.value[0];
-            const layerNameWidth = pdf.getTextDimensions(layerName).w;
-            const layerNameHeight = pdf.getTextDimensions(layerName).h;
-            const img = p.value[1];
-            const imgProps = pdf.getImageProperties(img);
-            const widthInMM = (imgProps.width * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
-            const heightInMM = (imgProps.height * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
-            rectangleHeight += layerNameHeight + heightInMM + 8;
-            if (widthInMM > rectangleWidth) rectangleWidth = widthInMM + 3;
-            if (layerNameWidth > rectangleWidth)
-              rectangleWidth = layerNameWidth + 3;
-          }
+        legends.forEach((legend) => {
+          const layerName = legend[0];
+          const layerNameWidth = pdf.getTextDimensions(layerName).w;
+          const layerNameHeight = pdf.getTextDimensions(layerName).h;
+          const img = legend[1];
+          const imgProps = pdf.getImageProperties(img);
+          const widthInMM = (imgProps.width * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
+          const heightInMM = (imgProps.height * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
+          rectangleHeight += layerNameHeight + heightInMM + 8;
+          if (widthInMM > rectangleWidth) rectangleWidth = widthInMM + 3;
+          if (layerNameWidth > rectangleWidth)
+            rectangleWidth = layerNameWidth + 3;
         });
         pdf.setFillColor(255, 255, 255);
         pdf.setDrawColor(0, 0, 0);
@@ -892,21 +887,19 @@ export class Export {
         currentX = startingX;
         currentY = startingY;
         pdf.setFontSize(pageSettings.subtitleFontSize);
-        allResolvedLegends.forEach((p) => {
-          if (p.status === "fulfilled") {
-            const layerName = p.value[0];
-            const layerNameWidth = pdf.getTextDimensions(layerName).w;
-            const img = p.value[1];
-            const imgProps = pdf.getImageProperties(img);
-            const widthInMM = (imgProps.width * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
-            const heightInMM = (imgProps.height * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
-            pdf.text(layerName, currentX + 2, currentY);
-            currentY += pdf.getTextDimensions(layerName).h;
-            pdf.addImage(img, currentX + 2, currentY, widthInMM, heightInMM);
-            if (widthInMM > maxWidth) maxWidth = widthInMM;
-            if (layerNameWidth > maxWidth) maxWidth = layerNameWidth;
-            currentY += heightInMM + 7.5;
-          }
+        legends.forEach((legend) => {
+          const layerName = legend[0];
+          const layerNameWidth = pdf.getTextDimensions(layerName).w;
+          const img = legend[1];
+          const imgProps = pdf.getImageProperties(img);
+          const widthInMM = (imgProps.width * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
+          const heightInMM = (imgProps.height * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
+          pdf.text(layerName, currentX + 2, currentY);
+          currentY += pdf.getTextDimensions(layerName).h;
+          pdf.addImage(img, currentX + 2, currentY, widthInMM, heightInMM);
+          if (widthInMM > maxWidth) maxWidth = widthInMM;
+          if (layerNameWidth > maxWidth) maxWidth = layerNameWidth;
+          currentY += heightInMM + 7.5;
         });
 
         break;
@@ -919,81 +912,101 @@ export class Export {
         currentX = startingX;
         currentY = startingY;
         pdf.setFontSize(pageSettings.titleFontSize);
-        allResolvedLegends.forEach((p) => {
-          if (p.status === "fulfilled") {
-            const layerName = p.value[0];
-            const layerNameWidth = pdf.getTextDimensions(layerName).w;
-            const img = p.value[1];
-            const imgProps = pdf.getImageProperties(img);
-            let widthInMM = (imgProps.width * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
-            let heightInMM = (imgProps.height * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
-            if (
-              currentY + heightInMM + pdf.getTextDimensions(layerName).h >=
-              pageHeight - pageMargin
-            ) {
-              currentX = pageMargin / 2 + maxWidth + 7.5;
-              currentY = startingY;
-            }
-
-            if (widthInMM > pageWidth - pageMargin) {
-              //key is wider than page.
-              const originalWidth = widthInMM;
-              widthInMM = pageWidth - pageMargin - startingX;
-              const scaleRatio = widthInMM / originalWidth;
-              heightInMM = heightInMM * scaleRatio;
-            }
-            if (heightInMM > pageHeight - pageMargin) {
-              //key is taller than page
-              const originalHeight = heightInMM;
-              heightInMM = pageHeight - pageMargin - startingY;
-              const scaleRatio = heightInMM / originalHeight;
-              widthInMM = widthInMM * scaleRatio;
-            }
-
-            if (
-              widthInMM + currentX > pageWidth - pageMargin ||
-              layerNameWidth + currentX > pageWidth - pageMargin
-            ) {
-              //key or title would overflow page edge
-              //add to new page
-              pdf.addPage(pageSize, pageOrientation);
-              pdf.setFontSize(pageSettings.standaloneLegendTitleFontSize);
-              pdf.text("Map Key (cont.)", pageMargin / 2, pageMargin / 2 + 3);
-              pdf.setFontSize(pageSettings.titleFontSize);
-              currentX = startingX;
-              currentY = startingY;
-              maxWidth = 0;
-            }
-            pdf.text(layerName, currentX, currentY);
-            currentY += pdf.getTextDimensions(layerName).h;
-            pdf.addImage(img, currentX, currentY, widthInMM, heightInMM);
-            if (widthInMM > maxWidth) maxWidth = widthInMM;
-            if (layerNameWidth > maxWidth) maxWidth = layerNameWidth;
-            currentY += heightInMM + 7.5;
+        legends.forEach((legend) => {
+          const layerName = legend[0];
+          const layerNameWidth = pdf.getTextDimensions(layerName).w;
+          const img = legend[1];
+          const imgProps = pdf.getImageProperties(img);
+          let widthInMM = (imgProps.width * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
+          let heightInMM = (imgProps.height * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
+          if (
+            currentY + heightInMM + pdf.getTextDimensions(layerName).h >=
+            pageHeight - pageMargin
+          ) {
+            currentX = pageMargin / 2 + maxWidth + 7.5;
+            currentY = startingY;
           }
+
+          if (widthInMM > pageWidth - pageMargin) {
+            //key is wider than page.
+            const originalWidth = widthInMM;
+            widthInMM = pageWidth - pageMargin - startingX;
+            const scaleRatio = widthInMM / originalWidth;
+            heightInMM = heightInMM * scaleRatio;
+          }
+          if (heightInMM > pageHeight - pageMargin) {
+            //key is taller than page
+            const originalHeight = heightInMM;
+            heightInMM = pageHeight - pageMargin - startingY;
+            const scaleRatio = heightInMM / originalHeight;
+            widthInMM = widthInMM * scaleRatio;
+          }
+
+          if (
+            widthInMM + currentX > pageWidth - pageMargin ||
+            layerNameWidth + currentX > pageWidth - pageMargin
+          ) {
+            //key or title would overflow page edge
+            //add to new page
+            pdf.addPage(pageSize, pageOrientation);
+            pdf.setFontSize(pageSettings.standaloneLegendTitleFontSize);
+            pdf.text("Map Key (cont.)", pageMargin / 2, pageMargin / 2 + 3);
+            pdf.setFontSize(pageSettings.titleFontSize);
+            currentX = startingX;
+            currentY = startingY;
+            maxWidth = 0;
+          }
+          pdf.text(layerName, currentX, currentY);
+          currentY += pdf.getTextDimensions(layerName).h;
+          pdf.addImage(img, currentX, currentY, widthInMM, heightInMM);
+          if (widthInMM > maxWidth) maxWidth = widthInMM;
+          if (layerNameWidth > maxWidth) maxWidth = layerNameWidth;
+          currentY += heightInMM + 7.5;
         });
         break;
     }
   }
 
-  private getLegendImages(legendUrls: LegendURLs) {
-    const promises: Promise<[string, HTMLImageElement]>[] = [];
-    legendUrls.availableLegends.forEach((legend) => {
-      promises.push(
-        new Promise<[string, HTMLImageElement]>((resolve, reject) => {
-          const img = new Image();
-          img.onload = () => {
-            if (img.width < 5) {
-              reject(`No legend available for ${legend.name}`);
-            }
-            resolve([legend.name, img]);
-          };
-          img.onerror = () => reject("Image load failed");
-          img.src = legend.legendUrl;
-        }),
-      );
-    });
-    return promises;
+  private async getLegendImages(legendUrls: LegendURLs, map:GIFWMap): Promise<[string, HTMLImageElement][]> {
+    const results: [string, HTMLImageElement][] = [];
+    for (const legend of legendUrls.availableLegends) {
+      try {
+        const img = await this.loadLegendImage(legend.legendUrl, map);
+        if (img.width < 5) {
+          // Optionally skip or handle "no legend" case
+          continue;
+        }
+        results.push([legend.name, img]);
+      } catch (ex) {
+        console.warn(`Getting a legend image failed.`);
+        console.error(ex);
+      }
+    }
+    return results;
+  }
+
+  private async loadLegendImage(url: string, map: GIFWMap): Promise<HTMLImageElement> {
+    const headers = new Headers();
+    map.authManager.applyAuthenticationToRequestHeaders(url, headers);
+    if (headers.has('Authorization')) {
+      const response = await fetch(url, { method: "GET", headers });
+      if (response.status !== 200) throw new Error("Failed to load image");
+      const blob = await response.blob();
+      return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => resolve(img);
+        img.onerror = () => reject("Image load failed");
+        img.src = URL.createObjectURL(blob);
+      });
+    } else {
+      return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => resolve(img);
+        img.onerror = () => reject("Image load failed");
+        img.src = url;
+      });
+    }
+    
   }
 
   /**
@@ -1053,31 +1066,30 @@ export class Export {
             : pageSettings.portraitKeyWrapLimit
         };`,
       );
-      const legendPromises = this.getLegendImages(legendUrls);
-      const promises = await Promise.allSettled(legendPromises);
+      const legends = await this.getLegendImages(legendUrls, map);
+      
       //calculate width and height required
       pdf.setFontSize(pageSettings.titleFontSize);
       let totalRequiredHeight = pdf.getTextDimensions("Map key").h;
       let totalRequiredWidth = pdf.getTextDimensions("Map key").w;
       pdf.setFontSize(pageSettings.subtitleFontSize);
-      promises.forEach((p) => {
-        if (p.status === "fulfilled") {
-          const layerName = p.value[0];
-          const layerNameWidth = pdf.getTextDimensions(layerName).w;
-          const layerNameHeight = pdf.getTextDimensions(layerName).h;
-          totalRequiredHeight += layerNameHeight;
-          if (totalRequiredWidth < layerNameWidth)
-            totalRequiredWidth = layerNameWidth;
+      legends.forEach((legend) => {
+        const layerName = legend[0];
+        const layerNameWidth = pdf.getTextDimensions(layerName).w;
+        const layerNameHeight = pdf.getTextDimensions(layerName).h;
+        totalRequiredHeight += layerNameHeight;
+        if (totalRequiredWidth < layerNameWidth)
+          totalRequiredWidth = layerNameWidth;
 
-          const img = p.value[1];
-          const imgProps = pdf.getImageProperties(img);
-          const widthInMM = (imgProps.width * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
-          const heightInMM = (imgProps.height * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
+        const img = legend[1];
+        const imgProps = pdf.getImageProperties(img);
+        const widthInMM = (imgProps.width * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
+        const heightInMM = (imgProps.height * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
 
-          totalRequiredHeight += heightInMM;
-          if (totalRequiredWidth < widthInMM) totalRequiredWidth = widthInMM;
-        }
+        totalRequiredHeight += heightInMM;
+        if (totalRequiredWidth < widthInMM) totalRequiredWidth = widthInMM;
       });
+
       const requiredTitleBoxDims = this.getTitleBoxRequiredDimensions(
         pdf,
         pageMargin,

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/LegendURLs.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/LegendURLs.ts
@@ -1,6 +1,7 @@
 export interface LegendURL {
   name: string;
   legendUrl: string;
+  headers?: Headers;
 }
 
 export interface LegendURLs {

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/LegendURLs.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/LegendURLs.ts
@@ -1,4 +1,4 @@
-interface LegendURL {
+export interface LegendURL {
   name: string;
   legendUrl: string;
 }

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -39,7 +39,8 @@ import {
   getDefaultStyleByGeomType,
   extractParamsFromHash,
   generatePermalinkForMap,
-  PrefersReducedMotion
+  PrefersReducedMotion,
+  extractCustomHeadersFromLayerSource
 } from "./Util";
 import LayerRenderer from "ol/renderer/Layer";
 import { Projection } from "./Interfaces/Projection";
@@ -1356,11 +1357,16 @@ export class GIFWMap {
             }
             params = { ...params, ...additionalParams };
 
-            const legendUrl = {
+            const legendUrl = source.getLegendUrl(resolution, params)
+            const layerConfig = this.getLayerConfigById(l.get("layerId"));
+            const headers = extractCustomHeadersFromLayerSource(layerConfig.layerSource);
+            this.authManager.applyAuthenticationToRequestHeaders(legendUrl, headers);
+            const legendInfo = {
               name: (l.get("name") as string).trim(),
-              legendUrl: source.getLegendUrl(resolution, params),
+              legendUrl: legendUrl,
+              headers: headers,
             };
-            legends.availableLegends.push(legendUrl);
+            legends.availableLegends.push(legendInfo);
           } else {
             legends.nonLegendableLayers.push((l.get("name") as string).trim());
           }

--- a/GIFrameworkMaps.Web/Scripts/Panels/LegendsPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/LegendsPanel.ts
@@ -65,11 +65,8 @@ export class LegendsPanel implements SidebarPanel {
       const legend = legends.availableLegends[index];
       this.appendLegendHeader(legendsContainer, legend.name);
 
-      const headers = new Headers();
-      this.gifwMapInstance.authManager.applyAuthenticationToRequestHeaders(legend.legendUrl, headers);
-
-      if (headers.has("Authorization")) {
-        await this.fetchAndAppendLegendImage(legendsContainer, legend, index, headers);
+      if (legend.headers != null && legend.headers.has("Authorization")) {
+        await this.fetchAndAppendLegendImage(legendsContainer, legend, index, legend.headers);
       } else {
         this.appendLegendImage(legendsContainer, legend, index);
         // Wait for the image to load or error before continuing

--- a/GIFrameworkMaps.Web/Scripts/Panels/LegendsPanel.ts
+++ b/GIFrameworkMaps.Web/Scripts/Panels/LegendsPanel.ts
@@ -65,7 +65,7 @@ export class LegendsPanel implements SidebarPanel {
       const legend = legends.availableLegends[index];
       this.appendLegendHeader(legendsContainer, legend.name);
 
-      if (legend.headers != null && legend.headers.has("Authorization")) {
+      if (legend.headers != null) {
         await this.fetchAndAppendLegendImage(legendsContainer, legend, index, legend.headers);
       } else {
         this.appendLegendImage(legendsContainer, legend, index);


### PR DESCRIPTION
This PR allows GetLegend requests used in the legends panel and printing to make use of custom and authorization headers.

Currently, it naïvely just creates a URL and applies it to the image source, but if the server requires custom headers (such as Authorization or other HTTP headers) these are currently ignored, even if set properly on the layer source.

There has also been some refactoring of the code for readability.