### PR TITLE
Add sortability to layers in categories

### DIFF
--- a/GIFrameworkMaps.Data/ViewModels/Management/CategoryEditViewModel.cs
+++ b/GIFrameworkMaps.Data/ViewModels/Management/CategoryEditViewModel.cs
@@ -14,5 +14,11 @@ namespace GIFrameworkMaps.Data.ViewModels.Management
 		public IList<SelectListItem> AvailableLayers { get; set; } = [];
 		public IList<Version> VersionsCategoryAppearsIn { get; set; } = [];
 
+		public Dictionary<int, int> LayerSortOrders { get; set; } = [];
+
+		/// <summary>
+		/// When true, all layers in this category use SortOrder 0 and sort alphabetically by default.
+		/// </summary>
+		public bool SortAlphabetically { get; set; } = true;
 	}
 }

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerCategoryController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementLayerCategoryController.cs
@@ -43,14 +43,15 @@ namespace GIFrameworkMaps.Web.Controllers.Management
 
         [HttpPost, ActionName("Create")]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> CreatePost(CategoryEditViewModel editModel, int[] selectedLayers)
+        public async Task<IActionResult> CreatePost(CategoryEditViewModel editModel, int[] selectedLayers, string[] sortOrderData, bool sortAlphabetically)
         {
             if (ModelState.IsValid)
             {
                 try
                 {
                     _context.Add(editModel.Category);
-                    UpdateCategoryLayers(selectedLayers, editModel.Category);
+                    var sortOrders = sortAlphabetically ? [] : ParseSortOrderData(sortOrderData);
+                    UpdateCategoryLayers(selectedLayers, editModel.Category, sortOrders);
                     await _context.SaveChangesAsync();
                     TempData["Message"] = "New layer category created";
                     TempData["MessageType"] = "success";
@@ -86,43 +87,45 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             return View(editModel);
         }
 
-        [HttpPost, ActionName("Edit")]
-        [ValidateAntiForgeryToken]
-        public async Task<IActionResult> EditPost(int id, int[] selectedLayers)
-        {
-            var categoryToUpdate = await _context.Categories
+		[HttpPost, ActionName("Edit")]
+		[ValidateAntiForgeryToken]
+		public async Task<IActionResult> EditPost(int id, int[] selectedLayers, string[] sortOrderData, bool sortAlphabetically)
+		{
+			var categoryToUpdate = await _context.Categories
 				.Include(o => o.ParentCategory)
-                .FirstOrDefaultAsync(o => o.Id == id);
+				.Include(o => o.Layers)
+				.FirstOrDefaultAsync(o => o.Id == id);
 
-            var editModel = new CategoryEditViewModel() { Category = categoryToUpdate };
+			var editModel = new CategoryEditViewModel() { Category = categoryToUpdate };
 
-            if (await TryUpdateModelAsync(
-                editModel.Category,
-                "Category",
-                a => a.Name,
-                a => a.Description,
-                a => a.Order,
-                a => a.ParentCategoryId
-                ))
-            {
-                try
-                {
-                    UpdateCategoryLayers(selectedLayers, categoryToUpdate);
-                    await _context.SaveChangesAsync();
-                    TempData["Message"] = "Layer category edited";
-                    TempData["MessageType"] = "success";
-                    return RedirectToAction(nameof(Index));
-                }
-                catch (DbUpdateException ex )
-                {
-                    _logger.LogError(ex, "Layer Category edit failed");
-                    ModelState.AddModelError("", "Unable to save changes. Try again, and if the problem persists, contact your system administrator.");
-                }
-            }
-            
-            await RebuildViewModel(editModel, categoryToUpdate);
-            return View(editModel);
-        }
+			if (await TryUpdateModelAsync(
+				editModel.Category,
+				"Category",
+				a => a.Name,
+				a => a.Description,
+				a => a.Order,
+				a => a.ParentCategoryId
+				))
+			{
+				try
+				{
+					var sortOrders = sortAlphabetically ? [] : ParseSortOrderData(sortOrderData);
+					UpdateCategoryLayers(selectedLayers, categoryToUpdate, sortOrders);
+					await _context.SaveChangesAsync();
+					TempData["Message"] = "Layer category edited";
+					TempData["MessageType"] = "success";
+					return RedirectToAction(nameof(Index));
+				}
+				catch (DbUpdateException ex )
+				{
+					_logger.LogError(ex, "Layer Category edit failed");
+					ModelState.AddModelError("", "Unable to save changes. Try again, and if the problem persists, contact your system administrator.");
+				}
+			}
+
+			await RebuildViewModel(editModel, categoryToUpdate);
+			return View(editModel);
+		}
 
         public async Task<IActionResult> Delete(int id)
         {
@@ -157,47 +160,56 @@ namespace GIFrameworkMaps.Web.Controllers.Management
             return View(categoryToDelete);
         }
 
-        private void UpdateCategoryLayers(int[] selectedLayers, Category categoryToUpdate)
-        {
-			if(selectedLayers.Length == 0)
+		private static Dictionary<int, int> ParseSortOrderData(string[] sortOrderData)
+		{
+			var result = new Dictionary<int, int>();
+			foreach (var entry in sortOrderData)
+			{
+				var parts = entry.Split(':');
+				if (parts.Length == 2 && int.TryParse(parts[0], out var layerId) && int.TryParse(parts[1], out var sortOrder))
+				{
+					result[layerId] = sortOrder;
+				}
+			}
+			return result;
+		}
+
+		private void UpdateCategoryLayers(int[] selectedLayers, Category categoryToUpdate, Dictionary<int, int> sortOrders)
+		{
+			var selectedLayerIds = new HashSet<int>(selectedLayers ?? []);
+			if (selectedLayerIds.Count == 0)
 			{
 				//get rid of all layers in the category early and exit
 				var categoryLayersToRemove = _context.CategoryLayers.Where(cl => cl.CategoryId == categoryToUpdate.Id);
 				_context.RemoveRange(categoryLayersToRemove);
 				return;
 			}
-			//figure out what to add and what to remove
-            var selectedCategoriesHS = new HashSet<int>(selectedLayers);
-            var versionCategories = new HashSet<int>();
-            if (categoryToUpdate.Layers.Count != 0)
-            {
-                versionCategories = new HashSet<int>(categoryToUpdate.Layers.Select(c => c.LayerId));
-            }
 
-            foreach (var layer in _context.Layers)
-            {
-                if (selectedCategoriesHS.Contains(layer.Id))
-                {
-                    if (!versionCategories.Contains(layer.Id))
-                    {                        
-                        categoryToUpdate.Layers.Add(new CategoryLayer
-                        {
-                            CategoryId = categoryToUpdate.Id,
-                            LayerId = layer.Id
-                        });
-                    }
-                }
-                else
-                {
+			var existingEntriesByLayerId = categoryToUpdate.Layers.ToDictionary(cl => cl.LayerId);
+			var layersToRemove = categoryToUpdate.Layers.Where(cl => !selectedLayerIds.Contains(cl.LayerId)).ToList();
+			foreach (var layerToRemove in layersToRemove)
+			{
+				categoryToUpdate.Layers.Remove(layerToRemove);
+				_context.Remove(layerToRemove);
+			}
 
-                    if (versionCategories.Contains(layer.Id))
-                    {
-                        CategoryLayer categoryLayerToRemove = categoryToUpdate.Layers.FirstOrDefault(i => i.LayerId == layer.Id);
-                        _context.Remove(categoryLayerToRemove);
-                    }
-                }
-            }
-        }
+			foreach (var layerId in selectedLayerIds)
+			{
+				if (existingEntriesByLayerId.TryGetValue(layerId, out var existingEntry))
+				{
+					existingEntry.SortOrder = sortOrders.GetValueOrDefault(layerId, 0);
+				}
+				else
+				{
+					categoryToUpdate.Layers.Add(new CategoryLayer
+					{
+						CategoryId = categoryToUpdate.Id,
+						LayerId = layerId,
+						SortOrder = sortOrders.GetValueOrDefault(layerId, 0)
+					});
+				}
+			}
+		}
 
 		private async Task RebuildViewModel(CategoryEditViewModel model, Category category)
 		{
@@ -230,9 +242,11 @@ namespace GIFrameworkMaps.Web.Controllers.Management
 			model.AvailableParentCategories = new SelectList(parentCategories, "Id", "Name", category.ParentCategoryId);
 			model.AvailableLayers = availableLayers;
 			model.SelectedLayers = selectedLayerIds.ToList();
+			model.LayerSortOrders = category.Layers.ToDictionary(cl => cl.LayerId, cl => cl.SortOrder);
+			model.SortAlphabetically = !category.Layers.Any(cl => cl.SortOrder != 0);
 			model.VersionsCategoryAppearsIn = await _repository.GetVersionsLayerCategoriesAppearIn([model.Category.Id]);
 
 			ViewData["SelectedLayers"] = model.SelectedLayers;
 		}
-    }
+	}
 }

