### PR TITLE
Show related versions in layer and category screens

### DIFF
--- a/GIFrameworkMaps.Data/Data/IManagementRepository.cs
+++ b/GIFrameworkMaps.Data/Data/IManagementRepository.cs
@@ -48,5 +48,6 @@ namespace GIFrameworkMaps.Data
 		Task<AnalyticsViewModel> GetAnalyticsModel();
 		Task<List<Basemap>> GetBasemaps();
 		Task<Basemap?> GetBasemap(int id);
+		Task<IList<Version>> GetVersionsLayerCategoriesAppearIn(IList<int> CategoryIds);
 	}
 }

--- a/GIFrameworkMaps.Data/Data/ManagementRepository.cs
+++ b/GIFrameworkMaps.Data/Data/ManagementRepository.cs
@@ -350,5 +350,15 @@ namespace GIFrameworkMaps.Data
 				.AsNoTracking()
 				.ToListAsync();
 		}
+
+		public async Task<IList<Version>> GetVersionsLayerCategoriesAppearIn(IList<int> CategoryIds)
+		{
+			var versions = await _context.Versions
+				.AsNoTracking()
+				.Include(v => v.VersionCategories)
+				.Where(v => v.VersionCategories.Any(cl => CategoryIds.Contains(cl.CategoryId)))
+				.ToListAsync();
+			return versions;
+		}
 	}
 }

--- a/GIFrameworkMaps.Data/ViewModels/Management/CategoryEditViewModel.cs
+++ b/GIFrameworkMaps.Data/ViewModels/Management/CategoryEditViewModel.cs
@@ -12,6 +12,7 @@ namespace GIFrameworkMaps.Data.ViewModels.Management
 		public IList<int> SelectedLayers { get; set; } = [];
 
 		public IList<SelectListItem> AvailableLayers { get; set; } = [];
+		public IList<Version> VersionsCategoryAppearsIn { get; set; } = [];
 
 	}
 }

--- a/GIFrameworkMaps.Data/ViewModels/Management/LayerEditViewModel.cs
+++ b/GIFrameworkMaps.Data/ViewModels/Management/LayerEditViewModel.cs
@@ -11,5 +11,6 @@ namespace GIFrameworkMaps.Data.ViewModels.Management
 		public SelectList? AvailableDisclaimers { get; set; }
 		public IList<int> SelectedCategories { get; set; } = [];
 		public IList<Category> AvailableCategories { get; set; } = [];
+		public IList<Version> VersionsLayerAppearsIn { get; set; } = [];
 	}
 }

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerCategoryController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerCategoryController.cs
@@ -230,6 +230,8 @@ namespace GIFrameworkMaps.Web.Controllers.Management
 			model.AvailableParentCategories = new SelectList(parentCategories, "Id", "Name", category.ParentCategoryId);
 			model.AvailableLayers = availableLayers;
 			model.SelectedLayers = selectedLayerIds.ToList();
+			model.VersionsCategoryAppearsIn = await _repository.GetVersionsLayerCategoriesAppearIn([model.Category.Id]);
+
 			ViewData["SelectedLayers"] = model.SelectedLayers;
 		}
     }

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerController.cs
@@ -1,4 +1,5 @@
-﻿using GIFrameworkMaps.Data;
+﻿using AspNetCoreGeneratedDocument;
+using GIFrameworkMaps.Data;
 using GIFrameworkMaps.Data.Models;
 using GIFrameworkMaps.Data.ViewModels.Management;
 using Microsoft.AspNetCore.Authorization;
@@ -246,9 +247,12 @@ namespace GIFrameworkMaps.Web.Controllers.Management
 				.AsNoTracking()
 				.OrderBy(b => b.Name);
 
+			var versions = await _repository.GetVersionsLayerCategoriesAppearIn(model.SelectedCategories);
+
 			model.AvailableBounds = new SelectList(bounds, "Id", "Name", layer.BoundId);
 			model.AvailableDisclaimers = new SelectList(disclaimers, "Id", "Name", layer.LayerDisclaimerId);
 			model.AvailableCategories = await categories.ToListAsync();
+			model.VersionsLayerAppearsIn = versions;
             ViewData["SelectedCategories"] = model.SelectedCategories;
             ViewData["AllCategories"] = model.AvailableCategories;
         }

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
@@ -11,7 +11,7 @@
 
 <div>
     <a href="https://dorset-council-uk.github.io/GIFramework-Maps-Admin-Guide/gui/layers/" class="btn btn-outline-primary" target="_blank"
-       role="button">Stuck? Read the help documentation</a>
+    role="button">Stuck? Read the help documentation</a>
 </div>
 
 <form asp-action="Edit">
@@ -27,13 +27,16 @@
             <div>
                 <a asp-action="Delete" asp-route-id="@Model.Layer.Id" class="btn btn-danger">Delete</a>
             </div>
