### PR TITLE
Allow layers to be set to auto-refresh

### DIFF
--- a/GIFrameworkMaps.Data/Data/AutoMapping.cs
+++ b/GIFrameworkMaps.Data/Data/AutoMapping.cs
@@ -48,7 +48,8 @@ namespace GIFrameworkMaps.Data
 				.ForMember(cl => cl.DefaultFilterEditable, lvm => lvm.MapFrom(s => s.Layer!.DefaultFilterEditable))
 				.ForMember(cl => cl.InfoListTitleTemplate, lvm => lvm.MapFrom(s => s.Layer!.InfoListTitleTemplate))
 				.ForMember(cl => cl.ProxyMapRequests, lvm => lvm.MapFrom(s => s.Layer!.ProxyMapRequests))
-				.ForMember(cl => cl.ProxyMetaRequests, lvm => lvm.MapFrom(s => s.Layer!.ProxyMetaRequests));
+				.ForMember(cl => cl.ProxyMetaRequests, lvm => lvm.MapFrom(s => s.Layer!.ProxyMetaRequests))
+				.ForMember(cl => cl.RefreshInterval, lvm => lvm.MapFrom(s => s.Layer!.RefreshInterval));
 
 			CreateMap<VersionProjection, ProjectionViewModel>()
 				.ForMember(vp => vp.EPSGCode, pvm => pvm.MapFrom(s => s.Projection!.EPSGCode))

--- a/GIFrameworkMaps.Data/Migrations/ApplicationDb/20250605164415_AddRefreshIntervalToLayer.Designer.cs
+++ b/GIFrameworkMaps.Data/Migrations/ApplicationDb/20250605164415_AddRefreshIntervalToLayer.Designer.cs
@@ -3,6 +3,7 @@ using GIFrameworkMaps.Data;
 using GIFrameworkMaps.Data.Models.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250605164415_AddRefreshIntervalToLayer")]
+    partial class AddRefreshIntervalToLayer
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMaps.Data/Migrations/ApplicationDb/20250605164415_AddRefreshIntervalToLayer.cs
+++ b/GIFrameworkMaps.Data/Migrations/ApplicationDb/20250605164415_AddRefreshIntervalToLayer.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddRefreshIntervalToLayer : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "RefreshInterval",
+                schema: "giframeworkmaps",
+                table: "Layers",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RefreshInterval",
+                schema: "giframeworkmaps",
+                table: "Layers");
+        }
+    }
+}

--- a/GIFrameworkMaps.Data/Models/Layer.cs
+++ b/GIFrameworkMaps.Data/Models/Layer.cs
@@ -35,7 +35,10 @@ namespace GIFrameworkMaps.Data.Models
         public bool ProxyMetaRequests { get; set; }
         [Display(Name = "Proxy Map Requests")]
         public bool ProxyMapRequests { get; set; }
-        public int LayerSourceId { get; set; }
+		[Display(Name = "Refresh Interval (seconds)")]
+		[Range(0, 3600, ErrorMessage = "Refresh interval must be between 0 and 3600 seconds. A value of 0 means no refresh.")]
+		public int? RefreshInterval { get; set; } // in seconds, null or 0 means no refresh
+		public int LayerSourceId { get; set; }
 		[Display(Name="Disclaimer (optional)")]
 		public int? LayerDisclaimerId { get; set; }
 		public LayerSource? LayerSource { get; set; }

--- a/GIFrameworkMaps.Data/ViewModels/LayerViewModel.cs
+++ b/GIFrameworkMaps.Data/ViewModels/LayerViewModel.cs
@@ -21,6 +21,7 @@ namespace GIFrameworkMaps.Data.ViewModels
 		public bool DefaultFilterEditable { get; set; }
 		public bool ProxyMetaRequests { get; set; }
 		public bool ProxyMapRequests { get; set; }
+		public int? RefreshInterval { get; set; }
 		public LayerSource? LayerSource { get; set; }
 		public LayerDisclaimer? LayerDisclaimer { get; set; }
 	}

--- a/GIFrameworkMaps.Web/Authorization/ClaimsTransformer.cs
+++ b/GIFrameworkMaps.Web/Authorization/ClaimsTransformer.cs
@@ -20,9 +20,12 @@ namespace GIFrameworkMaps.Web.Authorization
             
             foreach(var role in roles)
             {
-                Claim customRoleClaim = new(claimsIdentity.RoleClaimType, role.Role.RoleName);
-                claimsIdentity.AddClaim(customRoleClaim);
-            }
+				if (!claimsIdentity.HasClaim(claimsIdentity.RoleClaimType, role.Role.RoleName))
+				{
+					Claim customRoleClaim = new(claimsIdentity.RoleClaimType, role.Role.RoleName);
+					claimsIdentity.AddClaim(customRoleClaim);
+				}
+			}
             //fetch roles from extension_roles claim
             //Removed as not currently needed, but may be added/changed in future
             //var extensionRolesClaim = claimsIdentity.FindFirst("extension_roles");

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerController.cs
@@ -142,7 +142,8 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 a => a.Filterable,
                 a => a.ProxyMapRequests,
                 a => a.ProxyMetaRequests,
