### PR TITLE
Limit length of queries submitted to search definitions

### DIFF
--- a/GIFrameworkMaps.Data/Data/SearchRepository.cs
+++ b/GIFrameworkMaps.Data/Data/SearchRepository.cs
@@ -183,6 +183,9 @@ namespace GIFrameworkMaps.Data
 			var minLength = Math.Max(SearchLengthLimits.GlobalMinLength, selectedDefinition.MinSearchTextLength ?? SearchLengthLimits.GlobalMinLength);
 			var maxLength = Math.Min(SearchLengthLimits.GlobalMaxLength, selectedDefinition.MaxSearchTextLength ?? SearchLengthLimits.GlobalMaxLength);
 
+			// Ensure max is never below min (e.g. due to misconfiguration or legacy DB values)
+			maxLength = Math.Max(minLength, maxLength);
+
 			return (minLength, maxLength);
 		}
 

--- a/GIFrameworkMaps.Data/Data/SearchRepository.cs
+++ b/GIFrameworkMaps.Data/Data/SearchRepository.cs
@@ -110,39 +110,50 @@ namespace GIFrameworkMaps.Data
                     {
 						var selectedDefinition = searchDefinitions.FirstOrDefault(o => o?.Id == reqSearch.SearchDefinitionId, null);
 
-                        if (selectedDefinition is not null)
+						if (selectedDefinition is not null)
+					{
+						var (minLength, maxLength) = GetEffectiveLengthBounds(selectedDefinition);
+
+						// Skip this search provider entirely if the term is shorter than its effective minimum length
+						if (searchTerm.Length < minLength)
 						{
-							if (IsValidSearchTerm(searchTerm, selectedDefinition))
-                            {
-                                var searchResultCategory = new SearchResultCategory()
-                                {
+							continue;
+						}
+
+						// Truncate the term for this provider only if it exceeds its effective maximum length
+						var providerSearchTerm = searchTerm.Length > maxLength ? searchTerm[..maxLength] : searchTerm;
+
+						if (IsValidSearchTerm(providerSearchTerm, selectedDefinition))
+							{
+								var searchResultCategory = new SearchResultCategory()
+								{
 									CategoryName = selectedDefinition.Title,
 									Ordering = reqSearch.Order,
 									AttributionHtml = selectedDefinition.AttributionHtml,
 									SupressGeom = selectedDefinition.SupressGeom
-                                };
+								};
 
-                                try
-                                {
-                                    var results = await SingleSearch(searchTerm, selectedDefinition);
-                                    if (results.Count > 0)
-                                    {
-                                        searchResultCategory.Results = results;
-                                        searchResults.ResultCategories.Add(searchResultCategory);
-                                    }
-                                }
+								try
+								{
+									var results = await SingleSearch(providerSearchTerm, selectedDefinition);
+									if (results.Count > 0)
+									{
+										searchResultCategory.Results = results;
+										searchResults.ResultCategories.Add(searchResultCategory);
+									}
+								}
 								catch(Exception ex)
-                                {
-                                    //set the error flag as something went wrong. We still want to carry on with other searches though
-                                    _logger.LogError(ex,"Exception thrown executing search \"{definition}\"", selectedDefinition.Name);
-                                    searchResults.IsError = true;
-                                }
+								{
+									//set the error flag as something went wrong. We still want to carry on with other searches though
+									_logger.LogError(ex,"Exception thrown executing search \"{definition}\"", selectedDefinition.Name);
+									searchResults.IsError = true;
+								}
 
-                                // Stop search now if flag set on current search and something found since last time flag set
-                                if (searchResultCategory.Results.Count > 0 && reqSearch.StopIfFound)
-                                    break;
-                            }
-                        }
+								// Stop search now if flag set on current search and something found since last time flag set
+								if (searchResultCategory.Results.Count > 0 && reqSearch.StopIfFound)
+									break;
+							}
+						}
                     }
                 }
             }
@@ -150,16 +161,30 @@ namespace GIFrameworkMaps.Data
             return searchResults;
         }
 
