### PR TITLE
Fix issue with null filter not applying

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/LayerFilter.ts
+++ b/GIFrameworkMaps.Web/Scripts/LayerFilter.ts
@@ -1038,8 +1038,7 @@ export class LayerFilter {
         invalidFeedbackEle.remove();
       }
       filterRow
-        .querySelector(".valuesEditor input")
-        .classList.remove("is-invalid");
+        .querySelector(".valuesEditor input")?.classList.remove("is-invalid");
 
       switch (filterType.type) {
         case "singleValue": {
@@ -1744,11 +1743,13 @@ export class LayerFilter {
     const propertyName = this.getSelectedPropertyNameForRow(filterRow);
     const suggestions = await this.getValueSuggestionsForProperty(propertyName);
     const datalist = filterRow.querySelector("datalist");
+    if (datalist) {
     let opts = "";
     suggestions?.forEach((suggestion) => {
       opts += `<option value="${suggestion}"></option>`;
     });
     datalist.innerHTML = opts;
+  }
   }
 
   /**


### PR DESCRIPTION
This PR fixes an issue where choosing an IsNull filter would result in the dialog not closing and the filter not applying.

Whilst this fixes the specific issue, there are larger issues with how IsNull works. It is impossible to set an Is Not Null filter using the negation filters (they are just ignored), so it could do with some more work, but this is bigger, more complex work and will be covered in a new issue.

Closes #361 