### PR TITLE
Allow layer and category lists to be filtered

### DIFF
--- a/GIFrameworkMaps.Web/Options/GIFrameworkMapsOptions.cs
+++ b/GIFrameworkMaps.Web/Options/GIFrameworkMapsOptions.cs
@@ -15,5 +15,6 @@
 		public bool SuppressXFrameOptions { get; set; }
 		public string AppAccessRequestLink { get; set; }
 		public NetworkingOptions Networking { get; set; }
+		public string Version { get; set; }
 	}
 }

--- a/GIFrameworkMaps.Web/Scripts/Management/CheckboxListFilter.ts
+++ b/GIFrameworkMaps.Web/Scripts/Management/CheckboxListFilter.ts
@@ -1,0 +1,258 @@
+import Fuse from "fuse.js";
+
+interface CheckboxItem {
+  label: string;
+  formCheck: HTMLElement;
+}
+
+export class CheckboxListFilter {
+  private readonly _container: HTMLElement;
+  private readonly _searchInput: HTMLInputElement;
+  private readonly _toggleButton: HTMLButtonElement;
+  private readonly _allFormChecks: HTMLElement[];
+  private _fuseInstance: Fuse<CheckboxItem>;
+  private _showCheckedOnly = false;
+
+  constructor(container: HTMLElement) {
+    this._container = container;
+    this._searchInput = container.querySelector(
+      "[data-checkbox-filter-search]",
+    ) as HTMLInputElement;
+    this._toggleButton = container.querySelector(
+      "[data-checkbox-filter-toggle]",
+    ) as HTMLButtonElement;
+
+    // Collect every .form-check div that contains a checkbox within this container.
+    // We intentionally keep a flat reference list even for the nested VersionCategoryList
+    // structure so we can show/hide individual items without ever touching the DOM.
+    this._allFormChecks = Array.from(
+      container.querySelectorAll<HTMLElement>("div.form-check"),
+    );
+
+    this._fuseInstance = this._buildFuseInstance();
+    this._attachListeners();
+    this._attachFormSubmitGuard();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Initialisation helpers
+  // ---------------------------------------------------------------------------
+
+  private _buildFuseInstance(): Fuse<CheckboxItem> {
+    const items: CheckboxItem[] = this._allFormChecks.map((fc) => ({
+      label: (fc.querySelector("label")?.textContent ?? "").trim(),
+      formCheck: fc,
+    }));
+
+    return new Fuse(items, {
+      includeScore: true,
+      threshold: 0.3,
+      keys: ["label"],
+      ignoreLocation: true,
+    });
+  }
+
+  private _attachListeners(): void {
+    if (this._searchInput) {
+      this._searchInput.addEventListener("input", () => this._onSearchInput());
+    }
+    if (this._toggleButton) {
+      this._toggleButton.addEventListener("click", () =>
+        this._onToggleChecked(),
+      );
+    }
+  }
+
+  /**
+   * Attaches a submit listener to the nearest ancestor <form> that resets the
+   * display of every .form-check element before the browser serialises the form
+   * data.  This ensures that checked-but-filtered-out checkboxes always submit
+   * their values — the belt-and-braces guarantee described in the plan.
+   *
+   * NOTE: We intentionally do NOT set `disabled` anywhere in this class; CSS
+   * visibility (display:none) has no effect on form submission.  This guard is
+   * a safety net for any future code that might inadvertently alter that.
+   */
+  private _attachFormSubmitGuard(): void {
+    const form = this._container.closest("form");
+    if (!form) return;
+
+    form.addEventListener(
+      "submit",
+      () => {
+        // Reset display on every .form-check wrapper so every checked checkbox
+        // is reachable by the browser's form serialiser, regardless of filter state.
+        this._allFormChecks.forEach((fc) => {
+          fc.style.display = "";
+        });
+        // Also show any .ms-4 wrappers (nested category containers) that may be hidden.
+        this._container
+          .querySelectorAll<HTMLElement>(".ms-4")
+          .forEach((wrapper) => {
+            wrapper.style.display = "";
+          });
+      },
+      // Use capture so this fires before any other submit handler.
+      { capture: true },
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event handlers
+  // ---------------------------------------------------------------------------
+
+  private _onSearchInput(): void {
+    const query = this._searchInput.value.trim();
+
+    // If "show checked only" is active, clear it first so the two modes don't conflict.
+    if (this._showCheckedOnly) {
+      this._showCheckedOnly = false;
+      this._setToggleActiveState(false);
+    }
+
+    if (query === "") {
+      this._showAll();
+      return;
+    }
+
+    const results = this._fuseInstance.search(query);
+    const matchedFormChecks = new Set<HTMLElement>(
+      results.map((r) => r.item.formCheck),
+    );
+
+    this._allFormChecks.forEach((fc) => {
+      const visible = matchedFormChecks.has(fc);
+      fc.style.display = visible ? "" : "none";
+    });
+
+    // For the recursive VersionCategoryList: if a child matches, its parent
+    // .form-check and the .ms-4 wrapper that contains it must also stay visible.
+    this._ensureParentsVisible(matchedFormChecks);
+
+    // Hide any .ms-4 wrappers whose every child .form-check is hidden.
+    this._syncNestedWrappers();
+  }
+
+  private _onToggleChecked(): void {
+    // Clear text search when activating "show checked only".
+    if (!this._showCheckedOnly && this._searchInput) {
+      this._searchInput.value = "";
+    }
+
+    this._showCheckedOnly = !this._showCheckedOnly;
+    this._setToggleActiveState(this._showCheckedOnly);
+
+    if (!this._showCheckedOnly) {
+      this._showAll();
+      return;
+    }
+
+    // Disable the search input to prevent conflicting filter states.
+    if (this._searchInput) {
+      this._searchInput.disabled = true;
+    }
+
+    this._allFormChecks.forEach((fc) => {
+      const checkbox = fc.querySelector<HTMLInputElement>(
+        "input[type=checkbox]",
+      );
+      fc.style.display = checkbox?.checked ? "" : "none";
+    });
+
+    const checkedFormChecks = new Set<HTMLElement>(
+      this._allFormChecks.filter((fc) => {
+        const cb = fc.querySelector<HTMLInputElement>("input[type=checkbox]");
+        return cb?.checked === true;
+      }),
+    );
+
+    this._ensureParentsVisible(checkedFormChecks);
+    this._syncNestedWrappers();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Visibility helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Shows every .form-check and .ms-4 wrapper in the container and re-enables
+   * the search input.
+   */
+  private _showAll(): void {
+    this._allFormChecks.forEach((fc) => {
+      fc.style.display = "";
+    });
+    this._container
+      .querySelectorAll<HTMLElement>(".ms-4")
+      .forEach((wrapper) => {
+        wrapper.style.display = "";
+      });
+    if (this._searchInput) {
+      this._searchInput.disabled = false;
+    }
+  }
+
+  /**
+   * For a given set of visible (matched) .form-check elements, walk up the DOM
+   * to ensure every ancestor .form-check and .ms-4 wrapper within the container
+   * is also made visible.  This handles the nested VersionCategoryList tree.
+   */
+  private _ensureParentsVisible(visibleFormChecks: Set<HTMLElement>): void {
+    visibleFormChecks.forEach((fc) => {
+      let node: HTMLElement | null = fc.parentElement;
+      while (node && node !== this._container) {
+        if (
+          node.classList.contains("ms-4") ||
+          node.classList.contains("form-check")
+        ) {
+          node.style.display = "";
+          // Also ensure the sibling .form-check directly above the .ms-4 is visible.
+          if (node.classList.contains("ms-4")) {
+            const preceding = node.previousElementSibling as HTMLElement | null;
+            if (preceding?.classList.contains("form-check")) {
+              preceding.style.display = "";
+            }
+          }
+        }
+        node = node.parentElement;
+      }
+    });
+  }
+
+  /**
+   * Hides any .ms-4 wrapper whose every descendant .form-check is hidden.
+   * This keeps the tree tidy when no children match.
+   */
+  private _syncNestedWrappers(): void {
+    this._container
+      .querySelectorAll<HTMLElement>(".ms-4")
+      .forEach((wrapper) => {
+        const children = Array.from(
+          wrapper.querySelectorAll<HTMLElement>("div.form-check"),
+        );
+        const allHidden =
+          children.length > 0 &&
+          children.every((c) => c.style.display === "none");
+        wrapper.style.display = allHidden ? "none" : "";
+      });
+  }
+
+  // ---------------------------------------------------------------------------
+  // UI state
+  // ---------------------------------------------------------------------------
+
+  private _setToggleActiveState(active: boolean): void {
+    if (!this._toggleButton) return;
+    if (active) {
+      this._toggleButton.classList.add("active");
+      this._toggleButton.setAttribute("aria-pressed", "true");
+    } else {
+      this._toggleButton.classList.remove("active");
+      this._toggleButton.setAttribute("aria-pressed", "false");
+      // Re-enable the search input when toggle is turned off.
+      if (this._searchInput) {
+        this._searchInput.disabled = false;
+      }
+    }
+  }
+}

--- a/GIFrameworkMaps.Web/Scripts/Management/CheckboxListFilter.ts
+++ b/GIFrameworkMaps.Web/Scripts/Management/CheckboxListFilter.ts
@@ -67,12 +67,12 @@ export class CheckboxListFilter {
    * Attaches a submit listener to the nearest ancestor <form> that resets the
    * display of every .form-check element before the browser serialises the form
    * data.  This ensures that checked-but-filtered-out checkboxes always submit
-   * their values — the belt-and-braces guarantee described in the plan.
+   * their values
    *
-   * NOTE: We intentionally do NOT set `disabled` anywhere in this class; CSS
-   * visibility (display:none) has no effect on form submission.  This guard is
-   * a safety net for any future code that might inadvertently alter that.
-   */
+   * NOTE: We intentionally do NOT set `disabled` on any checkbox inputs in this class;
+   * CSS visibility (display:none) has no effect on form submission. This guard is
+   * a safety net for any future code that might inadvertently disable checkboxes.
+  */
   private _attachFormSubmitGuard(): void {
     const form = this._container.closest("form");
     if (!form) return;

--- a/GIFrameworkMaps.Web/Scripts/Management/CheckboxListFilter.ts
+++ b/GIFrameworkMaps.Web/Scripts/Management/CheckboxListFilter.ts
@@ -129,6 +129,9 @@ export class CheckboxListFilter {
     // .form-check and the .ms-4 wrapper that contains it must also stay visible.
     this._ensureParentsVisible(matchedFormChecks);
 
+    // If a parent matches the filter, keep its children visible too.
+    this._expandMatchedParents(matchedFormChecks);
+
     // Hide any .ms-4 wrappers whose every child .form-check is hidden.
     this._syncNestedWrappers();
   }
@@ -215,6 +218,24 @@ export class CheckboxListFilter {
           }
         }
         node = node.parentElement;
+      }
+    });
+  }
+
+  /**
+   * For every matched .form-check that has a .ms-4 sibling (i.e. it is a
+   * parent category), shows all descendant .form-check elements within that
+   * sibling.  This means a parent matching the search query keeps its children
+   * visible rather than hiding them.
+   */
+  private _expandMatchedParents(matchedFormChecks: Set<HTMLElement>): void {
+    matchedFormChecks.forEach((fc) => {
+      const next = fc.nextElementSibling as HTMLElement | null;
+      if (next?.classList.contains("ms-4")) {
+        next.querySelectorAll<HTMLElement>("div.form-check").forEach((child) => {
+          child.style.display = "";
+          matchedFormChecks.add(child);
+        });
       }
     });
   }

--- a/GIFrameworkMaps.Web/Scripts/Management/management.ts
+++ b/GIFrameworkMaps.Web/Scripts/Management/management.ts
@@ -3,6 +3,7 @@ import { SelectWebService } from "./SelectWebService";
 import { Broadcast } from "./Broadcast";
 import { CreateLayerFromSource } from "./CreateLayerFromSource";
 import { CreateSource } from "./CreateSource";
+import { CheckboxListFilter } from "./CheckboxListFilter";
 import accessibleAutocomplete from "accessible-autocomplete";
 import { Tooltip } from "bootstrap";
 
@@ -48,6 +49,10 @@ addEventListener("DOMContentLoaded", () => {
       accessibleAutocomplete.enhanceSelectElement({ selectElement: ele });
     });
   }
