### PR TITLE
Update version of jsPDF

### DIFF
--- a/GIFrameworkMaps.Web/package.json
+++ b/GIFrameworkMaps.Web/package.json
@@ -33,7 +33,7 @@
     "fuse.js": "7.1.0",
     "geostyler-openlayers-parser": "5.3.0",
     "geostyler-legend": "5.2.0",
-    "jspdf": "4.0.0",
+    "jspdf": "4.1.0",
     "lodash.debounce": "4.0.8",
     "luxon": "3.7.2",
     "nunjucks": "3.2.4",


### PR DESCRIPTION
The PR just updates the version of jsPDF used by the application. 

Closes https://github.com/Dorset-Council-UK/GIFramework-Maps/security/dependabot/37
Closes https://github.com/Dorset-Council-UK/GIFramework-Maps/security/dependabot/36
Closes https://github.com/Dorset-Council-UK/GIFramework-Maps/security/dependabot/35
Closes https://github.com/Dorset-Council-UK/GIFramework-Maps/security/dependabot/34