-        // A search term is valid if it's blank or it matches the Required Search's validation regular expression. 
-        private static bool IsValidSearchTerm(string searchTerm, SearchDefinition? selectedDefinition)
-        {
-            if (selectedDefinition is null) return false;
+		// A search term is valid if it's blank or it matches the Required Search's validation regular expression. 
+		private static bool IsValidSearchTerm(string searchTerm, SearchDefinition? selectedDefinition)
+		{
+			if (selectedDefinition is null) return false;
 
-            if (string.IsNullOrEmpty(selectedDefinition.ValidationRegex)) return true;
-            
+			if (string.IsNullOrEmpty(selectedDefinition.ValidationRegex)) return true;
+
 			var validationRegex = new Regex(selectedDefinition.ValidationRegex);
-            return validationRegex.IsMatch(searchTerm);
-        }
+			return validationRegex.IsMatch(searchTerm);
+		}
+
+		/// <summary>
+		/// Gets the effective minimum/maximum search term length for a search definition, clamping any
+		/// per-definition overrides so they can never exceed the global length limits.
+		/// </summary>
+		/// <param name="selectedDefinition">The search definition to get the bounds for</param>
+		/// <returns>A tuple containing the effective minimum and maximum lengths</returns>
+		private static (int MinLength, int MaxLength) GetEffectiveLengthBounds(SearchDefinition selectedDefinition)
+		{
+			var minLength = Math.Max(SearchLengthLimits.GlobalMinLength, selectedDefinition.MinSearchTextLength ?? SearchLengthLimits.GlobalMinLength);
+			var maxLength = Math.Min(SearchLengthLimits.GlobalMaxLength, selectedDefinition.MaxSearchTextLength ?? SearchLengthLimits.GlobalMaxLength);
+
+			return (minLength, maxLength);
+		}
 
         /// <summary>
         /// Performs a search against a particular search definition

--- a/GIFrameworkMaps.Data/Migrations/ApplicationDb/20260818094714_AddCharacterRestrictionsToSearchDefinitions.Designer.cs
+++ b/GIFrameworkMaps.Data/Migrations/ApplicationDb/20260818094714_AddCharacterRestrictionsToSearchDefinitions.Designer.cs
@@ -3,6 +3,7 @@ using GIFrameworkMaps.Data;
 using GIFrameworkMaps.Data.Models.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260818094714_AddCharacterRestrictionsToSearchDefinitions")]
+    partial class AddCharacterRestrictionsToSearchDefinitions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GIFrameworkMaps.Data/Migrations/ApplicationDb/20260818094714_AddCharacterRestrictionsToSearchDefinitions.cs
+++ b/GIFrameworkMaps.Data/Migrations/ApplicationDb/20260818094714_AddCharacterRestrictionsToSearchDefinitions.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GIFrameworkMaps.Data.Migrations.ApplicationDb
+{
+    /// <inheritdoc />
+    public partial class AddCharacterRestrictionsToSearchDefinitions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaxSearchTextLength",
+                schema: "giframeworkmaps",
+                table: "SearchDefinitions",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MinSearchTextLength",
+                schema: "giframeworkmaps",
+                table: "SearchDefinitions",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaxSearchTextLength",
+                schema: "giframeworkmaps",
+                table: "SearchDefinitions");
+
+            migrationBuilder.DropColumn(
+                name: "MinSearchTextLength",
+                schema: "giframeworkmaps",
+                table: "SearchDefinitions");
+        }
+    }
+}

--- a/GIFrameworkMaps.Data/Models/Search/SearchDefinition.cs
+++ b/GIFrameworkMaps.Data/Models/Search/SearchDefinition.cs
@@ -28,6 +28,14 @@ namespace GIFrameworkMaps.Data.Models.Search
         [DisplayName("Validation regex code (leave blank for no validation)")]
         public string? ValidationRegex { get; set; }
 
+        [Range(SearchLengthLimits.GlobalMinLength, SearchLengthLimits.GlobalMaxLength)]
+        [DisplayName("Minimum search text length (optional override, leave blank to use the global minimum)")]
+        public int? MinSearchTextLength { get; set; }
+
+        [Range(SearchLengthLimits.GlobalMinLength, SearchLengthLimits.GlobalMaxLength)]
+        [DisplayName("Maximum search text length (optional override, leave blank to use the global maximum)")]
+        public int? MaxSearchTextLength { get; set; }
+
         public bool SupressGeom { get; set; }
     }
 }

