### PR TITLE
Update GH actions to create deployable assets in releases

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,6 +5,14 @@ inputs:
   environment:
     description: 'The environment to build for (dev or prod).'
     required: true
+  release_tag:
+    description: 'The release tag name (e.g. v1.2.3). When provided, a zip asset is created and uploaded to the GitHub Release.'
+    required: false
+    default: ''
+  github_token:
+    description: 'GitHub token used to upload assets to the release. Pass secrets.GITHUB_TOKEN from the caller workflow.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -22,6 +30,14 @@ runs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
+
+    - name: Stamp version from release tag
+      if: ${{ inputs.release_tag != '' && startsWith(inputs.release_tag, 'v') }}
+      run: |
+        VERSION="${{ inputs.release_tag }}"
+        echo "Stamping version: $VERSION"
+        jq --arg v "$VERSION" '.GIFrameworkMaps.Version = $v' GIFrameworkMaps.Web/appsettings.json > tmp.json && mv tmp.json GIFrameworkMaps.Web/appsettings.json
+      shell: bash
 
     - name: Restore dependencies
       run: dotnet restore
@@ -48,6 +64,25 @@ runs:
     - name: Publish
       run: dotnet publish -o '../release'
       working-directory: 'GIFrameworkMaps.Web'
+      shell: bash
+
+    - name: Zip publish output
+      if: ${{ inputs.release_tag != '' && startsWith(inputs.release_tag, 'v') }}
+      run: |
+        cd release
+        zip -r "../giframework-maps-web-${{ inputs.release_tag }}.zip" .
+        cd ..
+      shell: bash
+
+    - name: Upload assets to the GitHub Release
+      if: ${{ inputs.release_tag != '' && startsWith(inputs.release_tag, 'v') }}
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        TAG: ${{ inputs.release_tag }}
+      run: |
+        gh release upload "$TAG" \
+          "giframework-maps-web-$TAG.zip" \
+          --clobber
       shell: bash
 
     - name: Upload Build Artifact

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -3,12 +3,24 @@ name: Development (.NET)
 on:
   pull_request:
     branches: [ "main" ]
+  release:
+    types: [prereleased]
+
+# Required so we can upload assets to the existing Release using GITHUB_TOKEN
+permissions:
+  contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        # On release events, build the exact tag that was released.
+        # On pull_request, this is ignored and checkout uses the PR ref as normal.
+        ref: ${{ github.event.release.tag_name }}
     - uses: ./.github/actions/build
       with:
         environment: 'dev'
+        release_tag: ${{ github.event.release.tag_name }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -1,14 +1,27 @@
 name: Production (.NET)
+
 on:
   push:
     branches: [ "main" ]
+  release:
+    types: [released]
+
+# Required so we can upload assets to the existing Release using GITHUB_TOKEN
+permissions:
+  contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        # On release events, build the exact tag that was released.
+        # On push, this is ignored and checkout uses the push ref as normal.
+        ref: ${{ github.event.release.tag_name }}
     - uses: ./.github/actions/build
       with:
         environment: 'prod'
+        release_tag: ${{ github.event.release.tag_name }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     


### PR DESCRIPTION
This PR aims to align the CI/CD process with our other repos. 

The new methodology makes more use of GitHub releases, creating a deployable zip package on release or pre-release creation, which can then be picked up by external release processes, or downloaded manually. It stamps the version number into the app settings. Pre-releases use the dev build (the only difference being it uses the development environment for the bun build), and release using the prod build.

Closes #435 