--- a/GIFrameworkMaps.Web/Scripts/Management/CategoryLayerSort.ts
+++ b/GIFrameworkMaps.Web/Scripts/Management/CategoryLayerSort.ts
@@ -1,0 +1,147 @@
+import Sortable from "sortablejs";
+import DOMPurify from "dompurify";
+
+export class CategoryLayerSort {
+  private readonly _sortList: HTMLUListElement;
+  private readonly _sortAlphaCheckbox: HTMLInputElement | null;
+  private readonly _customSortContainer: HTMLElement | null;
+  private _sortable: Sortable | null = null;
+
+  constructor(sortList: HTMLUListElement) {
+    this._sortList = sortList;
+    this._sortAlphaCheckbox = document.querySelector<HTMLInputElement>(
+      "#sort-alphabetically",
+    );
+    this._customSortContainer = document.querySelector<HTMLElement>(
+      "#layer-sort-custom",
+    );
+  }
+
+  init(): void {
+    this._sortable = new Sortable(this._sortList, {
+      handle: ".drag-handle",
+      animation: 150,
+      disabled: this._isAlphabetical(),
+      onEnd: () => {
+        this._renumberSortOrders();
+      },
+    });
+
+    this._attachCheckboxListeners();
+    this._attachAlphaCheckboxListener();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Alphabetical toggle
+  // ---------------------------------------------------------------------------
+
+  private _isAlphabetical(): boolean {
+    return this._sortAlphaCheckbox?.checked ?? false;
+  }
+
+  private _attachAlphaCheckboxListener(): void {
+    this._sortAlphaCheckbox?.addEventListener("change", () => {
+      if (this._isAlphabetical()) {
+        this._enableAlphabeticalMode();
+      } else {
+        this._enableCustomSortMode();
+      }
+    });
+  }
+
+  private _enableAlphabeticalMode(): void {
+    this._customSortContainer?.setAttribute("hidden", "");
+    this._sortable?.option("disabled", true);
+  }
+
+  private _enableCustomSortMode(): void {
+    this._customSortContainer?.removeAttribute("hidden");
+    this._sortable?.option("disabled", false);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sort order helpers
+  // ---------------------------------------------------------------------------
+
+  private _renumberSortOrders(): void {
+    const items = this._sortList.querySelectorAll<HTMLLIElement>(
+      "li[data-layer-id]",
+    );
+    items.forEach((li, index) => {
+      const input = li.querySelector<HTMLInputElement>(".sort-order-input");
+      if (input) {
+        const layerId = li.dataset.layerId;
+        input.value = `${layerId}:${index + 1}`;
+      }
+    });
+  }
+
+  private _attachCheckboxListeners(): void {
+    document
+      .querySelectorAll<HTMLInputElement>('input[type="checkbox"][name="SelectedLayers"]')
+      .forEach((checkbox) => {
+        checkbox.addEventListener("change", () => {
+          const layerId = checkbox.value;
+          if (checkbox.checked) {
+            this._addLayerToSortList(layerId, checkbox);
+          } else {
+            this._removeLayerFromSortList(layerId);
+          }
+        });
+      });
+  }
+
+  private _addLayerToSortList(layerId: string, checkbox: HTMLInputElement): void {
+    // Remove empty-state message if present
+    const emptyMessage = this._sortList.querySelector("#layer-sort-empty-message");
+    emptyMessage?.remove();
+
+    // Avoid duplicates
+    if (this._sortList.querySelector(`li[data-layer-id="${layerId}"]`)) {
+      return;
+    }
+
+    // Get the layer name from the associated label (text node only, before any child elements)
+    const label = document.querySelector<HTMLLabelElement>(
+      `label[for="SelectedLayers__${layerId}"]`,
+    );
+    const layerName = label?.firstChild?.textContent?.trim() ?? `Layer ${layerId}`;
+
+    // Work out the next sort order position
+    const existingItems = this._sortList.querySelectorAll("li[data-layer-id]");
+    const nextOrder = existingItems.length + 1;
+
+    const li = document.createElement("li");
+    li.className = "list-group-item d-flex align-items-center gap-2";
+    li.dataset.layerId = layerId;
+    li.dataset.layerName = layerName;
+    li.innerHTML = `
+      <span class="drag-handle bi bi-grip-vertical text-muted" style="cursor: grab;" title="Drag to reorder"></span>
+      <span class="flex-grow-1">${DOMPurify.sanitize(layerName)}</span>
+      <input type="hidden" name="sortOrderData" value="${layerId}:${nextOrder}" data-layer-id="${layerId}" class="sort-order-input" />
+    `;
+
+    this._sortList.appendChild(li);
+  }
+
+  private _removeLayerFromSortList(layerId: string): void {
+    const li = this._sortList.querySelector<HTMLLIElement>(
+      `li[data-layer-id="${layerId}"]`,
+    );
+    li?.remove();
+
+    // Renumber remaining items
+    this._renumberSortOrders();
+
+    // Show empty-state message if list is now empty
+    const remainingItems = this._sortList.querySelectorAll("li[data-layer-id]");
+    if (remainingItems.length === 0) {
+      const emptyLi = document.createElement("li");
+      emptyLi.id = "layer-sort-empty-message";
+      emptyLi.className = "list-group-item text-muted fst-italic";
+      emptyLi.innerHTML =
+        'No layers selected. Add layers in the <strong>Layers</strong> tab.';
+      this._sortList.appendChild(emptyLi);
+    }
+  }
+}

--- a/GIFrameworkMaps.Web/Scripts/Management/management.ts
+++ b/GIFrameworkMaps.Web/Scripts/Management/management.ts
@@ -4,6 +4,7 @@ import { Broadcast } from "./Broadcast";
 import { CreateLayerFromSource } from "./CreateLayerFromSource";
 import { CreateSource } from "./CreateSource";
 import { CheckboxListFilter } from "./CheckboxListFilter";
+import { CategoryLayerSort } from "./CategoryLayerSort";
 import accessibleAutocomplete from "accessible-autocomplete";
 import { Tooltip } from "bootstrap";
 
@@ -53,6 +54,11 @@ addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll<HTMLElement>("[data-checkbox-filter]").forEach((el) => {
     new CheckboxListFilter(el);
   });
+  //attach category layer sort if present
+  const sortList = document.querySelector<HTMLUListElement>("#layer-sort-list");
+  if (sortList) {
+    new CategoryLayerSort(sortList).init();
+  }
   //attach other general things that should appear everywhere
   const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
   [...tooltipTriggerList].map(tooltipTriggerEl => new Tooltip(tooltipTriggerEl));

--- a/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Create.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Create.cshtml
@@ -47,12 +47,20 @@
 
         </div>
         <div class="col-md-6">
-            <div class="card mb-2">
-                <div class="card-header">
-                    Layers
-                </div>
-                <div class="card-body">
+            <ul class="nav nav-underline mb-2" role="tablist">
+                <li class="nav-item active" role="presentation">
+                    <button class="nav-link active" id="layers-tab" data-bs-toggle="tab" data-bs-target="#layers-tab-pane" type="button" role="tab" aria-controls="layers-tab-pane" aria-selected="true">Layers</button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="sort-tab" data-bs-toggle="tab" data-bs-target="#sort-tab-pane" type="button" role="tab" aria-controls="sort-tab-pane" aria-selected="false">Layer sort order</button>
+                </li>
+            </ul>
+            <div class="tab-content">
+                <div class="tab-pane fade show active" id="layers-tab-pane" role="tabpanel" aria-labelledby="layers-tab" tabindex="0">
                     <partial name="ManagementPartials/CategoryLayerList" model="Model" view-data="ViewData" />
+                </div>
+                <div class="tab-pane fade" id="sort-tab-pane" role="tabpanel" aria-labelledby="sort-tab" tabindex="0">
+                    <partial name="ManagementPartials/CategoryLayerSortList" model="Model" view-data="ViewData" />
                 </div>
             </div>
         </div>

--- a/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Edit.cshtml
+++ b/GIFrameworkMaps.Web/Views/ManagementLayerCategory/Edit.cshtml
@@ -54,12 +54,18 @@
                     <button class="nav-link active" id="layers-tab" data-bs-toggle="tab" data-bs-target="#layers-tab-pane" type="button" role="tab" aria-controls="layers-tab-pane" aria-selected="true">Layers</button>
                 </li>
                 <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="sort-tab" data-bs-toggle="tab" data-bs-target="#sort-tab-pane" type="button" role="tab" aria-controls="sort-tab-pane" aria-selected="false">Layer sort order</button>
+                </li>
+                <li class="nav-item" role="presentation">
                     <button class="nav-link" id="versions-tab" data-bs-toggle="tab" data-bs-target="#versions-tab-pane" type="button" role="tab" aria-controls="versions-tab-pane" aria-selected="false">Appears in versions</button>
                 </li>
             </ul>
             <div class="tab-content">
                 <div class="tab-pane fade show active" id="layers-tab-pane" role="tabpanel" aria-labelledby="layers-tab" tabindex="0">
                     <partial name="ManagementPartials/CategoryLayerList" model="Model" view-data="ViewData" />
+                </div>
+                <div class="tab-pane fade" id="sort-tab-pane" role="tabpanel" aria-labelledby="sort-tab" tabindex="0">
+                    <partial name="ManagementPartials/CategoryLayerSortList" model="Model" view-data="ViewData" />
                 </div>
                 <div class="tab-pane fade" id="versions-tab-pane" role="tabpanel" aria-labelledby="versions-tab" tabindex="0">
                     @if (Model.VersionsCategoryAppearsIn is null || Model.VersionsCategoryAppearsIn.Count == 0)

--- a/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/CategoryLayerSortList.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/CategoryLayerSortList.cshtml
@@ -1,0 +1,46 @@
+@using GIFrameworkMaps.Data.ViewModels.Management
+@model CategoryEditViewModel
+
+@{
+    // Layers that are currently selected, ordered by their saved SortOrder, then alphabetically for ties/zeroes
+    var selectedLayers = Model.AvailableLayers
+        .Where(l => Model.SelectedLayers.Contains(int.Parse(l.Value)))
+        .OrderBy(l =>
+        {
+            var id = int.Parse(l.Value);
+            return Model.LayerSortOrders.TryGetValue(id, out var s) && s > 0 ? s : int.MaxValue;
+        })
+        .ThenBy(l => l.Text)
+        .ToList();
+}
+
+<div class="form-check mb-3">
+    <input type="checkbox" class="form-check-input" id="sort-alphabetically" name="sortAlphabetically" value="true" @(Model.SortAlphabetically ? "checked" : "") />
+    <label class="form-check-label" for="sort-alphabetically">Sort alphabetically</label>
+    <div class="form-text">When checked, layers sort alphabetically and any custom order is cleared.</div>
+</div>
+
+<div id="layer-sort-custom" @(Model.SortAlphabetically ? "hidden" : "")>
+    <p class="text-muted small">Drag and drop layers to set their display order within this category. Layers not added in the <strong>Layers</strong> tab will not appear here.</p>
+
+    <ul id="layer-sort-list" class="list-group">
+        @if (selectedLayers.Count == 0)
+        {
+            <li id="layer-sort-empty-message" class="list-group-item text-muted fst-italic">No layers selected. Add layers in the <strong>Layers</strong> tab.</li>
+        }
+        else
+        {
+            @for (int i = 0; i < selectedLayers.Count; i++)
+            {
+                var layer = selectedLayers[i];
+                var layerId = int.Parse(layer.Value);
+                var sortOrder = i + 1;
+                <li class="list-group-item d-flex align-items-center gap-2" data-layer-id="@layerId" data-layer-name="@layer.Text">
+                    <span class="drag-handle bi bi-grip-vertical text-muted" style="cursor: grab;" title="Drag to reorder"></span>
+                    <span class="flex-grow-1">@layer.Text</span>
+                    <input type="hidden" name="sortOrderData" value="@layerId:@sortOrder" data-layer-id="@layerId" class="sort-order-input" />
+                </li>
+            }
+        }
+    </ul>
+</div>


### PR DESCRIPTION
This PR introduces the ability for layers to be sorted by administrators within their categories, using a simple drag reorder interface. Admins can also choose to leave them alphabetical (which sets the sort order to 0 for all relevant layers)

Some work has been done to improve efficiency of DB updates of the category layers as well.

Closes #439 