+  //attach checkbox list filters
+  document.querySelectorAll<HTMLElement>("[data-checkbox-filter]").forEach((el) => {
+    new CheckboxListFilter(el);
+  });
   //attach other general things that should appear everywhere
   const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
   [...tooltipTriggerList].map(tooltipTriggerEl => new Tooltip(tooltipTriggerEl));

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/CreateFromSource.cshtml
@@ -41,7 +41,7 @@
 
             <div class="tab-content">
                 <div class="tab-pane fade show active" id="categories-tab-pane" role="tabpanel" aria-labelledby="categories-tab" tabindex="0">
-                    <partial name="ManagementPartials/VersionCategoryList" model="Model.AvailableCategories.Where(c => c.ParentCategoryId == null).ToList()" view-data="ViewData" />
+                    <partial name="ManagementPartials/VersionCategoryList" model="Model.AvailableCategories.Where(c => c.ParentCategoryId == null).ToList()" view-data='@(new ViewDataDictionary(ViewData) { { "IsRootCategoryList", true } })' />
                 </div>
                 <div class="tab-pane fade" id="details-tab-pane" role="tabpanel" aria-labelledby="details-tab" tabindex="0">
                     <table class="table table-sm table-striped">

--- a/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayer/Edit.cshtml
@@ -45,7 +45,7 @@
 
             <div class="tab-content">
                 <div class="tab-pane fade show active" id="categories-tab-pane" role="tabpanel" aria-labelledby="categories-tab" tabindex="0">