-				a => a.LayerDisclaimerId))
+				a => a.LayerDisclaimerId,
+				a => a.RefreshInterval))
             {
 
                 try

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/Layer.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/Layer.ts
@@ -49,4 +49,5 @@ export interface Layer {
   removable: boolean;
   proxyMetaRequests: boolean;
   proxyMapRequests: boolean;
+  refreshInterval: number;
 }

--- a/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
+++ b/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
@@ -153,9 +153,8 @@ export class GIFWLayerGroup implements LayerGroup {
         }
         ol_layers.push(ol_layer);
         if (layer.refreshInterval && layer.refreshInterval > 0) {
-          this.setAutoRefreshInterval(ol_layer, layer.refreshInterval); //set a default auto refresh interval of 10 seconds
+          this.setAutoRefreshInterval(ol_layer, layer.refreshInterval);
         }
-        
       }
     }
 
@@ -165,12 +164,6 @@ export class GIFWLayerGroup implements LayerGroup {
     layerGroup.setProperties({ type: this.layerGroupType });
 
     return layerGroup;
-  }
-
-  private setAutoRefreshInterval(layer: olLayer.Layer<olSource.Source, LayerRenderer<olLayer.Layer>>, interval: number) {
-    setInterval(() => {
-      layer.getSource().refresh();
-    }, interval * 1000)
   }
 
   async customTileLoader(
@@ -256,6 +249,14 @@ export class GIFWLayerGroup implements LayerGroup {
     });
   }
 
+  private setAutoRefreshInterval(layer: olLayer.Layer<olSource.Source, LayerRenderer<olLayer.Layer>>, interval: number) {
+    setInterval(() => {
+      if (layer.isVisible()) {
+        layer.getSource().refresh();
+      }
+    }, interval * 1000)
+  }
+
   addLayerToGroup(
     layer: Layer,
     ol_layer: olLayer.Layer<olSource.Source, LayerRenderer<olLayer.Layer>>,
@@ -265,6 +266,9 @@ export class GIFWLayerGroup implements LayerGroup {
     newLayerGroup.push(ol_layer);
     this.olLayerGroup.setLayers(newLayerGroup);
     this.addChangeEventsForLayer(ol_layer);
+    if (layer.refreshInterval && layer.refreshInterval > 0) {
+      this.setAutoRefreshInterval(ol_layer, layer.refreshInterval);
+    }
   }
 
   private createXYZLayer(

--- a/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
+++ b/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
@@ -152,6 +152,10 @@ export class GIFWLayerGroup implements LayerGroup {
           }
         }
         ol_layers.push(ol_layer);
+        if (layer.refreshInterval && layer.refreshInterval > 0) {
+          this.setAutoRefreshInterval(ol_layer, layer.refreshInterval); //set a default auto refresh interval of 10 seconds
+        }
+        
       }
     }
 
@@ -161,6 +165,12 @@ export class GIFWLayerGroup implements LayerGroup {
     layerGroup.setProperties({ type: this.layerGroupType });
 
     return layerGroup;
+  }
+
+  private setAutoRefreshInterval(layer: olLayer.Layer<olSource.Source, LayerRenderer<olLayer.Layer>>, interval: number) {
+    setInterval(() => {
+      layer.getSource().refresh();
+    }, interval * 1000)
   }
 
   async customTileLoader(

--- a/GIFrameworkMaps.Web/Scripts/Map.ts
+++ b/GIFrameworkMaps.Web/Scripts/Map.ts
@@ -647,6 +647,7 @@ export class GIFWMap {
       removable: type === LayerGroupType.UserNative,
       proxyMetaRequests: false,
       proxyMapRequests: false,
+      refreshInterval: 0,
     };
 
     const layerGroup = this.getLayerGroupOfType(type);
@@ -747,6 +748,7 @@ export class GIFWMap {
       removable: true,
       proxyMetaRequests: proxyMetaRequests,
       proxyMapRequests: proxyMapRequests,
+      refreshInterval: 0,
     };
 
     let layerGroup = this.getLayerGroupOfType(type);

--- a/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/EditLayerPartial.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/EditLayerPartial.cshtml
@@ -1,7 +1,7 @@
 ﻿@using GIFrameworkMaps.Data.ViewModels.Management
 @model LayerEditViewModel
 
-<div asp-validation-summary="ModelOnly" class="alert alert-danger mb-3"></div>
+<div asp-validation-summary="All" class="text-danger my-2"></div>
 <input type="hidden" asp-for="Layer.Id" />
 <div class="mb-3">
     <label asp-for="Layer.Name" class="control-label"></label>
@@ -135,6 +135,17 @@
         <input asp-for="Layer.ProxyMetaRequests" class="form-check-input" data-proxy-meta="true" />
         <label asp-for="Layer.ProxyMetaRequests" class="form-check-label"></label>
         <span asp-validation-for="Layer.ProxyMetaRequests" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="Layer.RefreshInterval" class="control-label"></label>
+        <div class="row">
+            <div class="col-lg-3 col-md-4 col-6">
+                <input asp-for="Layer.RefreshInterval" class="form-control" />
+            </div>
+        </div>
+        <div class="form-text">Recommend no less than 30, and no more than 3600 (1 hour)</div>
+        <span asp-validation-for="Layer.RefreshInterval" class="text-danger"></span>
     </div>
 
 </div>


### PR DESCRIPTION
This PR adds a `RefreshInterval` property to layers, which will trigger a layer to automatically reload data from the server every x seconds with no user intervention. This is useful for 'live' layers such as travel alerts or incident data.

There is also a small bug fix for the `ClaimsTransformer`, which was adding roles to the user claims for every http request, resulting in excessive duplicate claims being added.