### PR TITLE
Apply auth headers to management pages

### DIFF
--- a/GIFrameworkMaps.Data/Data/CommonRepository.cs
+++ b/GIFrameworkMaps.Data/Data/CommonRepository.cs
@@ -155,7 +155,7 @@ namespace GIFrameworkMaps.Data
             return viewModel;
         }
 
-		private async Task<List<URLAuthorizationRule>> GetURLAuthorizationRules()
+		public async Task<List<URLAuthorizationRule>> GetURLAuthorizationRules()
 		{
 			return await _context.URLAuthorizationRules
 			.AsNoTracking()

--- a/GIFrameworkMaps.Data/Data/ICommonRepository.cs
+++ b/GIFrameworkMaps.Data/Data/ICommonRepository.cs
@@ -21,6 +21,8 @@ namespace GIFrameworkMaps.Data
         Task<List<Bookmark>> GetBookmarksForUserAsync(string userId);
         Task<string> GenerateShortId(string url);
         Task<string> GetFullUrlFromShortId(string shortId);
-        bool IsURLCurrentApplication(string url);
+		Task<List<URLAuthorizationRule>> GetURLAuthorizationRules();
+
+		bool IsURLCurrentApplication(string url);
     }
 }

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementController.cs
@@ -29,7 +29,15 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             
         }
 