-                    <partial name="ManagementPartials/VersionCategoryList" model="Model.AvailableCategories.Where(c => c.ParentCategoryId == null).ToList()" view-data="ViewData" />
+                    <partial name="ManagementPartials/VersionCategoryList" model="Model.AvailableCategories.Where(c => c.ParentCategoryId == null).ToList()" view-data='@(new ViewDataDictionary(ViewData) { { "IsRootCategoryList", true } })' />
                 </div>
                 <div class="tab-pane fade" id="versions-tab-pane" role="tabpanel" aria-labelledby="versions-tab" tabindex="0">
                     @if(Model.VersionsLayerAppearsIn is null || Model.VersionsLayerAppearsIn.Count == 0)

--- a/GIFrameworkMaps.Web/Views/ManagementVersion/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementVersion/Create.cshtml
@@ -168,7 +168,7 @@
                     Categories
                 </div>
                 <div class="card-body">
-                    <partial name="ManagementPartials/VersionCategoryList" model="Model.AvailableCategories.Where(c => c.ParentCategoryId == null).ToList()" view-data="ViewData" />
+                    <partial name="ManagementPartials/VersionCategoryList" model="Model.AvailableCategories.Where(c => c.ParentCategoryId == null).ToList()" view-data='@(new ViewDataDictionary(ViewData) { { "IsRootCategoryList", true } })' />
                 </div>
             </div>
         </div>

