### PR TITLE
Tweak height of mobile welcome modal

### DIFF
--- a/GIFrameworkMaps.Web/wwwroot/css/map.css
+++ b/GIFrameworkMaps.Web/wwwroot/css/map.css
@@ -780,7 +780,7 @@
   #welcome-modal .modal-dialog {
     width: 100%;
     max-width: none;
-    height: 100%;
+    min-height: 80vh;
     margin: 0;
   }
 


### PR DESCRIPTION
Hotfix to fix issue with the height of the welcome modal being fixed to 100% on mobile views, which meant overflowing content in the modal didn't have a background

<img  height="1000" alt="image" src="https://github.com/user-attachments/assets/037684e7-93ec-4bdd-b13e-0ad89a2c46c1" />
