### PR TITLE
Improve handling of WMS parameters in layer source

### DIFF
--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerWizardController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerWizardController.cs
@@ -134,15 +134,19 @@ namespace GIFrameworkMaps.Web.Controllers.Management
 					model.LayerSource.LayerSourceOptions.Add(urlOpt);
 					if (model.ServiceType == ServiceType.WMS)
 					{
-						var paramsValue = new { LAYERS = model.LayerName, FORMAT = model.Format, VERSION = model.Version, CRS = model.Projection };
-						var valueStr = JsonSerializer.Serialize(paramsValue, wmsParamsObjectWriterOpts);
-						var paramsOpt = new LayerSourceOption
+						model.LayerSource.LayerSourceOptions.Add(new LayerSourceOption { Name = "params.LAYERS", Value = model.LayerName });
+						if (!string.IsNullOrEmpty(model.Format))
 						{
-							Name = "params",
-							Value = valueStr
-						};
-						model.LayerSource.LayerSourceOptions.Add(paramsOpt);
-
+							model.LayerSource.LayerSourceOptions.Add(new LayerSourceOption { Name = "params.FORMAT", Value = model.Format });
+						}
+						if (!string.IsNullOrEmpty(model.Version))
+						{
+							model.LayerSource.LayerSourceOptions.Add(new LayerSourceOption { Name = "params.VERSION", Value = model.Version });
+						}
+						if (!string.IsNullOrEmpty(model.Projection))
+						{
+							model.LayerSource.LayerSourceOptions.Add(new LayerSourceOption { Name = "params.CRS", Value = model.Projection });
+						}
 					}
 					else
 					{
@@ -198,12 +202,6 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             var xyzLayerSourceType = await _context.LayerSourceTypes.Where(l => l.Name == "XYZ").SingleOrDefaultAsync();
             model.LayerSource.LayerSourceTypeId = xyzLayerSourceType.Id;
         }