--- a/GIFrameworkMaps.Web/Views/ManagementVersion/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementVersion/Edit.cshtml
@@ -177,7 +177,7 @@
                     Categories
                 </div>
                 <div class="card-body">
-                    <partial name="ManagementPartials/VersionCategoryList" model="Model.AvailableCategories.Where(c => c.ParentCategoryId == null).ToList()" view-data="ViewData" />
+                    <partial name="ManagementPartials/VersionCategoryList" model="Model.AvailableCategories.Where(c => c.ParentCategoryId == null).ToList()" view-data='@(new ViewDataDictionary(ViewData) { { "IsRootCategoryList", true } })' />
                 </div>
             </div>
         </div>

--- a/GIFrameworkMaps.Web/Views/Map/Index.cshtml
+++ b/GIFrameworkMaps.Web/Views/Map/Index.cshtml
@@ -19,6 +19,7 @@
     ViewData["PrivacyLink"] = options.PrivacyLink;
     ViewData["AdminDocsLink"] = options.AdminDocsLink;
     ViewData["ShowLogin"] = Model.ShowLogin;
+    ViewData["AppVersion"] = options.Version;
     Layout = "_MapLayout";
     AnalyticsViewModel analyticsModel = (ViewData["AnalyticsModel"] != null ? (AnalyticsViewModel)ViewData["AnalyticsModel"] : new AnalyticsViewModel());
     analyticsModel.VersionID = int.Parse(ViewData["VersionID"].ToString());