-        public async Task<IActionResult> BroadcastMessage()
+		public async Task<JsonResult> URLAuthorizationRules()
+		{
+			var rules = await _repository.GetURLAuthorizationRules();
+			return Json(rules);
+		}
+
+
+
+		public async Task<IActionResult> BroadcastMessage()
         {
             var versions = await _repository.GetVersions();
             return View(versions);

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerWizardController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerWizardController.cs
@@ -24,10 +24,12 @@ namespace GIFrameworkMaps.Web.Controllers.Management
         private readonly ICommonRepository _commonRepository = commonRepository;
         private readonly ApplicationDbContext _context = context;
 
-		public IActionResult Index() {
+		public async Task<IActionResult> Index() {
             //get list of services
             var definitions = _commonRepository.GetWebLayerServiceDefinitions();
-            return View(definitions);
+			var authRules = await _commonRepository.GetURLAuthorizationRules();
+			ViewData["UrlAuthorizationRules"] = authRules;
+			return View(definitions);
         }
 
         [HttpPost]

--- a/GIFrameworkMaps.Web/Scripts/Management/management.ts
+++ b/GIFrameworkMaps.Web/Scripts/Management/management.ts
@@ -5,10 +5,9 @@ import { CreateLayerFromSource } from "./CreateLayerFromSource";
 import { CreateSource } from "./CreateSource";
 import accessibleAutocomplete from "accessible-autocomplete";
 import { Tooltip } from "bootstrap";
-import { UrlAuthorizationRules } from "../Interfaces/Authorization/UrlAuthorizationRules";
 
 declare let appRoot: string;
-declare let authRules: UrlAuthorizationRules[];
+declare let authRulesEndpoint: string;
 
 addEventListener("DOMContentLoaded", () => {
   //attach collapse caret changer
@@ -56,14 +55,14 @@ addEventListener("DOMContentLoaded", () => {
 
 //TODO - This method of initializing stuff is HORRIBLE. Replace with something better
 document.addEventListener("CreateLayerFromSourceInit", () => {
-  new CreateLayerFromSource().init();
+  new CreateLayerFromSource().init(appRoot, authRulesEndpoint);
 });
 document.addEventListener("BroadcastInit", () => {
   new Broadcast().init();
 });
 document.addEventListener("SelectWebServiceInit", () => {
   /*variables passed from index.cshtml. Use sparingly*/
-  new SelectWebService().init(authRules, appRoot);
+  new SelectWebService().init(appRoot, authRulesEndpoint);
 });
 document.addEventListener("CreateSourceInit", () => {
   new CreateSource().init();

--- a/GIFrameworkMaps.Web/Scripts/Management/management.ts
+++ b/GIFrameworkMaps.Web/Scripts/Management/management.ts
@@ -5,6 +5,10 @@ import { CreateLayerFromSource } from "./CreateLayerFromSource";
 import { CreateSource } from "./CreateSource";
 import accessibleAutocomplete from "accessible-autocomplete";
 import { Tooltip } from "bootstrap";
+import { UrlAuthorizationRules } from "../Interfaces/Authorization/UrlAuthorizationRules";
+
+declare let appRoot: string;
+declare let authRules: UrlAuthorizationRules[];
 
 addEventListener("DOMContentLoaded", () => {
   //attach collapse caret changer
@@ -58,7 +62,8 @@ document.addEventListener("BroadcastInit", () => {
   new Broadcast().init();
 });
 document.addEventListener("SelectWebServiceInit", () => {
-  new SelectWebService().init();
+  /*variables passed from index.cshtml. Use sparingly*/
+  new SelectWebService().init(authRules, appRoot);
 });
 document.addEventListener("CreateSourceInit", () => {
   new CreateSource().init();

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
@@ -135,12 +135,15 @@
         }
     </style>
 }
-<script>
-    var proxyEndpoint = '@proxyEndpoint';
-</script>
+@{
+    var host = Context.Request.Host.ToUriComponent();
+    var pathBase = Context.Request.PathBase.ToUriComponent();
+}
 @section Scripts{
     <script>
-        
+        var proxyEndpoint = '@proxyEndpoint';
+        var authRulesEndpoint = '@Url.Action("URLAuthorizationRules", "Management")';
+        var appRoot = '@host@pathBase/';
         document.addEventListener("DOMContentLoaded", (event) => {
             const ev = new Event("CreateLayerFromSourceInit")
             document.dispatchEvent(ev);

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
@@ -166,11 +166,15 @@
     </style>
 }
 
-<script>
-    var proxyEndpoint = '@proxyEndpoint';
-</script>
-@section Scripts{
+@{
+    var host = Context.Request.Host.ToUriComponent();
+    var pathBase = Context.Request.PathBase.ToUriComponent();
+}
+@section Scripts {
     <script>
+        var proxyEndpoint = '@proxyEndpoint';
+        var authRulesEndpoint = '@Url.Action("URLAuthorizationRules", "Management")';
+        var appRoot = '@host@pathBase/';
         document.addEventListener("DOMContentLoaded", (event) => {
             const ev = new Event("CreateLayerFromSourceInit")
             document.dispatchEvent(ev);

--- a/GIFrameworkMaps.Web/Views/ManagementLayerWizard/CreateSource.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerWizard/CreateSource.cshtml
@@ -1,4 +1,5 @@
 ﻿@using GIFrameworkMaps.Data.ViewModels.Management
+@using Microsoft.AspNetCore.Http
 @model LayerWizardCreateSourceViewModel
 
 @{
@@ -124,10 +125,11 @@
 </div>
 
 <script>
-    var attributionRendererEndpoint = '@Url.Action("RenderAttributionString","Management")';
+    var attributionRendererEndpoint = '@Url.Action("RenderAttributionString", "Management")';
 </script>
 @section Scripts{
     <script>
+
         document.addEventListener("DOMContentLoaded", (event) => {
             const ev = new Event("CreateSourceInit")
             document.dispatchEvent(ev);

--- a/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
@@ -146,9 +146,21 @@
 
     </div>
 </template>
+@{
+    var host = Context.Request.Host.ToUriComponent();
+    var pathBase = Context.Request.PathBase.ToUriComponent();
+    var jsonOptions = new System.Text.Json.JsonSerializerOptions
+    {
+        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
+    };
+    jsonOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
 
+}
 @section Scripts{
     <script>
+        var authRules = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(ViewData["UrlAuthorizationRules"], jsonOptions));
+
+        var appRoot = '@host@pathBase/';
         document.addEventListener("DOMContentLoaded", (event) => {
             const ev = new Event("SelectWebServiceInit")
             document.dispatchEvent(ev);

--- a/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerWizard/Index.cshtml
@@ -149,17 +149,10 @@
 @{
     var host = Context.Request.Host.ToUriComponent();
     var pathBase = Context.Request.PathBase.ToUriComponent();
-    var jsonOptions = new System.Text.Json.JsonSerializerOptions
-    {
-        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
-    };
-    jsonOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
-
 }
 @section Scripts{
     <script>
-        var authRules = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(ViewData["UrlAuthorizationRules"], jsonOptions));
-
+        var authRulesEndpoint = '@Url.Action("URLAuthorizationRules", "Management")';
         var appRoot = '@host@pathBase/';
         document.addEventListener("DOMContentLoaded", (event) => {
             const ev = new Event("SelectWebServiceInit")


### PR DESCRIPTION
This PR adds authentication headers where required to requests from the management pages.

This currently includes
- Layer Wizard
- Layer Edit and Create

The actual method isn't particularly nice, but does reuse most of how it works in the main map pages.