### PR TITLE
Update appsettings with OpenTelemetry setting

### DIFF
--- a/GIFrameworkMaps.Web/appsettings.Development.json
+++ b/GIFrameworkMaps.Web/appsettings.Development.json
@@ -6,7 +6,7 @@
       "Microsoft.Hosting.Lifetime": "Information",
       "Microsoft.EntityFrameworkCore.Database.Command": "Information"
     },
-    "ApplicationInsights": {
+    "OpenTelemetry": {
       "LogLevel": {
         "Default": "Information",
         "Microsoft": "Warning",

--- a/GIFrameworkMaps.Web/appsettings.Production.json
+++ b/GIFrameworkMaps.Web/appsettings.Production.json
@@ -5,7 +5,7 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     },
-    "ApplicationInsights": {
+    "OpenTelemetry": {
       "LogLevel": {
         "Default": "Warning",
         "Microsoft": "Warning",

--- a/GIFrameworkMaps.Web/appsettings.json
+++ b/GIFrameworkMaps.Web/appsettings.json
@@ -5,7 +5,7 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     },
-    "ApplicationInsights": {
+    "OpenTelemetry": {
       "LogLevel": {
         "Default": "Information",
         "Microsoft": "Warning",


### PR DESCRIPTION
The switch from ApplicationInsights classic to OpenTelemetry means the app settings also need updating with the new setting, which was missed in previous PRs.