### PR TITLE
Fix issue with erroneous invisible annotations being drawn when using buffer

### DIFF
--- a/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationDraw.ts
+++ b/GIFrameworkMaps.Web/Scripts/Annotate/AnnotationDraw.ts
@@ -96,7 +96,7 @@ export default class AnnotationDraw extends Draw {
         const formatter = new GeoJSON({
           dataProjection: "EPSG:4326",
         });
-        const featureGeom = e.feature.getGeometry().clone();
+        const featureGeom = e.feature.getGeometry();
         featureGeom.transform(
           this.getMap().getView().getProjection(),
           "EPSG:4326",
@@ -114,8 +114,6 @@ export default class AnnotationDraw extends Draw {
           this.getMap().getView().getProjection(),
         );
         feature = new Feature(bufferedGeometry);
-        // Remove the original point feature that was automatically added
-        annotationLayer.getSource().removeFeature(e.feature);
         annotationLayer.getSource().addFeature(feature);
       }
 


### PR DESCRIPTION
This PR fixes an issue where, when drawing a buffer annotation, and erroneous annotation was being added at coordinates 0,0, which, whilst invisible, would export and be selectable.

The fix involves
- Not using the `annotationLayer` source in the super constructor, therefore stopping a feature being created when the user clicks the center location
- 
Fixes #366 