### PR TITLE
Fix: Apply max-height in vh to .ol-popup-content to prevent overflow

### DIFF
--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -640,7 +640,7 @@
   bottom: 12px;
   left: -50px;
   min-width: 260px;
-  max-height: 80vh;
+  /* max-height: 80vh;*/
 }
 @media (min-width: 768px) {
   .giframeworkMapContainer .ol-popup {
@@ -681,7 +681,7 @@
 }
 
 .giframeworkMapContainer .ol-popup-content {
-  max-height: 500px;
+  max-height: 80vh;
   max-width: 400px;
   overflow-y: auto;
 }

--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -640,7 +640,6 @@
   bottom: 12px;
   left: -50px;
   min-width: 260px;
-  /* max-height: 80vh;*/
 }
 @media (min-width: 768px) {
   .giframeworkMapContainer .ol-popup {


### PR DESCRIPTION
Hi @RobQuincey, this PR addresses issue #354. Could you please review it when convenient? Thanks!

![changes](https://github.com/user-attachments/assets/2a59194d-f3d7-401a-abd5-ed61cb3998a3)

## Summary

This pull request fixes a UI issue where popup content in `.giframeworkMapContainer .ol-popup` could overflow beyond the container when displaying large amounts of information.

## Fix Details

- Removed `max-height` from `.ol-popup`.
- Applied `max-height: 80vh` and `overflow-y: auto` to `.ol-popup-content`.
- This ensures the popup content scrolls properly within the container without overflowing.

## Linked Issue

Fixes #354