-
-		private static readonly JsonSerializerOptions wmsParamsObjectWriterOpts = new()
-		{
-			WriteIndented = true,
-			DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-		};
 
 		private static readonly JsonSerializerOptions layerResourceDeserializationOpts = new()
 		{

--- a/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
+++ b/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
@@ -19,7 +19,7 @@ import { Options as TileWMSOptions } from "ol/source/TileWMS";
 import { Options as VectorTileOptions } from "ol/source/VectorTile";
 import { Options as XYZOptions } from "ol/source/XYZ";
 import TileGrid from "ol/tilegrid/TileGrid";
-import { Layer } from "../Interfaces/Layer";
+import { Layer, LayerSourceOption } from "../Interfaces/Layer";
 import { LayerGroupType } from "../Interfaces/LayerGroupType";
 import { TileMatrixSet } from "../Interfaces/OGCMetadata/TileMatrixSet";
 import { GIFWMap } from "../Map";
@@ -358,23 +358,53 @@ export class GIFWLayerGroup implements LayerGroup {
    * (Name="params.KEY", e.g. "params.LAYERS"). When both are present, new-style
    * keys take precedence over the legacy blob.
    */
-  private resolveWmsParams(options: import("../Interfaces/Layer").LayerSourceOption[]): Record<string, string> {
-    // Build object from new-style params.KEY entries
-    const newStyleParams: Record<string, string> = {};
+  private resolveWmsParams(options: LayerSourceOption[]): Record<string, string> {
+    const merged: Record<string, unknown> = {};
+    // Legacy params blob first (so new-style keys can override)
+    const legacyOpt = options.find((o) => o.name.toLowerCase() === "params");
+    if (legacyOpt) {
+      try {
+        const parsed: unknown = JSON.parse(legacyOpt.value);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          Object.assign(merged, parsed as Record<string, unknown>);
+        }
+      } catch {
+        // Ignore invalid legacy JSON
+      }
+    }
+
+    // New-style params.KEY entries
     for (const opt of options) {
       if (opt.name.toLowerCase().startsWith("params.")) {
-        const key = opt.name.substring("params.".length);
-        if (key) {
-          newStyleParams[key] = opt.value;
+        const rawKey = opt.name.substring("params.".length).trim();
+        if (rawKey) {
+          merged[rawKey.toUpperCase()] = opt.value;
         }
       }
     }
 
-    // Also read legacy params JSON blob (if present), letting new-style keys win
-    const legacyOpt = options.find((o) => o.name.toLowerCase() === "params");
-    const legacyParams: Record<string, string> = legacyOpt ? JSON.parse(legacyOpt.value) : {};
+    return merged;
 
-    return { ...legacyParams, ...newStyleParams };
+
+
+
+
+    // // Build object from new-style params.KEY entries
+    // const newStyleParams: Record<string, string> = {};
+    // for (const opt of options) {
+    //   if (opt.name.toLowerCase().startsWith("params.")) {
+    //     const key = opt.name.substring("params.".length);
+    //     if (key) {
+    //       newStyleParams[key] = opt.value;
+    //     }
+    //   }
+    // }
+
+    // // Also read legacy params JSON blob (if present), letting new-style keys win
+    // const legacyOpt = options.find((o) => o.name.toLowerCase() === "params");
+    // const legacyParams: Record<string, string> = legacyOpt ? JSON.parse(legacyOpt.value) : {};
+
+    // return { ...legacyParams, ...newStyleParams };
   }
 
   private createTileWMSLayer(

--- a/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
+++ b/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
@@ -352,6 +352,31 @@ export class GIFWLayerGroup implements LayerGroup {
     return ol_layer;
   }
 
+  /**
+   * Resolves WMS params from a layer's source options, supporting both the legacy
+   * single-JSON-blob format (Name="params") and the new individual key format
+   * (Name="params.KEY", e.g. "params.LAYERS"). When both are present, new-style
+   * keys take precedence over the legacy blob.
+   */
+  private resolveWmsParams(options: import("../Interfaces/Layer").LayerSourceOption[]): Record<string, string> {
+    // Build object from new-style params.KEY entries
+    const newStyleParams: Record<string, string> = {};
+    for (const opt of options) {
+      if (opt.name.toLowerCase().startsWith("params.")) {
+        const key = opt.name.substring("params.".length);
+        if (key) {
+          newStyleParams[key] = opt.value;
+        }
+      }
+    }
+
+    // Also read legacy params JSON blob (if present), letting new-style keys win
+    const legacyOpt = options.find((o) => o.name.toLowerCase() === "params");
+    const legacyParams: Record<string, string> = legacyOpt ? JSON.parse(legacyOpt.value) : {};
+
+    return { ...legacyParams, ...newStyleParams };
+  }
+
   private createTileWMSLayer(
     layer: Layer,
     visible: boolean,
@@ -368,13 +393,7 @@ export class GIFWLayerGroup implements LayerGroup {
       url: url,
       attributions:
         layer.layerSource.attribution.renderedAttributionHTML,
-      params: layer.layerSource.layerSourceOptions
-        .filter((o) => {
-          return o.name.toLowerCase() == "params";
-        })
-        .map((o) => {
-          return JSON.parse(o.value);
-        })[0],
+      params: this.resolveWmsParams(layer.layerSource.layerSourceOptions),
       crossOrigin: "anonymous",
       projection: projection,
     };
@@ -424,13 +443,7 @@ export class GIFWLayerGroup implements LayerGroup {
     const imageWMSOpts: ImageWMSOptions = {
       url: url,
       attributions: layer.layerSource.attribution.renderedAttributionHTML,
-      params: layer.layerSource.layerSourceOptions
-        .filter((o) => {
-          return o.name == "params";
-        })
-        .map((o) => {
-          return JSON.parse(o.value);
-        })[0],
+      params: this.resolveWmsParams(layer.layerSource.layerSourceOptions),
       projection: projection,
     };
     if (layer.proxyMapRequests || hasCustomHeaders || this.gifwMapInstance.authManager) {

--- a/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
+++ b/GIFrameworkMaps.Web/Scripts/LayerGroup/GIFWLayerGroup.ts
@@ -384,27 +384,6 @@ export class GIFWLayerGroup implements LayerGroup {
     }
 
     return merged;
-
-
-
-
-
-    // // Build object from new-style params.KEY entries
-    // const newStyleParams: Record<string, string> = {};
-    // for (const opt of options) {
-    //   if (opt.name.toLowerCase().startsWith("params.")) {
-    //     const key = opt.name.substring("params.".length);
-    //     if (key) {
-    //       newStyleParams[key] = opt.value;
-    //     }
-    //   }
-    // }
-
-    // // Also read legacy params JSON blob (if present), letting new-style keys win
-    // const legacyOpt = options.find((o) => o.name.toLowerCase() === "params");
-    // const legacyParams: Record<string, string> = legacyOpt ? JSON.parse(legacyOpt.value) : {};
-
-    // return { ...legacyParams, ...newStyleParams };
   }
 
   private createTileWMSLayer(

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
@@ -80,8 +80,16 @@
                 .FirstOrDefault(o => string.Equals(o.Name, "params", StringComparison.OrdinalIgnoreCase));
             if (legacyParamsOpt != null)
             {
-                var values = JsonSerializer.Deserialize<Dictionary<string, string>>(legacyParamsOpt.Value);
-                name = values?.FirstOrDefault(v => v.Key.ToLower() == "layers").Value ?? "";
+                Dictionary<string, string> values = null;
+                try
+                {
+                    values = JsonSerializer.Deserialize<Dictionary<string, string>>(legacyParamsOpt.Value, new System.Text.Json.JsonSerializerOptions { AllowTrailingCommas = true });
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    // Ignore invalid legacy JSON
+                }
+                name = values?.FirstOrDefault(v => string.Equals(v.Key, "layers", StringComparison.OrdinalIgnoreCase)).Value ?? "";
             }
         }
         baseUrl = Model.Layer.LayerSource.LayerSourceOptions.Where(o => o.Name == "url").FirstOrDefault().Value;

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
@@ -66,9 +66,24 @@
     var baseUrl = "";
     var type = "WMS";
     if(Model.Layer.LayerSource.LayerSourceType.Name.Contains("WMS")){
-        var paramsOpt = Model.Layer.LayerSource.LayerSourceOptions.Where(o => o.Name == "params").FirstOrDefault().Value;
-        var values = JsonSerializer.Deserialize<Dictionary<string, string>>(paramsOpt);
-        name = values.Where(v => v.Key.ToLower() == "layers").FirstOrDefault().Value;
+        // New-style: look for a params.LAYERS option first
+        var paramsLayersOpt = Model.Layer.LayerSource.LayerSourceOptions
+            .FirstOrDefault(o => string.Equals(o.Name, "params.LAYERS", StringComparison.OrdinalIgnoreCase));
+        if (paramsLayersOpt != null)
+        {
+            name = paramsLayersOpt.Value;
+        }
+        else
+        {
+            // Legacy fallback: deserialize the single JSON blob params option
+            var legacyParamsOpt = Model.Layer.LayerSource.LayerSourceOptions
+                .FirstOrDefault(o => string.Equals(o.Name, "params", StringComparison.OrdinalIgnoreCase));
+            if (legacyParamsOpt != null)
+            {
+                var values = JsonSerializer.Deserialize<Dictionary<string, string>>(legacyParamsOpt.Value);
+                name = values?.FirstOrDefault(v => v.Key.ToLower() == "layers").Value ?? "";
+            }
+        }
         baseUrl = Model.Layer.LayerSource.LayerSourceOptions.Where(o => o.Name == "url").FirstOrDefault().Value;
     }
     else

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
@@ -96,9 +96,35 @@
     var type = "WMS";
     if (Model.Layer.LayerSource.LayerSourceType.Name.Contains("WMS"))
     {
-        var paramsOpt = Model.Layer.LayerSource.LayerSourceOptions.Where(o => o.Name == "params").FirstOrDefault().Value;
-        var values = JsonSerializer.Deserialize<Dictionary<string, string>>(paramsOpt);
-        name = values.Where(v => v.Key.ToLower() == "layers").FirstOrDefault().Value;
+        // New-style: look for a params.LAYERS option first
+        var paramsLayersOpt = Model.Layer.LayerSource.LayerSourceOptions
+            .FirstOrDefault(o => string.Equals(o.Name, "params.LAYERS", StringComparison.OrdinalIgnoreCase));
+        if (paramsLayersOpt != null)
+        {
+            name = paramsLayersOpt.Value;
+        }
+        else
+        {
+            // Legacy fallback: deserialize the single JSON blob params option
+            var legacyParamsOpt = Model.Layer.LayerSource.LayerSourceOptions
+                .FirstOrDefault(o => string.Equals(o.Name, "params", StringComparison.OrdinalIgnoreCase));
+            if (legacyParamsOpt != null)
+            {
+                if (legacyParamsOpt != null)
+                {
+                    Dictionary<string, string> values = null;
+                    try
+                    {
+                        values = JsonSerializer.Deserialize<Dictionary<string, string>>(legacyParamsOpt.Value, new System.Text.Json.JsonSerializerOptions { AllowTrailingCommas = true });
+                    }
+                    catch (System.Text.Json.JsonException)
+                    {
+                        // Ignore invalid legacy JSON
+                    }
+                    name = values?.FirstOrDefault(v => string.Equals(v.Key, "layers", StringComparison.OrdinalIgnoreCase)).Value ?? "";
+                }
+            }
+        }
         baseUrl = Model.Layer.LayerSource.LayerSourceOptions.Where(o => o.Name == "url").FirstOrDefault().Value;
     }
     else

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/CreateOption.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/CreateOption.cshtml
@@ -22,6 +22,11 @@
                 <label asp-for="LayerSourceOption.Name" class="control-label"></label>
                 <input asp-for="LayerSourceOption.Name" class="form-control" />
                 <span asp-validation-for="LayerSourceOption.Name" class="text-danger"></span>
+                <div class="form-text">
+                    To add a WMS parameter, use the <code>params.<em>KEY</em></code> naming convention.
+                    For example: <code>params.LAYERS</code>, <code>params.FORMAT</code>, <code>params.VERSION</code>, <code>params.CRS</code>.
+                    Each parameter is stored as a separate option with its value as plain text.
+                </div>
             </div>
 
             <div class="mb-3">

--- a/GIFrameworkMaps.Web/Views/ManagementLayerSource/EditOption.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerSource/EditOption.cshtml
@@ -22,6 +22,12 @@
                 <label asp-for="LayerSourceOption.Name" class="control-label"></label>
                 <input asp-for="LayerSourceOption.Name" class="form-control" />
                 <span asp-validation-for="LayerSourceOption.Name" class="text-danger"></span>
+                <div class="form-text">
+                    To add a WMS parameter, use the <code>params.<em>KEY</em></code> naming convention.
+                    For example: <code>params.LAYERS</code>, <code>params.FORMAT</code>, <code>params.VERSION</code>, <code>params.CRS</code>.
+                    Each parameter is stored as a separate option with its value as plain text.
+                    The legacy single <code>params</code> option (containing raw JSON) is still supported for existing layers.
+                </div>
             </div>
 
             <div class="mb-3">


### PR DESCRIPTION
This PR improves how WMS parameters are handled by default, by allowing them to be stored in the database with the notation `params.LAYERS`. This is then handled in the layer creation by merging all the `params` keys together. Old style JSON based single option is still allowed, and will be merged and fallen back to if individual keys do not exist. This allows us to start migrating to the new style without breaking existing layers.

This should make the creation and editing of these parameters much easier and less brittle, as the existing JSON needed to be valid, and if it wasn't, would break the layer creation.

Closes #333 (UI updates mentioned aren't really needed with this method, and the additional job of being able to selectively include/exclude certain parameters will be moved to a separate issue)