### PR TITLE
Add compression to jsPDF addImage to fix large print file sizes

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Export.ts
+++ b/GIFrameworkMaps.Web/Scripts/Export.ts
@@ -256,6 +256,8 @@ export class Export {
         pageOrientation === "l"
           ? chosenPageSettings.pageHeight - pageMargin
           : chosenPageSettings.pageWidth - pageMargin,
+        undefined,
+        'FAST'
       );
       pdf.rect(
         mapStartingX,
@@ -837,7 +839,7 @@ export class Export {
             const heightInMM = (imgProps.height * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
             pdf.text(layerName, currentX + 2, currentY);
             currentY += pdf.getTextDimensions(layerName).h;
-            pdf.addImage(img, currentX + 2, currentY, widthInMM, heightInMM);
+            pdf.addImage(img, currentX + 2, currentY, widthInMM, heightInMM, undefined, 'FAST');
             if (widthInMM > maxWidth) maxWidth = widthInMM;
             if (layerNameWidth > maxWidth) maxWidth = layerNameWidth;
             currentY += heightInMM + 7.5;
@@ -896,7 +898,7 @@ export class Export {
           const heightInMM = (imgProps.height * this.ONE_INCH) / this.DEFAULT_SCREEN_RESOLUTION;
           pdf.text(layerName, currentX + 2, currentY);
           currentY += pdf.getTextDimensions(layerName).h;
-          pdf.addImage(img, currentX + 2, currentY, widthInMM, heightInMM);
+          pdf.addImage(img, currentX + 2, currentY, widthInMM, heightInMM, undefined, 'FAST');
           if (widthInMM > maxWidth) maxWidth = widthInMM;
           if (layerNameWidth > maxWidth) maxWidth = layerNameWidth;
           currentY += heightInMM + 7.5;
@@ -958,7 +960,7 @@ export class Export {
           }
           pdf.text(layerName, currentX, currentY);
           currentY += pdf.getTextDimensions(layerName).h;
-          pdf.addImage(img, currentX, currentY, widthInMM, heightInMM);
+          pdf.addImage(img, currentX, currentY, widthInMM, heightInMM, undefined, 'FAST');
           if (widthInMM > maxWidth) maxWidth = widthInMM;
           if (layerNameWidth > maxWidth) maxWidth = layerNameWidth;
           currentY += heightInMM + 7.5;
@@ -1156,6 +1158,8 @@ export class Export {
       pageMargin / 2 + 1,
       newWidth,
       newHeight,
+      undefined,
+      'FAST'
     );
   }
 
@@ -1212,6 +1216,8 @@ export class Export {
       startingAttrYPosition - pageMargin / 2 - adjustedYHeight,
       newWidth,
       newHeight,
+      undefined,
+      'FAST'
     );
   }
 
@@ -1262,8 +1268,8 @@ export class Export {
       newWidth,
       newHeight,
       undefined,
-      undefined,
-      0,
+      'FAST',
+      0
     );
   }
 

--- a/GIFrameworkMaps.Web/package-lock.json
+++ b/GIFrameworkMaps.Web/package-lock.json
@@ -45,7 +45,6 @@
         "@types/lodash": "4.17.20",
         "@types/luxon": "3.7.1",
         "@types/nunjucks": "3.2.6",
-        "@types/proj4": "2.19.0",
         "@types/sortablejs": "1.15.8",
         "@typescript-eslint/eslint-plugin": "8.24.0",
         "@typescript-eslint/parser": "8.24.0",
@@ -1061,16 +1060,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
       "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="
-    },
-    "node_modules/@types/proj4": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.19.0.tgz",
-      "integrity": "sha512-mirdnXu5sW9+IphQ4r+ZVii2JVLDbXgMp1lxqbiCppdgL22EwMwL4Dy/cyHVaJ2y/mi7LUQHghpILd3w3j2bnA==",
-      "deprecated": "This is a stub types definition. proj4 provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "proj4": "*"
-      }
     },
     "node_modules/@types/raf": {
       "version": "3.4.3",

--- a/GIFrameworkMaps.Web/package.json
+++ b/GIFrameworkMaps.Web/package.json
@@ -55,7 +55,6 @@
     "@types/lodash": "4.17.20",
     "@types/luxon": "3.7.1",
     "@types/nunjucks": "3.2.6",
-    "@types/proj4": "2.19.0",
     "@types/sortablejs": "1.15.8",
     "@typescript-eslint/eslint-plugin": "8.24.0",
     "@typescript-eslint/parser": "8.24.0",


### PR DESCRIPTION
This PR adds a default compression (`'FAST'`) to all uses of `addImage` in the export library. 

When jsPDF updated to 3.0.2, the default behaviour changed. Previously, if you didn't provide a `compression` values to `addImage`, it defaulted to a certain level of compression. This was changed in 3.0.2 so if you didn't provide a value, no compression was used. This increased file sizes to a minimum of 13MB.

Also removed unneeded proj4 defs file.