### PR TITLE
Optimise build process

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,73 @@
+name: Build GIFrameworkMaps
+description: |
+  This workflow builds the GIFrameworkMaps project, runs npm and webpack, and uploads the artifact.
+inputs:
+  environment:
+    description: 'The environment to build for (dev or prod).'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+
+    - uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+      shell: bash
+
+    - name: npm install
+      run: npm install --force
+      working-directory: 'GIFrameworkMaps.Web'
+      shell: bash
+
+    - name: Install webpack
+      run: npm i -g webpack webpack-cli
+      working-directory: 'GIFrameworkMaps.Web'
+      shell: bash
+
+    - name: webpack dev
+      if: ${{ inputs.environment == 'dev' }}
+      run: webpack --config webpack.dev.js
+      working-directory: 'GIFrameworkMaps.Web'
+      shell: bash
+    
+    - name: webpack prod
+      if: ${{ inputs.environment == 'prod' }}
+      run: webpack --config webpack.prod.js
+      working-directory: 'GIFrameworkMaps.Web'
+      shell: bash
+
+    - name: Build
+      run: dotnet build --no-restore
+      shell: bash
+
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+      shell: bash
+
+    - name: Publish
+      run: dotnet publish -o '../release'
+      working-directory: 'GIFrameworkMaps.Web'
+      shell: bash
+
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        path: 'release'

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -15,6 +15,7 @@ runs:
       with:
         node-version: 20
         cache: 'npm'
+        cache-dependency-path: GIFrameworkMaps.Web/package-lock.json
 
     - uses: actions/cache@v4
       with:
@@ -32,8 +33,8 @@ runs:
       run: dotnet restore
       shell: bash
 
-    - name: npm install
-      run: npm install --force
+    - name: npm clean install
+      run: npm ci
       working-directory: 'GIFrameworkMaps.Web'
       shell: bash
 

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,6 +1,3 @@
-# This workflow will build the .NET project, run npm and webpack, and upload the artifact
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
 name: Development (.NET)
 
 on:
@@ -9,45 +6,9 @@ on:
 
 jobs:
   build:
-
-    runs-on: windows-latest
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: ./.github/actions/build
       with:
-        node-version: 20
-        cache: 'npm'
-    - uses: actions/cache@v4
-      with:
-        path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-      
-    - name: npm install
-      run: npm install --force
-      working-directory: 'GIFrameworkMaps.Web'
-    - name: Install webpack
-      run: npm i -g webpack webpack-cli
-      working-directory: 'GIFrameworkMaps.Web'
-    - name: webpack
-      run: webpack --config webpack.dev.js
-      working-directory: 'GIFrameworkMaps.Web'
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
-    - name: Publish
-      run: dotnet publish -o '../release'
-      working-directory: 'GIFrameworkMaps.Web'
-    - name: Upload Build Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        path: 'release'
+        environment: 'dev'

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -2,51 +2,16 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: Production (.NET)
-
 on:
   push:
     branches: [ "main" ]
 
 jobs:
   build:
-
-    runs-on: windows-latest
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: ./.github/actions/build
       with:
-        node-version: 20
-        cache: 'npm'
-    - uses: actions/cache@v4
-      with:
-        path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: npm install
-      run: npm install --force
-      working-directory: 'GIFrameworkMaps.Web'
-    - name: Install webpack
-      run: npm i -g webpack webpack-cli
-      working-directory: 'GIFrameworkMaps.Web'
-    - name: webpack
-      run: webpack --config webpack.prod.js
-      working-directory: 'GIFrameworkMaps.Web'
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
-    - name: Publish
-      run: dotnet publish -o '../release'
-      working-directory: 'GIFrameworkMaps.Web'
-    - name: Upload Build Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        path: 'release'
+        environment: 'prod'
+    

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -1,6 +1,3 @@
-# This workflow will build the .NET project, run npm and webpack, and upload the artifact
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
 name: Production (.NET)
 on:
   push:


### PR DESCRIPTION
* [ Cache node packages correctly in a monorepo ](https://github.com/actions/setup-node?tab=readme-ov-file#caching-global-packages-data)
* Reduce redundant/duplicate code by creating a reusable composite action
* Change runner from `windows-latest` to `ubuntu-latest`