--- a/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/CategoryLayerList.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/CategoryLayerList.cshtml
@@ -6,11 +6,19 @@
     var editUrl = Url.Action("Edit", "ManagementLayer");
 }
 
-@foreach (var layer in Model.AvailableLayers)
-{
-    string id = "SelectedLayers__" + layer.Value;
-    <div class="form-check">
-        <input type="checkbox" class="form-check-input" name="SelectedLayers" value="@layer.Value" id="@id" @(layer.Selected ? "checked=checked" : "")  />
-        <label class="form-check-label" for="@id">@layer.Text <small>(ID: <a href="@editUrl/@layer.Value">@layer.Value</a>)</small></label>
+<div data-checkbox-filter>
+    <div class="mb-2">
+        <button type="button" class="btn btn-sm btn-outline-primary text-nowrap" data-checkbox-filter-toggle aria-pressed="false"><span class="bi bi-check2-square"></span> Show checked only</button>
     </div>
-}
+    <div class="mb-2">
+        <input type="text" class="form-control form-control-sm" data-checkbox-filter-search placeholder="Filter layers..." aria-label="Filter layers" />
+    </div>
+    @foreach (var layer in Model.AvailableLayers)
+    {
+        string id = "SelectedLayers__" + layer.Value;
+        <div class="form-check">
+            <input type="checkbox" class="form-check-input" name="SelectedLayers" value="@layer.Value" id="@id" @(layer.Selected ? "checked=checked" : "")  />
+            <label class="form-check-label" for="@id">@layer.Text <small>(ID: <a href="@editUrl/@layer.Value">@layer.Value</a>)</small></label>
+        </div>
+    }
+</div>

