### PR TITLE
Fix minor colour issue with links

### DIFF
--- a/GIFrameworkMaps.Web/wwwroot/css/site.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/site.css
@@ -22,7 +22,7 @@ a {
   color: #1d70b8;
 }
 [data-bs-theme="dark"] a {
-  color: #72b7df;
+  color: var(--bs-body-color);
 }
 a:hover,
 a:focus {


### PR DESCRIPTION
Fixes a minor CSS colour issue with links. Buttons and links were being rendered as blue in dark mode, which was OK for some links, but created colour contrast issues with some buttons. Colour now uses bootstrap variable so should be suitable always.

Existing style

This is OK
<img width="188" height="191" alt="Colour contrast example 1" src="https://github.com/user-attachments/assets/880f4476-a267-460d-8e41-3a25e46270cc" />

But these were not
<img width="280" height="152" alt="Colour contrast example 2" src="https://github.com/user-attachments/assets/68cf3d74-6465-4d44-9696-f0e28d3ebf21" />

Now they render as white text