--- a/GIFrameworkMaps.Data/Models/Search/SearchLengthLimits.cs
+++ b/GIFrameworkMaps.Data/Models/Search/SearchLengthLimits.cs
@@ -1,0 +1,12 @@
+namespace GIFrameworkMaps.Data.Models.Search
+{
+	/// <summary>
+	/// Global limits for search query text length. Individual <see cref="SearchDefinition"/>
+	/// overrides can only tighten these bounds, never relax them.
+	/// </summary>
+	public static class SearchLengthLimits
+	{
+		public const int GlobalMinLength = 2;
+		public const int GlobalMaxLength = 500;
+	}
+}

--- a/GIFrameworkMaps.Tests/SearchRepositoryTests.cs
+++ b/GIFrameworkMaps.Tests/SearchRepositoryTests.cs
@@ -440,5 +440,246 @@ namespace GIFrameworkMaps.Tests
             Assert.That(capturedUri, Does.Contain(expectedEncodedTerm), $"Expected encoded term '{expectedEncodedTerm}' in URI");
             Assert.That(capturedUri, Does.Not.Contain("#"), "URI must not contain an unencoded '#' character");
         }
+
+        [Test(Description = "When the search term is shorter than the search definition's effective minimum length, the search definition should be skipped entirely and produce no results")]
+        public async Task Search_TermShorterThanMinLength_SkipsSearchDefinition()
+        {
+            const int searchDefId = 55;
+
+            var mockLogger = new Mock<ILogger<SearchRepository>>();
+            var mockIApplicationDbContext = new Mock<IApplicationDbContext>();
+
+            var localSearchDef = new LocalSearchDefinition
+            {
+                Id = searchDefId,
+                Name = "BNG12Figure",
+                LocalSearchName = "BNG12Figure",
+                Title = "Long Minimum Search",
+                MinSearchTextLength = 50
+            };
+
+            mockIApplicationDbContext.Setup(m => m.APISearchDefinitions)
+                .Returns(new List<APISearchDefinition>().BuildMockDbSet().Object);
+            mockIApplicationDbContext.Setup(m => m.DatabaseSearchDefinitions)
+                .Returns(new List<DatabaseSearchDefinition>().BuildMockDbSet().Object);
+            mockIApplicationDbContext.Setup(m => m.LocalSearchDefinitions)
+                .Returns(new List<LocalSearchDefinition> { localSearchDef }.BuildMockDbSet().Object);
+
+            var versionSearchDef = new VersionSearchDefinition
+            {
+                SearchDefinitionId = searchDefId,
+                SearchDefinition = localSearchDef
+            };
+            mockIApplicationDbContext.Setup(m => m.VersionSearchDefinitions)
+                .Returns(new List<VersionSearchDefinition> { versionSearchDef }.BuildMockDbSet().Object);
+
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(_ => _.HttpContext).Returns(new DefaultHttpContext());
+            var mockFactory = new Mock<IHttpClientFactory>();
+
+            var repository = new SearchRepository(
+                mockLogger.Object,
+                mockIApplicationDbContext.Object,
+                mockFactory.Object,
+                mockHttpContextAccessor.Object,
+                new MemoryCache(new MemoryCacheOptions()));
+
+            var requiredSearches = new List<RequiredSearch>
+            {
+                new() { SearchDefinitionId = searchDefId, Enabled = true, Order = 1 }
+            };
+
+            // Act - the search term ("abc") is shorter than the definition's MinSearchTextLength (50)
+            var results = await repository.Search("abc", requiredSearches);
+
+            // Assert
+            Assert.That(results.ResultCategories, Is.Empty, "No categories should be produced when the term is below the minimum length");
+            Assert.That(results.TotalResults, Is.EqualTo(0));
+            Assert.That(results.IsError, Is.False);
+        }
+
+		[Test(Description = "When the search term is longer than the search definition's effective maximum length, the search term should be truncated")]
+		public async Task Search_TermLongerThanMaxLength_TruncatesSearchTerm()
+		{
+			const int searchDefId = 55;
+
+			var mockLogger = new Mock<ILogger<SearchRepository>>();
+			var mockIApplicationDbContext = new Mock<IApplicationDbContext>();
+
+			var localSearchDef = new LocalSearchDefinition
+			{
+				Id = searchDefId,
+				Name = "BNG12Figure",
+				LocalSearchName = "BNG12Figure",
+				Title = "Short Maximum Search",
+				MaxSearchTextLength = 13
+			};
+
+			mockIApplicationDbContext.Setup(m => m.APISearchDefinitions)
+				.Returns(new List<APISearchDefinition>().BuildMockDbSet().Object);
+			mockIApplicationDbContext.Setup(m => m.DatabaseSearchDefinitions)
+				.Returns(new List<DatabaseSearchDefinition>().BuildMockDbSet().Object);
+			mockIApplicationDbContext.Setup(m => m.LocalSearchDefinitions)
+				.Returns(new List<LocalSearchDefinition> { localSearchDef }.BuildMockDbSet().Object);
+
+			var versionSearchDef = new VersionSearchDefinition
+			{
+				SearchDefinitionId = searchDefId,
+				SearchDefinition = localSearchDef
+			};
+			mockIApplicationDbContext.Setup(m => m.VersionSearchDefinitions)
+				.Returns(new List<VersionSearchDefinition> { versionSearchDef }.BuildMockDbSet().Object);
+
+			var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+			mockHttpContextAccessor.Setup(_ => _.HttpContext).Returns(new DefaultHttpContext());
+			var mockFactory = new Mock<IHttpClientFactory>();
+
+			var repository = new SearchRepository(
+				mockLogger.Object,
+				mockIApplicationDbContext.Object,
+				mockFactory.Object,
+				mockHttpContextAccessor.Object,
+				new MemoryCache(new MemoryCacheOptions()));
+
+			var requiredSearches = new List<RequiredSearch>
+			{
+				new() { SearchDefinitionId = searchDefId, Enabled = true, Order = 1 }
+			};
+
+			// Act - the search term ("366646 101677z") is longer than the definition's MaxSearchTextLength (13)
+			// This is a bit of a hack of a test. By making the search term longer than the max length, we are testing that the search term is truncated to 13 characters.
+			// The LocalSearch method will then process the truncated term ("366646 101677") and produce a result.
+			var results = await repository.Search("366646 101677z", requiredSearches);
+
+			// Assert
+			
+			Assert.That(results.ResultCategories, Has.Exactly(1).Items);
+			Assert.That(results.TotalResults, Is.EqualTo(1));
+			Assert.That(results.IsError, Is.False);
+		}
+
+		[Test(Description = "When a search definition produces results and StopIfFound is set, subsequent enabled search definitions should not be processed")]
+        public async Task Search_StopIfFoundSetAndResultsFound_StopsProcessingFurtherDefinitions()
+        {
+            const int firstSearchDefId = 61;
+            const int secondSearchDefId = 62;
+
+            var mockLogger = new Mock<ILogger<SearchRepository>>();
+            var mockIApplicationDbContext = new Mock<IApplicationDbContext>();
+
+            var firstLocalSearchDef = new LocalSearchDefinition
+            {
+                Id = firstSearchDefId,
+                Name = "BNG12Figure",
+                LocalSearchName = "BNG12Figure",
+                Title = "BNG 12 Figure"
+            };
+
+            var secondLocalSearchDef = new LocalSearchDefinition
+            {
+                Id = secondSearchDefId,
+                Name = "BNG12Figure",
+                LocalSearchName = "BNG12Figure",
+                Title = "Should Not Run"
+            };
+
+            mockIApplicationDbContext.Setup(m => m.APISearchDefinitions)
+                .Returns(new List<APISearchDefinition>().BuildMockDbSet().Object);
+            mockIApplicationDbContext.Setup(m => m.DatabaseSearchDefinitions)
+                .Returns(new List<DatabaseSearchDefinition>().BuildMockDbSet().Object);
+            mockIApplicationDbContext.Setup(m => m.LocalSearchDefinitions)
+                .Returns(new List<LocalSearchDefinition> { firstLocalSearchDef, secondLocalSearchDef }.BuildMockDbSet().Object);
+
+            var versionSearchDefs = new List<VersionSearchDefinition>
+            {
+                new() { SearchDefinitionId = firstSearchDefId, SearchDefinition = firstLocalSearchDef },
+                new() { SearchDefinitionId = secondSearchDefId, SearchDefinition = secondLocalSearchDef }
+            };
+            mockIApplicationDbContext.Setup(m => m.VersionSearchDefinitions)
+                .Returns(versionSearchDefs.BuildMockDbSet().Object);
+
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(_ => _.HttpContext).Returns(new DefaultHttpContext());
+            var mockFactory = new Mock<IHttpClientFactory>();
+
+            var repository = new SearchRepository(
+                mockLogger.Object,
+                mockIApplicationDbContext.Object,
+                mockFactory.Object,
+                mockHttpContextAccessor.Object,
+                new MemoryCache(new MemoryCacheOptions()));
+
+            var requiredSearches = new List<RequiredSearch>
+            {
+                new() { SearchDefinitionId = firstSearchDefId, Enabled = true, Order = 1, StopIfFound = true },
+                new() { SearchDefinitionId = secondSearchDefId, Enabled = true, Order = 2, StopIfFound = false }
+            };
+
+            // Act - a valid 12-figure BNG grid reference produces a result for the first definition
+            var results = await repository.Search("366646 101677", requiredSearches);
+
+            // Assert
+            Assert.That(results.ResultCategories, Has.Exactly(1).Items, "Only the first search definition should have produced a result category");
+            Assert.That(results.ResultCategories[0].CategoryName, Is.EqualTo("BNG 12 Figure"));
+            Assert.That(results.TotalResults, Is.GreaterThan(0));
+        }
+
+        [Test(Description = "When executing a single search throws an exception, the error flag should be set on the results but the method should not throw")]
+        public async Task Search_ExceptionThrownDuringSingleSearch_SetsIsErrorFlag()
+        {
+            const int searchDefId = 71;
+
+            var mockLogger = new Mock<ILogger<SearchRepository>>();
+            var mockIApplicationDbContext = new Mock<IApplicationDbContext>();
+
+            var searchDefinition = new LocalSearchDefinition
+            {
+                Id = searchDefId,
+                Name = "BNG12Figure",
+                LocalSearchName = "BNG12Figure",
+                Title = "Erroring Search"
+            };
+
+            mockIApplicationDbContext.Setup(m => m.APISearchDefinitions)
+                .Returns(new List<APISearchDefinition>().BuildMockDbSet().Object);
+            mockIApplicationDbContext.Setup(m => m.DatabaseSearchDefinitions)
+                .Returns(new List<DatabaseSearchDefinition>().BuildMockDbSet().Object);
+            // Deliberately do NOT set up LocalSearchDefinitions so that accessing it inside
+            // SingleSearch throws a NullReferenceException, which should be caught and
+            // recorded via the IsError flag rather than bubbling out of Search().
+            mockIApplicationDbContext.Setup(m => m.LocalSearchDefinitions)
+                .Returns(default(Microsoft.EntityFrameworkCore.DbSet<LocalSearchDefinition>));
+
+            var versionSearchDef = new VersionSearchDefinition
+            {
+                SearchDefinitionId = searchDefId,
+                SearchDefinition = searchDefinition
+            };
+            mockIApplicationDbContext.Setup(m => m.VersionSearchDefinitions)
+                .Returns(new List<VersionSearchDefinition> { versionSearchDef }.BuildMockDbSet().Object);
+
+            var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            mockHttpContextAccessor.Setup(_ => _.HttpContext).Returns(new DefaultHttpContext());
+            var mockFactory = new Mock<IHttpClientFactory>();
+
+            var repository = new SearchRepository(
+                mockLogger.Object,
+                mockIApplicationDbContext.Object,
+                mockFactory.Object,
+                mockHttpContextAccessor.Object,
+                new MemoryCache(new MemoryCacheOptions()));
+
+            var requiredSearches = new List<RequiredSearch>
+            {
+                new() { SearchDefinitionId = searchDefId, Enabled = true, Order = 1 }
+            };
+
+            // Act
+            var results = await repository.Search("366646 101677", requiredSearches);
+
+            // Assert
+            Assert.That(results.IsError, Is.True, "The IsError flag should be set when a single search throws an exception");
+            Assert.That(results.ResultCategories, Is.Empty, "No results should be added for the definition that threw");
+        }
     }
 }