--- a/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/VersionCategoryList.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/VersionCategoryList.cshtml
@@ -24,7 +24,7 @@ else
 {
     @foreach (var category in Model)
     {
-        bool IsCategoryChecked = selectedCategories != null && selectedCategories.Where(b => b == category.Id).Count() != 0;
+        bool IsCategoryChecked = selectedCategories?.Contains(category.Id) == true;
 
         <div class="form-check">
             <input type="checkbox"
@@ -37,7 +37,7 @@ else
         </div>
 
         var children = allCategories.Where(c => c.ParentCategoryId == category.Id).ToList();
-        if (children.Count() != 0)
+        if (children.Count != 0)
         {
             <div class="ms-4">
                 <partial name="ManagementPartials/VersionCategoryList" model="children" />

--- a/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/VersionCategoryList.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/VersionCategoryList.cshtml
@@ -3,30 +3,45 @@
 @{
     var allCategories = ViewData["AllCategories"] as List<GIFrameworkMaps.Data.Models.Category>;
     var selectedCategories = ViewData["SelectedCategories"] as List<int>;
+    var isRoot = ViewData["IsRootCategoryList"] is true;
 }
-@foreach (var category in Model)
+
+@if (isRoot)
 {
-
-    bool IsCategoryChecked = selectedCategories != null && selectedCategories.Where(b => b == category.Id).Count() != 0;
-
-    <div class="form-check">
-        <input type="checkbox"
-            class="form-check-input"
-            name="SelectedCategories"
-           value="@category.Id"
-           id="SelectedCategories__@category.Id"
-           @(Html.Raw(IsCategoryChecked ? "checked=\"checked\"" : "")) />
-        <label class="form-check-label" for="SelectedCategories__@category.Id">@category.Name</label>
-    </div>
-
-    var children = allCategories.Where(c => c.ParentCategoryId == category.Id).ToList();
-    if (children.Count() != 0)
-    {
-        <div class="ms-4">
-            <partial name="ManagementPartials/VersionCategoryList" model="children" />
+    var innerViewData = new ViewDataDictionary(ViewData);
+    innerViewData["IsRootCategoryList"] = false;
+    <div data-checkbox-filter>
+        <div class="mb-2">
+            <button type="button" class="btn btn-sm btn-outline-primary text-nowrap" data-checkbox-filter-toggle aria-pressed="false"><span class="bi bi-check2-square"></span> Show checked only</button>
         </div>
+        <div class="mb-2">
+            <input type="text" class="form-control form-control-sm" data-checkbox-filter-search placeholder="Filter categories..." aria-label="Filter categories" />
+        </div>
+        @await Html.PartialAsync("ManagementPartials/VersionCategoryList", Model, innerViewData)
+    </div>
+}
+else
+{
+    @foreach (var category in Model)
+    {
+        bool IsCategoryChecked = selectedCategories != null && selectedCategories.Where(b => b == category.Id).Count() != 0;
+
+        <div class="form-check">
+            <input type="checkbox"
+                class="form-check-input"
+                name="SelectedCategories"
+               value="@category.Id"
+               id="SelectedCategories__@category.Id"
+               @(Html.Raw(IsCategoryChecked ? "checked=\"checked\"" : "")) />
+            <label class="form-check-label" for="SelectedCategories__@category.Id">@category.Name</label>
+        </div>
+
+        var children = allCategories.Where(c => c.ParentCategoryId == category.Id).ToList();
+        if (children.Count() != 0)
+        {
+            <div class="ms-4">
+                <partial name="ManagementPartials/VersionCategoryList" model="children" />
+            </div>
+        }
     }
-
-
-
 }

--- a/GIFrameworkMaps.Web/Views/Shared/_HelpMenuPartial.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/_HelpMenuPartial.cshtml
@@ -5,6 +5,7 @@
     var hasHelpLink = false;
     var hasFeedbackLink = false;
     var hasCookieControlLink = false;
+    var hasAppVersionString = false;
     @if (!String.IsNullOrEmpty(Convert.ToString(ViewData["PrivacyLink"])) && Uri.IsWellFormedUriString(Convert.ToString(ViewData["PrivacyLink"]), UriKind.Absolute))
     {
         num_links++;
@@ -29,6 +30,10 @@
     {
         num_links++;
         hasCookieControlLink = true;
+    }
+    @if (!String.IsNullOrEmpty(Convert.ToString(ViewData["AppVersion"])))
+    {
+        hasAppVersionString = true;
     }
 }
 
@@ -69,7 +74,15 @@
                     <a class="dropdown-item" id="CookieControlLink" rel="noopener" href="#">Cookie preferences</a>
                 </li>
             }
+            @if (hasAppVersionString)
+            {
+                <li><hr class="dropdown-divider"></li>
+                <li>
+                    <p class="mb-0 small"><a href="https://github.com/Dorset-Council-UK/GIFramework-Maps#giframework-maps" target="_blank" rel="noopener" class="dropdown-item text-muted"><span class="bi bi-github"></span> @ViewData["AppVersion"]</a></p>
+                </li>
+            }
         </ul>
+
     </li>
 }
 else

--- a/GIFrameworkMaps.Web/Views/Shared/_Layout.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/_Layout.cshtml
@@ -7,6 +7,7 @@
     string tosLink = options.ToSLink;
     string privacyLink = options.PrivacyLink;
     string adminDocsLink = options.AdminDocsLink;
+    string appVersion = options.Version;
     AnalyticsViewModel analyticsModel = (ViewData["AnalyticsModel"] != null? (AnalyticsViewModel)ViewData["AnalyticsModel"] :new AnalyticsViewModel());
     analyticsModel.VersionID = -1;
 }
@@ -49,7 +50,7 @@
                             <li class="nav-item">
                                 <a class="nav-link" asp-controller="Management" asp-action="Index">Manage application</a>
                             </li>
-                            @if (!String.IsNullOrEmpty(adminDocsLink) && Uri.IsWellFormedUriString(adminDocsLink, UriKind.Absolute))
+                            @if (!string.IsNullOrEmpty(adminDocsLink) && Uri.IsWellFormedUriString(adminDocsLink, UriKind.Absolute))
                             {
                                 <li class="nav-item">
                                     <a class="nav-link" target="_blank" rel="noopener" href="@adminDocsLink">Admin Help</a>
@@ -68,7 +69,7 @@
     <div class="container flex-grow">
         <main role="main" class="pb-3">
             @{
-                if (!String.IsNullOrEmpty((string)TempData["Message"]))
+                if (!string.IsNullOrEmpty((string)TempData["Message"]))
                 {
                     <div class="alert alert-@((string)TempData["MessageType"] != "" ? TempData["MessageType"] : "info")">
                         @TempData["Message"]
@@ -84,11 +85,11 @@
             <div class="row">
                 <div class="col-6">
                     <ul class="list-unstyled">
-                        @if (!String.IsNullOrEmpty(tosLink) && Uri.IsWellFormedUriString(tosLink, UriKind.Absolute))
+                        @if (!string.IsNullOrEmpty(tosLink) && Uri.IsWellFormedUriString(tosLink, UriKind.Absolute))
                         {
                             <li><a href="@tosLink">Terms of use</a></li>
                         }
-                        @if (!String.IsNullOrEmpty(privacyLink) && Uri.IsWellFormedUriString(privacyLink, UriKind.Absolute))
+                        @if (!string.IsNullOrEmpty(privacyLink) && Uri.IsWellFormedUriString(privacyLink, UriKind.Absolute))
                         {
                             <li><a href="@privacyLink">Privacy</a></li>
                         }
@@ -96,6 +97,11 @@
                 </div>
                 <div class="col-sm-6">
                     <p>Built with ❤ and ☕ by the <a href="https://github.com/Dorset-Council-UK/GIFramework-Maps">Dorset Council GIS team and other contributors</a></p>
+
+                    @if(!string.IsNullOrEmpty(appVersion))
+                    {
+                        <p><a href="https://github.com/Dorset-Council-UK/GIFramework-Maps/releases"><span class="bi bi-github"></span> GIFramework Maps @appVersion</a></p>
+                    }
                 </div>
             </div>
         </div>

--- a/GIFrameworkMaps.Web/appsettings.json
+++ b/GIFrameworkMaps.Web/appsettings.json
@@ -29,6 +29,7 @@
     "Networking": {
       "UseForwardedHeadersMiddleware": false,
       "KnownProxies": []
-    }
+    },
+    "Version": "DEVELOPMENT"
   }
 }


### PR DESCRIPTION
This PR allows the potentially very long list of categories/layers that are shown on the Version, Layer and Category management screen to be filtered either using a simple Fuse based text search, or filtered to just items that are currently checked.

Additionally, the new `Version` app setting that is automatically stamped on in releases is now surfaced in the Help menu and the footer of non-map pages.

Closes #440 