-        
+
         </div>
         <div class="col-md-4 col-lg-6">
 
             <ul class="nav nav-underline mb-2" role="tablist">
                 <li class="nav-item active" role="presentation">
                     <button class="nav-link active" id="categories-tab" data-bs-toggle="tab" data-bs-target="#categories-tab-pane" type="button" role="tab" aria-controls="categories-tab-pane" aria-selected="true">Layer Categories</button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="versions-tab" data-bs-toggle="tab" data-bs-target="#versions-tab-pane" type="button" role="tab" aria-controls="versions-tab-pane" aria-selected="false">Appears in versions</button>
                 </li>
                 <li class="nav-item" role="presentation">
                     <button class="nav-link" id="details-tab" data-bs-toggle="tab" data-bs-target="#details-tab-pane" type="button" role="tab" aria-controls="details-tab-pane" aria-selected="false">Source details</button>
@@ -43,6 +46,30 @@
             <div class="tab-content">
                 <div class="tab-pane fade show active" id="categories-tab-pane" role="tabpanel" aria-labelledby="categories-tab" tabindex="0">
                     <partial name="ManagementPartials/VersionCategoryList" model="Model.AvailableCategories.Where(c => c.ParentCategoryId == null).ToList()" view-data="ViewData" />
+                </div>
+                <div class="tab-pane fade" id="versions-tab-pane" role="tabpanel" aria-labelledby="versions-tab" tabindex="0">
+                    @if(Model.VersionsLayerAppearsIn is null || Model.VersionsLayerAppearsIn.Count == 0)
+                    {
+                        <div class="alert alert-info">This layer doesn't appear in any versions at the moment</div>
+                    }
+                    else
+                    {
+                        <ul class="list-group">
+                            @foreach (var version in Model.VersionsLayerAppearsIn.OrderBy(v => v.Name))
+                            {
+                                <li class="list-group-item">
+                                    <a asp-action="Edit" asp-controller="ManagementVersion" asp-route-id="@version.Id">@version.Name</a>
+                                    <span class="text-muted fst-italic">/@version.Slug</span>
+                                    @if (version.RequireLogin)
+                                    {
+                                        <span class="bi bi-lock" title="This version requires a login"></span>
+                                    }
+                                </li>
+
+
+                        }
+                        </ul>
+                    }
                 </div>
                 <div class="tab-pane fade" id="details-tab-pane" role="tabpanel" aria-labelledby="details-tab" tabindex="0">
                     <table class="table table-sm table-striped">

--- a/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Edit.cshtml
@@ -47,13 +47,41 @@
             <a asp-action="Delete" asp-route-id="@Model.Category.Id" class="btn btn-danger">Delete</a>
 
         </div>
+
         <div class="col-md-6">
-            <div class="card mb-2">
-                <div class="card-header">
-                    Layers
-                </div>
-                <div class="card-body">
+            <ul class="nav nav-underline mb-2" role="tablist">
+                <li class="nav-item active" role="presentation">
+                    <button class="nav-link active" id="layers-tab" data-bs-toggle="tab" data-bs-target="#layers-tab-pane" type="button" role="tab" aria-controls="layers-tab-pane" aria-selected="true">Layers</button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="versions-tab" data-bs-toggle="tab" data-bs-target="#versions-tab-pane" type="button" role="tab" aria-controls="versions-tab-pane" aria-selected="false">Appears in versions</button>
+                </li>
+            </ul>
+            <div class="tab-content">
+                <div class="tab-pane fade show active" id="layers-tab-pane" role="tabpanel" aria-labelledby="layers-tab" tabindex="0">
                     <partial name="ManagementPartials/CategoryLayerList" model="Model" view-data="ViewData" />
+                </div>
+                <div class="tab-pane fade" id="versions-tab-pane" role="tabpanel" aria-labelledby="versions-tab" tabindex="0">
+                    @if (Model.VersionsCategoryAppearsIn is null || Model.VersionsCategoryAppearsIn.Count == 0)
+                    {
+                        <div class="alert alert-info">This layer doesn't appear in any versions at the moment</div>
+                    }
+                    else
+                    {
+                        <ul class="list-group">
+                            @foreach (var version in Model.VersionsCategoryAppearsIn.OrderBy(v => v.Name))
+                            {
+                                <li class="list-group-item">
+                                    <a asp-action="Edit" asp-controller="ManagementVersion" asp-route-id="@version.Id">@version.Name</a>
+                                    <span class="text-muted fst-italic">/@version.Slug</span>
+                                    @if (version.RequireLogin)
+                                    {
+                                        <span class="bi bi-lock" title="This version requires a login"></span>
+                                    }
+                                </li>
+                            }
+                        </ul>
+                    }
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR adds a tab to the edit pages of Layer and Category, showing which versions the item appears in, to help administrators understand where a layer or category appears and the potential impact of any changes.

Closes #324 and #326