--- a/GIFrameworkMaps.Web/Controllers/Management/ManagementSearchDefinitionController.cs
+++ b/GIFrameworkMaps.Web/Controllers/Management/ManagementSearchDefinitionController.cs
@@ -208,6 +208,8 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 a => a.ZoomLevel,
                 a => a.EPSG,
                 a => a.ValidationRegex,
+				a => a.MinSearchTextLength,
+				a => a.MaxSearchTextLength,
                 a => a.SupressGeom,
                 a => a.URLTemplate,
                 a => a.XFieldPath,
@@ -255,7 +257,9 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 a => a.ZoomLevel,
                 a => a.EPSG,
                 a => a.ValidationRegex,
-                a => a.SupressGeom,
+				a => a.MinSearchTextLength,
+				a => a.MaxSearchTextLength,
+				a => a.SupressGeom,
                 a => a.TableName,
                 a => a.XField,
                 a => a.YField,
@@ -300,7 +304,9 @@ namespace GIFrameworkMaps.Web.Controllers.Management
                 a => a.ZoomLevel,
                 a => a.EPSG,
                 a => a.ValidationRegex,
-                a => a.SupressGeom,
+				a => a.MinSearchTextLength,
+				a => a.MaxSearchTextLength,
+				a => a.SupressGeom,
                 a => a.LocalSearchName))
             {
 

--- a/GIFrameworkMaps.Web/Controllers/SearchController.cs
+++ b/GIFrameworkMaps.Web/Controllers/SearchController.cs
@@ -10,17 +10,24 @@ using System.Threading.Tasks;
 namespace GIFrameworkMaps.Web.Controllers
 {
 	public class SearchController(ISearchRepository repository, ILogger<SearchController> logger) : Controller
-    {
-        //dependency injection
-        private readonly ISearchRepository _repository = repository;
-        private readonly ILogger<SearchController> _logger = logger;
+	{
+		//dependency injection
+		private readonly ISearchRepository _repository = repository;
+		private readonly ILogger<SearchController> _logger = logger;
 
-		public async Task<JsonResult> Index([FromBody]SearchQuery searchQuery)
-        {
-            //Sanitise user input to prevent log forging
-            _logger.LogInformation("User searched for {searchQuery}", searchQuery.Query.Replace(Environment.NewLine, ""));
+		public async Task<IActionResult> Index([FromBody]SearchQuery searchQuery)
+		{
+			var trimmedQuery = searchQuery.Query?.Trim() ?? string.Empty;
 
-            var results = await _repository.Search(searchQuery.Query, searchQuery.Searches);
+			if (trimmedQuery.Length < SearchLengthLimits.GlobalMinLength || trimmedQuery.Length > SearchLengthLimits.GlobalMaxLength)
+			{
+				return BadRequest($"Search query must be between {SearchLengthLimits.GlobalMinLength} and {SearchLengthLimits.GlobalMaxLength} characters long");
+			}
+
+			//Sanitise user input to prevent log forging
+			_logger.LogInformation("User searched for {searchQuery}", searchQuery.Query.Replace(Environment.NewLine, ""));
+
+			var results = await _repository.Search(searchQuery.Query, searchQuery.Searches);
 
             //Sanitise user input to prevent log forging
             _logger.LogInformation("{TotalResults} results returned for query {searchQuery}", results.TotalResults, searchQuery.Query.Replace(Environment.NewLine, ""));

--- a/GIFrameworkMaps.Web/Scripts/Interfaces/Search/SearchDefinition.ts
+++ b/GIFrameworkMaps.Web/Scripts/Interfaces/Search/SearchDefinition.ts
@@ -7,5 +7,7 @@
   zoomLevel?: number | null;
   epsg?: number;
   validationRegex?: string;
+  minSearchTextLength?: number | null;
+  maxSearchTextLength?: number | null;
   supressGeom?: boolean;
 }

--- a/GIFrameworkMaps.Web/Scripts/Search.ts
+++ b/GIFrameworkMaps.Web/Scripts/Search.ts
@@ -35,6 +35,9 @@ export class Search {
   gifwMapInstance: GIFWMap;
   searchEndpointURL: string;
   searchOptionsURL: string;
+  // These must match GIFrameworkMaps.Data.Models.Search.SearchLengthLimits on the server
+  static readonly globalMinSearchLength: number = 2;
+  static readonly globalMaxSearchLength: number = 500;
   searchBoxHTML: string = `
         <div class="ol-unselectable ol-control gifw-search-control">
             <button class="search-control-toggle d-md-none"><i class="bi bi-search"></i></button>
@@ -42,7 +45,7 @@ export class Search {
         <div class="search-control d-none d-md-block">
             <form id="gifw-search-form">
                 <div class="input-group">
-                    <input type="search" class="form-control" placeholder="Enter a search" aria-label="Search" aria-describedby="gifw-search-button" required>
+                    <input type="search" class="form-control" placeholder="Enter a search" aria-label="Search" aria-describedby="gifw-search-button" required minlength="${Search.globalMinSearchLength}" maxlength="${Search.globalMaxSearchLength}">
                     <button class="btn btn-outline-primary" type="submit" id="gifw-search-button">Search</button>
                     <button class="btn btn-outline-secondary" type="button" id="gifw-search-configure-button" aria-label="Configure search options" title="Configure search options"><i class="bi-gear-fill"></i></button>
                 </div>
@@ -254,7 +257,10 @@ export class Search {
     if (searchTermInput !== null) {
       const searchTerm = searchTermInput.value.trim();
 
-      if (searchTerm.length !== 0) {
+      if (
+        searchTerm.length >= Search.globalMinSearchLength &&
+        searchTerm.length <= Search.globalMaxSearchLength
+      ) {
         if (!this.isOpen) {
           this.open();
         }
@@ -276,6 +282,8 @@ export class Search {
             this.isRunning = false;
             this.cancelledByUser = false;
           });
+      } else {
+        searchTermInput.reportValidity();
       }
     }
     event.preventDefault();

--- a/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/SearchDefinitionFormPartial.cshtml
+++ b/GIFrameworkMaps.Web/Views/Shared/ManagementPartials/SearchDefinitionFormPartial.cshtml
@@ -49,6 +49,20 @@
 </div>
 
 <div class="mb-3">
+    <label asp-for="MinSearchTextLength" class="control-label"></label>
+    <input asp-for="MinSearchTextLength" class="form-control" />
+    <div class="form-text">Optional. Overrides the global minimum search text length (2). This cannot be set lower than the global minimum. Leave blank to use the global minimum.</div>
+    <span asp-validation-for="MinSearchTextLength" class="text-danger"></span>
+</div>
+
+<div class="mb-3">
+    <label asp-for="MaxSearchTextLength" class="control-label"></label>
+    <input asp-for="MaxSearchTextLength" class="form-control" />
+    <div class="form-text">Optional. Overrides the global maximum search text length (500). This cannot be set higher than the global maximum. Leave blank to use the global maximum.</div>
+    <span asp-validation-for="MaxSearchTextLength" class="text-danger"></span>
+</div>
+
+<div class="mb-3">
     <label asp-for="SupressGeom" class="control-label">Supress geometry?</label>
     <input asp-for="SupressGeom" class="form-check-input" type="checkbox" />
     <div class="form-text">This prevents a pin, line or polygon from being drawn on the map when a user clicks on a search result</div>


### PR DESCRIPTION
This PR adds configurable and default limits to the search queries, preventing massive essays or single character searches from ever hitting searches if not relevant.

There is a global limit of minimum 2 characters maximum 500 characters. Each individual search definition can then override these values to ones that the database/API can handle, meaning we can ensure an API won't error if there is a known upper or lower character limit. When a search term is over the limit, the search term will be truncated to the max. When a search term is under the limit, the search definition will be skipped. There is a slight downside that users don't get feedback that their search is too long or too short, except when its under the global limit of 2 (standard validation on the input kicks in). This is an acceptable compromise and not likely to cause any issues.

Fixes #427 